### PR TITLE
[CM-33] JwtProvider 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Jwt
+	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/myteam/server/ServerApplication.java
+++ b/src/main/java/org/myteam/server/ServerApplication.java
@@ -2,8 +2,10 @@ package org.myteam.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/myteam/server/global/jwt/JwtProperties.java
+++ b/src/main/java/org/myteam/server/global/jwt/JwtProperties.java
@@ -1,0 +1,18 @@
+package org.myteam.server.global.jwt;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
+
+@Getter
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+    private final String issuer;
+    private final String secretKey;
+
+    @ConstructorBinding
+    public JwtProperties(String issuer, String secretKey) {
+        this.issuer = issuer;
+        this.secretKey = secretKey;
+    }
+}

--- a/src/main/java/org/myteam/server/global/jwt/JwtProvider.java
+++ b/src/main/java/org/myteam/server/global/jwt/JwtProvider.java
@@ -1,0 +1,111 @@
+package org.myteam.server.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class JwtProvider {
+
+    private final JwtProperties jwtProperties;
+
+    /**
+     * 토큰 발급
+     *
+     * @param duration Duration 만료 기간
+     * @param userId UUID
+     * @param role String
+     * @return String
+     */
+    public String generateToken(Duration duration, UUID userId, String role) {
+        Date now = new Date();
+        return makeToken(new Date(now.getTime() + duration.toMillis()), userId, role);
+    }
+
+    /**
+     * 토큰 생성
+     *
+     * @param expirationDate Date 만료 시간
+     * @param userId UUID
+     * @param role String
+     * @return String
+     */
+    private String makeToken(Date expirationDate, UUID userId, String role) {
+        return Jwts.builder()
+                .issuer(jwtProperties.getIssuer())
+                .issuedAt(new Date())
+                .expiration(expirationDate)
+                .claim("id", userId)
+                .claim("role", role)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    /**
+     * 토큰 유효성 검사
+     *
+     * @param token String
+     * @return boolean
+     */
+    public boolean validToken(final String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * 토큰으로부터 Authentication 객체를 가져옴
+     *
+     * @param token String
+     * @return Authentication
+     */
+    public Authentication getAuthentication(final String token) {
+        Claims claims = getClaims(token);
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(
+                new SimpleGrantedAuthority(claims.get("role", String.class)));
+        return new UsernamePasswordAuthenticationToken(
+                claims.get("id", UUID.class),
+                token,
+                authorities
+        );
+    }
+
+    /**
+     * 토큰으로부터 Claims를 가져옴
+     *
+     * @param token String
+     * @return Claims
+     */
+    private Claims getClaims(String token) {
+        Jws<Claims> claimsJws = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build().parseSignedClaims(token);
+        return claimsJws.getPayload();
+    }
+
+    /**
+     * 서명 키 생성
+     *
+     * @return SecretKey
+     */
+    public SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(jwtProperties.getSecretKey()));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: myteam-server
+
+#TODO: 환경변수로 변경
+jwt:
+  issuer: "myteam.org"
+  secret-key: "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1"


### PR DESCRIPTION
## 기능 설명
- Jwt 발급, 검증, 인증객체 조회 기능
## 작업 내용
- Jwt Issuer, secret-key yml 을 통해 가져오도록 개발
- JwtProvider 개발

## 수정 사항
- applcation.properties -> appliation.yml로 변경

## 추가 작업 예정
- 유저 role String이 아닌 ENUM으로 관리하도록 변경