### PR TITLE
[PH-35] Jwt 인증 인가 로직 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,43 +1,49 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.0'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.0'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'org.myteam'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// Jwt
-	implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    // h2 database
+    runtimeOnly 'com.h2database:h2'
+
+    // jakarta validation
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.0'
+
+    // Jwt
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Jwt
+	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/myteam/server/ServerApplication.java
+++ b/src/main/java/org/myteam/server/ServerApplication.java
@@ -2,8 +2,10 @@ package org.myteam.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/myteam/server/auth/controller/AuthController.java
+++ b/src/main/java/org/myteam/server/auth/controller/AuthController.java
@@ -1,0 +1,29 @@
+package org.myteam.server.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.auth.dto.LoginRequestDto;
+import org.myteam.server.auth.dto.SignupRequestDto;
+import org.myteam.server.auth.dto.TokenResponseDto;
+import org.myteam.server.auth.service.AuthService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public TokenResponseDto login(@RequestBody LoginRequestDto requestDto) {
+        return authService.login(requestDto);
+    }
+
+    @PostMapping("/signup")
+    public TokenResponseDto signup(@RequestBody SignupRequestDto requestDto) {
+        return authService.signup(requestDto);
+    }
+}

--- a/src/main/java/org/myteam/server/auth/dto/LoginRequestDto.java
+++ b/src/main/java/org/myteam/server/auth/dto/LoginRequestDto.java
@@ -1,0 +1,15 @@
+package org.myteam.server.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+
+@NoArgsConstructor
+@Getter
+public class LoginRequestDto {
+
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String username;
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/org/myteam/server/auth/dto/SignupRequestDto.java
+++ b/src/main/java/org/myteam/server/auth/dto/SignupRequestDto.java
@@ -1,0 +1,26 @@
+package org.myteam.server.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.member.entity.Member;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@NoArgsConstructor
+@Getter
+public class SignupRequestDto {
+
+    @NotBlank(message = "username은 필수 입력 값입니다.")
+    private String username;
+
+    @NotBlank(message = "password는 필수 입력 값입니다.")
+    private String password;
+
+    @NotBlank(message = "email은 필수 입력 값입니다.")
+    private String email;
+
+    public Member toEntity(PasswordEncoder passwordEncoder) {
+        return Member.builder().username(username).password(passwordEncoder.encode(password)).email(email).role("USER")
+                .build();
+    }
+}

--- a/src/main/java/org/myteam/server/auth/dto/TokenResponseDto.java
+++ b/src/main/java/org/myteam/server/auth/dto/TokenResponseDto.java
@@ -1,0 +1,21 @@
+package org.myteam.server.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class TokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+
+    public static TokenResponseDto of(String accessToken, String refreshToken) {
+        return TokenResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/myteam/server/auth/service/AuthService.java
+++ b/src/main/java/org/myteam/server/auth/service/AuthService.java
@@ -23,13 +23,16 @@ public class AuthService {
     @Transactional(readOnly = true)
     public TokenResponseDto login(LoginRequestDto requestDto) {
 
+        //유저확인
         Member member = memberRepository.findByUsername(requestDto.getUsername())
                 .orElseThrow(() -> new RuntimeException("Member not found"));
 
+        //비밀번호 확인
         if (!passwordEncoder.matches(requestDto.getPassword(), member.getPassword())) {
             throw new RuntimeException("Password not matched");
         }
 
+        //토큰 생성
         String accessToken = jwtProvider.generateToken(Duration.ofHours(1), member.getPublicId(), member.getRole());
         String refreshToken = jwtProvider.generateToken(Duration.ofDays(7), member.getPublicId(), member.getRole());
 
@@ -38,9 +41,11 @@ public class AuthService {
 
     @Transactional
     public TokenResponseDto signup(SignupRequestDto requestDto) {
+        //회원 정보 저장
         Member member = requestDto.toEntity(passwordEncoder);
         memberRepository.save(member);
 
+        //토큰 생성
         String accessToken = jwtProvider.generateToken(Duration.ofHours(1), member.getPublicId(), member.getRole());
         String refreshToken = jwtProvider.generateToken(Duration.ofDays(7), member.getPublicId(), member.getRole());
 

--- a/src/main/java/org/myteam/server/auth/service/AuthService.java
+++ b/src/main/java/org/myteam/server/auth/service/AuthService.java
@@ -1,0 +1,50 @@
+package org.myteam.server.auth.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.auth.dto.LoginRequestDto;
+import org.myteam.server.auth.dto.SignupRequestDto;
+import org.myteam.server.auth.dto.TokenResponseDto;
+import org.myteam.server.global.jwt.JwtProvider;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.repository.MemberRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional(readOnly = true)
+    public TokenResponseDto login(LoginRequestDto requestDto) {
+
+        Member member = memberRepository.findByUsername(requestDto.getUsername())
+                .orElseThrow(() -> new RuntimeException("Member not found"));
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), member.getPassword())) {
+            throw new RuntimeException("Password not matched");
+        }
+
+        String accessToken = jwtProvider.generateToken(Duration.ofHours(1), member.getPublicId(), member.getRole());
+        String refreshToken = jwtProvider.generateToken(Duration.ofDays(7), member.getPublicId(), member.getRole());
+
+        return TokenResponseDto.of(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public TokenResponseDto signup(SignupRequestDto requestDto) {
+        Member member = requestDto.toEntity(passwordEncoder);
+        memberRepository.save(member);
+
+        String accessToken = jwtProvider.generateToken(Duration.ofHours(1), member.getPublicId(), member.getRole());
+        String refreshToken = jwtProvider.generateToken(Duration.ofDays(7), member.getPublicId(), member.getRole());
+
+        return TokenResponseDto.of(accessToken, refreshToken);
+
+    }
+}

--- a/src/main/java/org/myteam/server/auth/test/TestController.java
+++ b/src/main/java/org/myteam/server/auth/test/TestController.java
@@ -1,0 +1,30 @@
+package org.myteam.server.auth.test;
+
+import java.util.UUID;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+public class TestController {
+
+    @GetMapping("/user-access-test")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public String userAccessTest(@AuthenticationPrincipal UUID publicId) {
+        System.out.println("publicId = " + publicId);
+
+        return "User Access Test";
+    }
+
+    @GetMapping("/manager-access-test")
+    @PreAuthorize("hasRole('ROLE_MANAGER')")
+    public String managerAccessTest(@AuthenticationPrincipal UUID publicId, Authentication authentication) {
+        System.out.println("publicId = " + publicId);
+
+        return "Manager Access Test";
+    }
+}

--- a/src/main/java/org/myteam/server/global/config/PasswordEncoderConfig.java
+++ b/src/main/java/org/myteam/server/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package org.myteam.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/myteam/server/global/jwt/JwtProperties.java
+++ b/src/main/java/org/myteam/server/global/jwt/JwtProperties.java
@@ -1,0 +1,18 @@
+package org.myteam.server.global.jwt;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.ConstructorBinding;
+
+@Getter
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+    private final String issuer;
+    private final String secretKey;
+
+    @ConstructorBinding
+    public JwtProperties(String issuer, String secretKey) {
+        this.issuer = issuer;
+        this.secretKey = secretKey;
+    }
+}

--- a/src/main/java/org/myteam/server/global/jwt/JwtProvider.java
+++ b/src/main/java/org/myteam/server/global/jwt/JwtProvider.java
@@ -73,8 +73,9 @@ public class JwtProvider {
     public Authentication getAuthentication(final String token) {
         Claims claims = getClaims(token);
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(
-                new SimpleGrantedAuthority(claims.get("role", String.class)));
-        return new UsernamePasswordAuthenticationToken(claims.get("id", UUID.class), token, authorities);
+                new SimpleGrantedAuthority("ROLE_" + claims.get("role", String.class)));
+        return new UsernamePasswordAuthenticationToken(UUID.fromString(claims.get("id", String.class)), token,
+                authorities);
     }
 
     /**

--- a/src/main/java/org/myteam/server/global/jwt/JwtProvider.java
+++ b/src/main/java/org/myteam/server/global/jwt/JwtProvider.java
@@ -27,8 +27,8 @@ public class JwtProvider {
      * 토큰 발급
      *
      * @param duration Duration 만료 기간
-     * @param userId UUID
-     * @param role String
+     * @param userId   UUID
+     * @param role     String
      * @return String
      */
     public String generateToken(Duration duration, UUID userId, String role) {
@@ -40,19 +40,13 @@ public class JwtProvider {
      * 토큰 생성
      *
      * @param expirationDate Date 만료 시간
-     * @param userId UUID
-     * @param role String
+     * @param userId         UUID
+     * @param role           String
      * @return String
      */
     private String makeToken(Date expirationDate, UUID userId, String role) {
-        return Jwts.builder()
-                .issuer(jwtProperties.getIssuer())
-                .issuedAt(new Date())
-                .expiration(expirationDate)
-                .claim("id", userId)
-                .claim("role", role)
-                .signWith(getSigningKey())
-                .compact();
+        return Jwts.builder().issuer(jwtProperties.getIssuer()).issuedAt(new Date()).expiration(expirationDate)
+                .claim("id", userId).claim("role", role).signWith(getSigningKey()).compact();
     }
 
     /**
@@ -80,11 +74,7 @@ public class JwtProvider {
         Claims claims = getClaims(token);
         Set<SimpleGrantedAuthority> authorities = Collections.singleton(
                 new SimpleGrantedAuthority(claims.get("role", String.class)));
-        return new UsernamePasswordAuthenticationToken(
-                claims.get("id", UUID.class),
-                token,
-                authorities
-        );
+        return new UsernamePasswordAuthenticationToken(claims.get("id", UUID.class), token, authorities);
     }
 
     /**
@@ -94,9 +84,7 @@ public class JwtProvider {
      * @return Claims
      */
     private Claims getClaims(String token) {
-        Jws<Claims> claimsJws = Jwts.parser()
-                .verifyWith(getSigningKey())
-                .build().parseSignedClaims(token);
+        Jws<Claims> claimsJws = Jwts.parser().verifyWith(getSigningKey()).build().parseSignedClaims(token);
         return claimsJws.getPayload();
     }
 

--- a/src/main/java/org/myteam/server/global/jwt/JwtProvider.java
+++ b/src/main/java/org/myteam/server/global/jwt/JwtProvider.java
@@ -1,0 +1,111 @@
+package org.myteam.server.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class JwtProvider {
+
+    private final JwtProperties jwtProperties;
+
+    /**
+     * 토큰 발급
+     *
+     * @param duration Duration 만료 기간
+     * @param userId UUID
+     * @param role String
+     * @return String
+     */
+    public String generateToken(Duration duration, UUID userId, String role) {
+        Date now = new Date();
+        return makeToken(new Date(now.getTime() + duration.toMillis()), userId, role);
+    }
+
+    /**
+     * 토큰 생성
+     *
+     * @param expirationDate Date 만료 시간
+     * @param userId UUID
+     * @param role String
+     * @return String
+     */
+    private String makeToken(Date expirationDate, UUID userId, String role) {
+        return Jwts.builder()
+                .issuer(jwtProperties.getIssuer())
+                .issuedAt(new Date())
+                .expiration(expirationDate)
+                .claim("id", userId)
+                .claim("role", role)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    /**
+     * 토큰 유효성 검사
+     *
+     * @param token String
+     * @return boolean
+     */
+    public boolean validToken(final String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * 토큰으로부터 Authentication 객체를 가져옴
+     *
+     * @param token String
+     * @return Authentication
+     */
+    public Authentication getAuthentication(final String token) {
+        Claims claims = getClaims(token);
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(
+                new SimpleGrantedAuthority(claims.get("role", String.class)));
+        return new UsernamePasswordAuthenticationToken(
+                claims.get("id", UUID.class),
+                token,
+                authorities
+        );
+    }
+
+    /**
+     * 토큰으로부터 Claims를 가져옴
+     *
+     * @param token String
+     * @return Claims
+     */
+    private Claims getClaims(String token) {
+        Jws<Claims> claimsJws = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build().parseSignedClaims(token);
+        return claimsJws.getPayload();
+    }
+
+    /**
+     * 서명 키 생성
+     *
+     * @return SecretKey
+     */
+    public SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(jwtProperties.getSecretKey()));
+    }
+}

--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -32,8 +32,11 @@ public class SecurityConfig {
                 .logout(AbstractHttpConfigurer::disable).sessionManagement(
                         sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/h2-console").permitAll().anyRequest()
-                        .permitAll());
+                        .requestMatchers("/h2-console").permitAll()
+                        .requestMatchers("/test/**").authenticated()
+                        .anyRequest().permitAll());
+
+        http.addFilterBefore(new TokenAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -1,7 +1,11 @@
 package org.myteam.server.global.security.config;
 
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.global.jwt.JwtProvider;
+import org.myteam.server.global.security.filter.TokenAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -9,10 +13,15 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.HstsConfig;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package org.myteam.server.global.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.HstsConfig;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http.headers(headers -> headers.httpStrictTransportSecurity(HstsConfig::disable)
+                        .frameOptions(FrameOptionsConfig::disable)).csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable).httpBasic(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable).sessionManagement(
+                        sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/h2-console").permitAll().anyRequest()
+                        .permitAll());
+
+        return http.build();
+    }
+}

--- a/src/main/java/org/myteam/server/global/security/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/org/myteam/server/global/security/filter/TokenAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package org.myteam.server.global.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.global.jwt.JwtProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+        String accessToken = getAccessToken(authorizationHeader);
+
+        if (jwtProvider.validToken(accessToken)) {
+            Authentication authentication = jwtProvider.getAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * authorization header 에서 access token 을 추출합니다.
+     *
+     * @param authorizationHeader : String authorization header
+     * @return String access token
+     */
+    private String getAccessToken(String authorizationHeader) {
+        if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+            return authorizationHeader.replace(TOKEN_PREFIX, "");
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/myteam/server/member/entity/Member.java
+++ b/src/main/java/org/myteam/server/member/entity/Member.java
@@ -1,0 +1,48 @@
+package org.myteam.server.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_members")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String role;
+
+    //TODO: 적은 확률로 충돌이 일어나는 상황을 방지하는 로직 필요
+    @Column(nullable = false, updatable = false, unique = true, columnDefinition = "BINARY(16)")
+    private UUID publicId = UUID.randomUUID();
+
+    @Builder
+    private Member(String username, String password, String email, String role) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/org/myteam/server/member/repository/MemberRepository.java
+++ b/src/main/java/org/myteam/server/member/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package org.myteam.server.member.repository;
+
+import java.util.Optional;
+import org.myteam.server.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUsername(String username);
+}

--- a/src/main/resources/application-auth.yml
+++ b/src/main/resources/application-auth.yml
@@ -1,0 +1,4 @@
+#TODO: 환경변수로 변경
+jwt:
+  issuer: "myteam.org"
+  secret-key: "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1"

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,41 @@
+spring:
+
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password: password
+
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: false
+        use_sql_comments: false
+        default_batch_fetch_size: 1000 #최적화 옵션
+    hibernate:
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+      ddl-auto: create
+      #  create	기존테이블을 삭제하고 다시 생성
+      #  create-drop 기존테이블을 삭제하고 다시생성. 종료 시점에 테이블삭제
+      #  update	변경된 스키마 적용 (운영 DB 에서 사용X)
+      #  validate Entity 와 테이블이 정상 매핑 되었는지 확인
+      #  none 기존테이블을 더 이상 건드리지 않음.
+    open-in-view: true
+
+logging:
+  level:
+    root: INFO  # 전체 로그를 INFO, DEBUG, WARN 수준으로 설정
+    org.springframework.security: TRACE
+    org.springframework.web: INFO
+    com.myteam.server: DEBUG
+    # 필요 시 특정 SQL 로그를 추가하거나 Hibernate SQL 로그를 설정
+    hibernate.SQL: INFO
+    org.springframework.boot.autoconfigure: INFO
+    org.springframework.beans.factory.support.DefaultListableBeanFactory: WARN
+    # 아직 Thymeleaf 를 사용하지 않기 때문에, 경고 메세지를 제거합니다.
+    spring.thymeleaf.check-template-location: false
+    org.hibernate.type: INFO
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
+  profiles:
+    active: dev
+    include: auth
   application:
     name: myteam-server
-
-#TODO: 환경변수로 변경
-jwt:
-  issuer: "myteam.org"
-  secret-key: "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: myteam-server
+
+#TODO: 환경변수로 변경
+jwt:
+  issuer: "myteam.org"
+  secret-key: "401b09eab3c013d4ca54922bb802bec8fd5318192b0a75f201d8b3727429080fb337591abd3e44453b954555b7a0812e1081c39b740293f765eae731f5a65ed1"


### PR DESCRIPTION
## 기능 설명
- 인증 인가가 필요한 API 의 접근을 제한합니다
- 발급받은 Jwt를 헤더에 삽입하여 API 에 접근할 수 있습니다.

## 작업 내용
- JwtFilter 개발 및 시큐리티에 추가
- test api 를 만들어서 로직 작동 확인

## 수정 사항

## 추가 작업 예정
- refresh 토큰을 이용한 accesstoken 갱신 로직 개발
- access token과 refresh token의 구분 로직 개발
