### PR TITLE
Feat/ph 97

### DIFF
--- a/src/main/java/org/myteam/server/board/controller/CategoryController.java
+++ b/src/main/java/org/myteam/server/board/controller/CategoryController.java
@@ -23,7 +23,6 @@ public class CategoryController {
 
     // CREATE: 카테고리 생성
     @PostMapping
-    @PreAuthorize("hasAuthority(T(org.myteam.server.member.domain.MemberRole).ADMIN.name())")
     public ResponseEntity<ResponseDto<CategoryResponse>> createCategory(@Valid @RequestBody CategorySaveRequest categorySaveRequest) {
         CategoryResponse response = categoryService.create(categorySaveRequest);
         return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "카테고리 생성 성공", response));
@@ -31,7 +30,6 @@ public class CategoryController {
 
     // UPDATE: 카테고리 수정
     @PutMapping("/{id}")
-    @PreAuthorize("hasAuthority(T(org.myteam.server.member.domain.MemberRole).ADMIN.name())")
     public ResponseEntity<ResponseDto<CategoryResponse>> updateCategory(@PathVariable Long id,
                                                                         @Valid @RequestBody CategoryUpdateRequest categoryUpdateRequest) {
         CategoryResponse response = categoryService.update(id, categoryUpdateRequest);
@@ -40,7 +38,6 @@ public class CategoryController {
 
     // DELETE: 카테고리 삭제
     @DeleteMapping("/{id}")
-    @PreAuthorize("hasAuthority(T(org.myteam.server.member.domain.MemberRole).ADMIN.name())")
     public ResponseEntity<ResponseDto<Void>> deleteCategory(@PathVariable Long id) {
         categoryService.delete(id);
         return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "카테고리 삭제 성공", null));

--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.myteam.server.oauth2.service.CustomOAuth2UserService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -97,14 +98,14 @@ public class SecurityConfig {
             );
 
         http
-            .addFilterBefore(
+            .addFilterAt(
+                    new JwtAuthenticationFilter(authenticationManager(), jwtProvider, refreshJpaRepository),
+                    UsernamePasswordAuthenticationFilter.class
+            ) // 로그인 인증 필터
+            .addFilterAfter(
                         new TokenAuthenticationFilter(jwtProvider),
                         JwtAuthenticationFilter.class
-            )
-            .addFilterAfter(
-                        new JwtAuthenticationFilter(authenticationManager(), jwtProvider, refreshJpaRepository),
-                        TokenAuthenticationFilter.class
-            ); // 회원 로그인 필터
+            ); // JWT 토큰 검증 필터
 
         // cors 설정
         http
@@ -113,13 +114,24 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
             .authorizeHttpRequests(authorizeRequests ->
-                    authorizeRequests
-                            .requestMatchers(TOKEN_REISSUE_PATH).permitAll()          // 토큰 재발급
-                            .requestMatchers("/h2-console").permitAll()       // H2 콘솔 접근 허용
-                            .requestMatchers("/api/members/role").permitAll()       // 유저 권한 변경 허용
-                            .requestMatchers("/api/members/get-token/{email}").permitAll()       // 테스트용 토큰 발급용
-                            .requestMatchers("/api/admin/**").hasAnyRole(MemberRole.ADMIN.name())
-                            .anyRequest().permitAll()                   // 나머지 요청은 모두 허용
+                authorizeRequests
+                    .requestMatchers("/upload/**").permitAll()       // 정적 자원 접근 허용
+                    .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
+
+                    .requestMatchers("/h2-console").permitAll()       // H2 콘솔 접근 허용
+                    .requestMatchers("/api/members/get-token/**").permitAll()       // 테스트용 토큰 발급용
+
+                    .requestMatchers("/api/admin/**").hasAnyAuthority(MemberRole.ADMIN.name())
+                    .requestMatchers(HttpMethod.POST, "/api/me/create").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/categories/**").permitAll()
+                    .requestMatchers(HttpMethod.PUT, "/api/categories/**").hasAnyAuthority(MemberRole.ADMIN.name())
+                    .requestMatchers(HttpMethod.DELETE, "/api/categories/**").hasAnyAuthority(MemberRole.ADMIN.name())
+                    .requestMatchers(HttpMethod.POST, "/api/categories").hasAnyAuthority(MemberRole.ADMIN.name())
+
+                    .requestMatchers(TOKEN_REISSUE_PATH).permitAll()          // 토큰 재발급
+                    .requestMatchers("/api/members/role").permitAll()       // 유저 권한 변경 허용
+
+                    .anyRequest().authenticated()                   // 나머지 요청은 모두 허용
             );
 
         http

--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -114,12 +114,12 @@ public class SecurityConfig {
         http
             .authorizeHttpRequests(authorizeRequests ->
                     authorizeRequests
-                            .requestMatchers("/h2-console").permitAll()       // H2 콘솔 접근 허용
                             .requestMatchers(TOKEN_REISSUE_PATH).permitAll()          // 토큰 재발급
-                            .requestMatchers("/api/admin/**").hasAnyRole(MemberRole.ADMIN.name())
+                            .requestMatchers("/h2-console").permitAll()       // H2 콘솔 접근 허용
                             .requestMatchers("/api/members/role").permitAll()       // 유저 권한 변경 허용
                             .requestMatchers("/api/members/get-token/{email}").permitAll()       // 테스트용 토큰 발급용
-                            .anyRequest().permitAll()                         // 나머지 요청은 모두 허용
+                            .requestMatchers("/api/admin/**").hasAnyRole(MemberRole.ADMIN.name())
+                            .anyRequest().permitAll()                   // 나머지 요청은 모두 허용
             );
 
         http

--- a/src/main/java/org/myteam/server/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/myteam/server/global/security/filter/JwtAuthenticationFilter.java
@@ -85,7 +85,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
             if (status.equals(PENDING.name())) {
                 log.warn("PENDING 상태인 경우 로그인이 불가능합니다");
-                sendErrorResponse(response, HttpStatus.FORBIDDEN, "PENDING 상태인 경우 로그인이 불가능합니다");
+                sendErrorResponse(response, HttpStatus.LOCKED, "PENDING 상태인 경우 로그인이 불가능합니다");
                 return;
             } else if (status.equals(INACTIVE.name())) {
                 log.warn("INACTIVE 상태인 경우 로그인이 불가능합니다");
@@ -113,6 +113,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
             log.debug("print accessToken: {}", accessToken);
             log.debug("print refreshToken: {}", refreshToken);
+            log.debug("print role: {}", role);
 
             //Refresh 토큰 저장
             addRefreshEntity(publicId, refreshToken, Duration.ofHours(24));
@@ -121,7 +122,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
             response.addCookie(createCookie(REFRESH_TOKEN_KEY, cookieValue, TOKEN_REISSUE_PATH, 24 * 60 * 60, true));
             response.addCookie(createCookie(REFRESH_TOKEN_KEY, cookieValue, LOGOUT_PATH, 24 * 60 * 60, true));
             response.setStatus(HttpStatus.OK.value());
-
 
 //            frontUrl += "?" + ACCESS_TOKEN_KEY + "=" + ("Bearer%20" + accessToken);
 //            frontUrl += "&" + REFRESH_TOKEN_KEY + "=" + ("Bearer%20" + refreshToken);

--- a/src/main/java/org/myteam/server/global/security/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/org/myteam/server/global/security/filter/TokenAuthenticationFilter.java
@@ -34,24 +34,26 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        log.info("TokenAuthenticationFilter 토큰을 검사중");
+        log.info("Token Authenticate Filter 토큰을 검사중");
         String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
         String accessToken = jwtProvider.getAccessToken(authorizationHeader);
 
         log.info("accessToken : " + accessToken);
         if (StringUtils.isNotBlank(accessToken)) {
-            if (jwtProvider.validToken(accessToken)) {
-
-                String accessCategory = jwtProvider.getCategory(accessToken);
-
-                if (!accessCategory.equals(TOKEN_CATEGORY_ACCESS)) {
-                    // RestControllerAdvice 로 에러가 전달 되지 않아 여기서 에러 처리함
-                    log.warn("잘못된 토큰 유형입니다.");
-                    sendErrorResponse(response, INVALID_TOKEN_TYPE.getStatus(), "잘못된 토큰 유형");
+            try {
+                if (!jwtProvider.validToken(accessToken)) {
+                    log.warn("인증되지 않은 토큰입니다");
+                    filterChain.doFilter(request, response);
                     return;
                 }
 
-                // 토큰에서 username과 role 획득
+                String accessCategory = jwtProvider.getCategory(accessToken);
+                if (!TOKEN_CATEGORY_ACCESS.equals(accessCategory)) {
+                    log.warn("잘못된 토큰 유형입니다");
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 UUID publicId = jwtProvider.getPublicId(accessToken);
                 String role = jwtProvider.getRole(accessToken);
                 String status = jwtProvider.getStatus(accessToken);
@@ -60,7 +62,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                 log.info("role : " + role);
                 log.info("status : " + status);
 
-                // Member 를 생성하여 값 set
                 Member member = Member.builder()
                         .publicId(publicId)
                         .role(MemberRole.valueOf(role))
@@ -68,45 +69,16 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                         .build();
 
                 CustomUserDetails customUserDetails = new CustomUserDetails(member);
-
                 Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
                 SecurityContextHolder.getContext().setAuthentication(authToken);
-                log.info("security Context 에 정보 저장이 완료되었습니다.");
-            } else {
-                try {
-                    if (jwtProvider.isExpired(accessToken)) {
-                        // RestControllerAdvice 로 에러가 전달 되지 않아 여기서 에러 처리함
-                        log.warn("토큰이 만료되었습니다.");
-                        sendErrorResponse(response, ACCESS_TOKEN_EXPIRED.getStatus(), "만료된 토큰");
-                        return;
-                    }
-                } catch (JwtException | IllegalArgumentException e) {
-                    // RestControllerAdvice 로 에러가 전달 되지 않아 여기서 에러 처리함
-                    log.error("잘못된 JWT 토큰 형식 또는 그 외 에러 : {}", e.getMessage());
-                    sendErrorResponse(response, INVALID_ACCESS_TOKEN.getStatus(), "잘못된 JWT 토큰 형식 또는 그 외 에러");
-                    return;
-                }
-                // RestControllerAdvice 로 에러가 전달 되지 않아 여기서 에러 처리함
-                log.warn("인증되지 않은 토큰입니다.");
-                sendErrorResponse(response, INVALID_ACCESS_TOKEN.getStatus(), "인증되지 않은 토큰");
+                log.info("SecurityContext 에 인증 정보 저장 완료");
+            } catch (JwtException e) {
+                log.error("JWT 처리 중 오류 발생: {}", e.getMessage());
+                filterChain.doFilter(request, response);
                 return;
             }
         }
         filterChain.doFilter(request, response);
-    }
-
-    /**
-     * 공통 에러 응답 처리 메서드
-     *
-     * @param response HttpServletResponse
-     * @param httpStatus HTTP 상태 오브젝트
-     * @param message 메시지
-     * @throws IOException
-     */
-    private void sendErrorResponse(HttpServletResponse response, HttpStatus httpStatus, String message) throws IOException {
-        response.setStatus(httpStatus.value());
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        response.getWriter().write(String.format("{\"message\":\"%s\",\"status\":\"%s\"}", message, httpStatus.name()));
     }
 }

--- a/src/main/java/org/myteam/server/member/controller/MemberController.java
+++ b/src/main/java/org/myteam/server/member/controller/MemberController.java
@@ -80,11 +80,19 @@ public class MemberController {
         return new ResponseEntity<>(new ResponseDto<>(SUCCESS.name(), "권한 변경 성공", response), HttpStatus.OK);
     }
 
-    @GetMapping("/get-token/{email}")
+    @GetMapping("/get-token/admin/{email}")
+    public ResponseEntity<?> getAdminToken(@PathVariable String email) {
+        log.info("getToken 메서드가 실행되었습니다.");
+        MemberResponse response = memberService.getByEmail(email);
+        String encode = TOKEN_PREFIX + jwtProvider.generateToken(TOKEN_CATEGORY_ACCESS, Duration.ofHours(10), response.getPublicId(), MemberRole.ADMIN.name(), response.getStatus().name());
+        return new ResponseEntity<>(new ResponseDto<>(SUCCESS.name(), "토큰 조회 성공", encode), HttpStatus.OK);
+    }
+
+    @GetMapping("/get-token/user/{email}")
     public ResponseEntity<?> getToken(@PathVariable String email) {
         log.info("getToken 메서드가 실행되었습니다.");
         MemberResponse response = memberService.getByEmail(email);
-        String encode = TOKEN_PREFIX + jwtProvider.generateToken(TOKEN_CATEGORY_ACCESS, Duration.ofHours(6), response.getPublicId(), MemberRole.USER.name(), response.getStatus().name());
+        String encode = TOKEN_PREFIX + jwtProvider.generateToken(TOKEN_CATEGORY_ACCESS, Duration.ofHours(10), response.getPublicId(), MemberRole.USER.name(), response.getStatus().name());
         return new ResponseEntity<>(new ResponseDto<>(SUCCESS.name(), "토큰 조회 성공", encode), HttpStatus.OK);
     }
 }

--- a/src/main/java/org/myteam/server/member/controller/MemberController.java
+++ b/src/main/java/org/myteam/server/member/controller/MemberController.java
@@ -66,11 +66,9 @@ public class MemberController {
         log.info("email : {}" , response.getEmail());
 
         // 서비스 호출
-        MemberStatus memberStatus = memberStatusUpdateRequest.getStatus(); // 변경 상태
         String targetEmail = response.getEmail(); // 상태를 변경할 대상 이메일
-        String extractedEmail = memberStatusUpdateRequest.getEmail(); // 토큰에서 추출된 이메일
 
-        memberService.updateStatus(extractedEmail, targetEmail, memberStatus);
+        memberService.updateStatus(targetEmail, memberStatusUpdateRequest);
 
         return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "회원 상태가 성공적으로 변경되었습니다.", null));
     }

--- a/src/main/java/org/myteam/server/member/controller/MemberController.java
+++ b/src/main/java/org/myteam/server/member/controller/MemberController.java
@@ -66,7 +66,7 @@ public class MemberController {
         log.info("email : {}" , response.getEmail());
 
         // 서비스 호출
-        String targetEmail = response.getEmail(); // 상태를 변경할 대상 이메일
+        String targetEmail = response.getEmail(); // 변경을 시도하는 유저의 이메일 (본인 또는 관리자)
 
         memberService.updateStatus(targetEmail, memberStatusUpdateRequest);
 

--- a/src/main/java/org/myteam/server/member/domain/GenderType.java
+++ b/src/main/java/org/myteam/server/member/domain/GenderType.java
@@ -2,9 +2,6 @@ package org.myteam.server.member.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.myteam.server.global.exception.PlayHiveException;
-
-import static org.myteam.server.global.exception.ErrorCode.INVALID_PARAMETER;
 
 @AllArgsConstructor
 @Getter
@@ -18,6 +15,6 @@ public enum GenderType {
                 return gender;
             }
         }
-        throw new PlayHiveException(INVALID_PARAMETER, "Invalid gender value: " + value);
+        return null;
     }
 }

--- a/src/main/java/org/myteam/server/member/dto/MemberDeleteRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberDeleteRequest.java
@@ -14,6 +14,6 @@ public class MemberDeleteRequest {
 
     @NotBlank
     // @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문+숫자 조합 4 ~ 10자 이내로 입력해주세요")
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 10자 이내로 입력해주세요")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{4,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 15자 이내로 입력해주세요")
     private String password; // 비밀번호
 }

--- a/src/main/java/org/myteam/server/member/dto/MemberSaveRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberSaveRequest.java
@@ -17,7 +17,7 @@ public class MemberSaveRequest {
 
     @NotBlank
     // @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문+숫자 조합 4 ~ 10자 이내로 입력해주세요")
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 10자 이내로 입력해주세요")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{4,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 15자 이내로 입력해주세요")
     private String password; // 비밀번호
 
     @NotBlank

--- a/src/main/java/org/myteam/server/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberUpdateRequest.java
@@ -30,7 +30,7 @@ public class MemberUpdateRequest {
     @Column(name = "birth_date")
     private LocalDate birthdate;
 
-    @Pattern(regexp = "^(MALE|FEMALE)$", message = "성별은 MALE, FEMALE 중 하나여야 합니다.")
+    @Pattern(regexp = "^(?i)(MALE|FEMALE)$", message = "성별은 MALE, FEMALE 중 하나여야 합니다.")
     private String gender;
 
     private MemberStatus status;

--- a/src/main/java/org/myteam/server/member/dto/PasswordChangeRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/PasswordChangeRequest.java
@@ -8,15 +8,15 @@ import lombok.*;
 @NoArgsConstructor
 public class PasswordChangeRequest {
     @NotNull
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 10자 이내로 입력해주세요")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{4,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 15자 이내로 입력해주세요")
     private String password;
 
     @NotNull
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 10자 이내로 입력해주세요")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{4,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 15자 이내로 입력해주세요")
     private String newPassword;
 
     @NotNull
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{8,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 10자 이내로 입력해주세요")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9]).{4,15}$", message = "비밀번호는 영문, 숫자 조합 4 ~ 15자 이내로 입력해주세요")
     private String confirmPassword;
 
     @Builder

--- a/src/main/java/org/myteam/server/member/entity/Member.java
+++ b/src/main/java/org/myteam/server/member/entity/Member.java
@@ -16,6 +16,7 @@ import org.myteam.server.member.dto.MemberUpdateRequest;
 import org.myteam.server.member.dto.PasswordChangeRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static org.myteam.server.member.domain.MemberRole.ADMIN;
 import static org.myteam.server.member.domain.MemberRole.USER;
 import static org.myteam.server.member.domain.MemberStatus.PENDING;
 import static org.myteam.server.member.domain.MemberType.LOCAL;
@@ -124,6 +125,10 @@ public class Member {
 
     public boolean verifyOwnEmail(String email) {
         return email.equals(this.email);
+    }
+
+    public boolean isAdmin() {
+        return this.role.equals(ADMIN);
     }
 
     public boolean validatePassword(String inputPassword, PasswordEncoder bCryptPasswordEncoder) {


### PR DESCRIPTION
## 기능 설명
  유저 도메인 에러 및 기능 수정 커밋 

## 작업 내용
1. 유저 상태변경 관련 에러 수정 
 - 자신의 상태를 변경 
 - 관리자가 다른 계정의 상태를 변경 …
 - 일반 유저가 다른 사람의 유저 변경시 에러 확인
 2. 정적 자원 경로 허용 
 3. 사용자 편의용 토큰 메서드 생성 
 4. 비밀번호 패스워드 관련 validation 수정 
 5. 성별 validation 수정 5
 6. PENDING 관련 상태코드 423 으로 변경
 7. Oauth 에서 pending 상태 일 때 리프레시 토큰을 발급하고 이동하도록 수정

## 수정 사항

## 추가 작업 예정
