### PR TITLE
Feat/ph 108 fix : 소셜 로그인 부분 로직 수정 

### DIFF
--- a/src/main/java/org/myteam/server/auth/controller/ReIssueController.java
+++ b/src/main/java/org/myteam/server/auth/controller/ReIssueController.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import static org.myteam.server.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
 import static org.myteam.server.global.security.jwt.JwtProvider.*;
 import static org.myteam.server.global.util.cookie.CookieUtil.createCookie;
+import static org.myteam.server.global.util.domain.DomainUtil.extractDomain;
 
 /**
  * TODO_ : 리프레시 토큰에 대한 블랙 리스트 작성
@@ -50,7 +51,8 @@ public class ReIssueController {
                     URLEncoder.encode(TOKEN_PREFIX + tokens.getRefreshToken(), StandardCharsets.UTF_8),
                     TOKEN_REISSUE_PATH,
                     24 * 60 * 60,
-                    true
+                    true,
+                    extractDomain(request.getServerName())
             ));
 
             response.addCookie(createCookie(
@@ -58,7 +60,8 @@ public class ReIssueController {
                     URLEncoder.encode(TOKEN_PREFIX + tokens.getRefreshToken(), StandardCharsets.UTF_8),
                     LOGOUT_PATH,
                     24 * 60 * 60,
-                    true
+                    true,
+                    extractDomain(request.getServerName())
             ));
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (PlayHiveException e) {

--- a/src/main/java/org/myteam/server/auth/repository/RefreshJpaRepository.java
+++ b/src/main/java/org/myteam/server/auth/repository/RefreshJpaRepository.java
@@ -4,12 +4,11 @@ import org.myteam.server.auth.entity.Refresh;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 import java.util.UUID;
 
 public interface RefreshJpaRepository extends JpaRepository<Refresh, Long> {
     Boolean existsByRefreshAndPublicId(String refresh, UUID publicId);
-    Optional<Refresh> findByPublicId(UUID publicId); // 테스트 용으로 추가함
+
     @Transactional
-    void deleteByRefreshAndPublicId(String refresh, UUID publicId);
+    void deleteByPublicId(UUID publicId);
 }

--- a/src/main/java/org/myteam/server/global/config/WebConfig.java
+++ b/src/main/java/org/myteam/server/global/config/WebConfig.java
@@ -17,8 +17,6 @@ public class WebConfig {
 
     @Value("${FRONT_URL:http://localhost:3000}")
     private String frontUrl;
-    @Value("${BACKEND_URL:http://localhost:8080}")
-    private String backendUrl;
 
     protected WebConfig() {
     }
@@ -28,7 +26,7 @@ public class WebConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
 
-        final String[] ALLOWED_ORIGIN = {frontUrl, backendUrl};
+        final String[] ALLOWED_ORIGIN = {frontUrl};
 
         config.setAllowCredentials(true);
         config.setAllowedOrigins(Arrays.asList(ALLOWED_ORIGIN));

--- a/src/main/java/org/myteam/server/global/config/WebConfig.java
+++ b/src/main/java/org/myteam/server/global/config/WebConfig.java
@@ -1,5 +1,6 @@
 package org.myteam.server.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -14,11 +15,10 @@ import static org.myteam.server.global.security.jwt.JwtProvider.REFRESH_TOKEN_KE
 @Configuration
 public class WebConfig {
 
-    private final String[] ALLOWED_ORIGIN = {
-            "http://localhost:3000",
-            "http://playhive.com:3000",
-    };
-
+    @Value("${FRONT_URL:http://localhost:3000}")
+    private String frontUrl;
+    @Value("${BACKEND_URL:http://localhost:8080}")
+    private String backendUrl;
 
     protected WebConfig() {
     }
@@ -27,6 +27,8 @@ public class WebConfig {
     public CorsFilter corsFilter() {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
+
+        final String[] ALLOWED_ORIGIN = {frontUrl, backendUrl};
 
         config.setAllowCredentials(true);
         config.setAllowedOrigins(Arrays.asList(ALLOWED_ORIGIN));

--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.myteam.server.global.security.config;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.auth.repository.RefreshJpaRepository;
@@ -64,6 +65,8 @@ public class SecurityConfig {
 
     @Value("${FRONT_URL:http://localhost:3000}")
     private String frontUrl;
+    @Value("${BACKEND_URL:http://localhost:8080}")
+    private String backendUrl;
     private final JwtProvider jwtProvider;
     private final WebConfig webConfig;
     private final CustomUserDetailsService customUserDetailsService;
@@ -71,6 +74,12 @@ public class SecurityConfig {
     private final CustomOauth2SuccessHandler customOauth2SuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final RefreshJpaRepository refreshJpaRepository;
+
+    @PostConstruct
+    public void init() {
+        log.debug("init security config");
+        log.debug("frontUrl = {}", frontUrl);
+    }
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -153,7 +162,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.DELETE, "/api/categories/**").hasAnyAuthority(MemberRole.ADMIN.name())
                                 .requestMatchers(HttpMethod.POST, "/api/categories").hasAnyAuthority(MemberRole.ADMIN.name())
 
-                                .requestMatchers(TOKEN_REISSUE_PATH).permitAll()          // 토큰 재발급
+                                .requestMatchers(HttpMethod.POST, TOKEN_REISSUE_PATH).permitAll()          // 토큰 재발급
                                 .requestMatchers("/api/members/role").permitAll()       // 유저 권한 변경 허용
 
                                 .anyRequest().authenticated()                   // 나머지 요청은 모두 허용
@@ -192,7 +201,7 @@ public class SecurityConfig {
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.addAllowedOriginPattern(frontUrl); // TODO_ 추후 변경 해야함 배포시
-        configuration.addAllowedOriginPattern("http://playhive.com:3000"); // TODO_ 추후 변경 해야함 배포시
+        configuration.addAllowedOriginPattern(backendUrl); // TODO_ 추후 변경 해야함 배포시
         configuration.setAllowCredentials(true);
         configuration.addExposedHeader(HEADER_AUTHORIZATION);
         configuration.addExposedHeader(REFRESH_TOKEN_KEY);

--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -65,8 +65,6 @@ public class SecurityConfig {
 
     @Value("${FRONT_URL:http://localhost:3000}")
     private String frontUrl;
-    @Value("${BACKEND_URL:http://localhost:8080}")
-    private String backendUrl;
     private final JwtProvider jwtProvider;
     private final WebConfig webConfig;
     private final CustomUserDetailsService customUserDetailsService;
@@ -201,7 +199,6 @@ public class SecurityConfig {
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.addAllowedOriginPattern(frontUrl); // TODO_ 추후 변경 해야함 배포시
-        configuration.addAllowedOriginPattern(backendUrl); // TODO_ 추후 변경 해야함 배포시
         configuration.setAllowCredentials(true);
         configuration.addExposedHeader(HEADER_AUTHORIZATION);
         configuration.addExposedHeader(REFRESH_TOKEN_KEY);

--- a/src/main/java/org/myteam/server/global/util/cookie/CookieUtil.java
+++ b/src/main/java/org/myteam/server/global/util/cookie/CookieUtil.java
@@ -12,27 +12,32 @@ public class CookieUtil {
     /**
      * 쿠키 생성
      *
-     * @param key   쿠키 키
-     * @param value 쿠키 값
-     * @param maxAge 쿠키 유효시간 (초 단위)
+     * @param key        쿠키 키
+     * @param value      쿠키 값
+     * @param maxAge     쿠키 유효시간 (초 단위)
+     * @param path       쿠키 경로
      * @param isHttpOnly JavaScript 에서 접근 불가능하도록 설정
      * @return Cookie
      */
-    public static Cookie createCookie(String key, String value, String path, int maxAge, boolean isHttpOnly) {
+    public static Cookie createCookie(String key, String value, String path, int maxAge, boolean isHttpOnly, String domain) {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(maxAge);
         // cookie.setSecure(isSecure); // Secure 설정 여부 (HTTPS에서만 사용)
         cookie.setPath(path);
         cookie.setHttpOnly(isHttpOnly);
+        if (domain != null) {
+            // ex) playhive.shop
+            cookie.setDomain(domain);
+        }
         return cookie;
     }
 
     /**
      * 쿠키 생성
      *
-     * @param key   쿠키 키
-     * @param value 쿠키 값
-     * @param maxAge 쿠키 유효시간 (초 단위)
+     * @param key        쿠키 키
+     * @param value      쿠키 값
+     * @param maxAge     쿠키 유효시간 (초 단위)
      * @param isHttpOnly JavaScript 에서 접근 불가능하도록 설정
      * @return Cookie
      */

--- a/src/main/java/org/myteam/server/global/util/domain/DomainUtil.java
+++ b/src/main/java/org/myteam/server/global/util/domain/DomainUtil.java
@@ -1,0 +1,17 @@
+package org.myteam.server.global.util.domain;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DomainUtil {
+    public static String extractDomain(String str) {
+        String regPattern = "([a-z\\d\\-]+(?:\\.(?:asia|gg|info|name|mobi|shop|com|net|org|biz|tel|xxx|kr|co|so|me|eu|cc|or|pe|ne|re|tv|jp|tw|edu\\.vn|vn)){1,2})(?::\\d{1,5})?(?:/[^\\?]*)?(?:\\?.+)?$";
+        Pattern pattern = Pattern.compile(regPattern, Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(str);
+
+        if (matcher.find()) {
+            return matcher.group(1); // 첫 번째 그룹 매칭 반환
+        }
+        throw new IllegalArgumentException("유효하지 않은 URL 또는 도메인: " + str);
+    }
+}

--- a/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
@@ -1,5 +1,6 @@
 package org.myteam.server.member.dto;
 
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,5 +12,6 @@ public class MemberStatusUpdateRequest {
     @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email; // 계정
 
+    @NotNull
     private MemberStatus status;
 }

--- a/src/main/java/org/myteam/server/member/entity/Member.java
+++ b/src/main/java/org/myteam/server/member/entity/Member.java
@@ -38,10 +38,10 @@ public class Member extends Base {
     @Column(nullable = false, length = 60) // 패스워드 인코딩(BCrypt)
     private String password; // 비밀번호
 
-    @Column(nullable = false, length = 11)
+    @Column(length = 11)
     private String tel;
 
-    @Column(nullable = false, length = 60)
+    @Column(length = 60)
     private String nickname;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/myteam/server/oauth2/handler/CustomOauth2SuccessHandler.java
+++ b/src/main/java/org/myteam/server/oauth2/handler/CustomOauth2SuccessHandler.java
@@ -4,6 +4,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.myteam.server.auth.service.ReIssueService;
 import org.myteam.server.global.security.jwt.JwtProvider;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.repository.MemberJpaRepository;
@@ -13,6 +14,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -21,7 +23,11 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
 
-import static org.myteam.server.global.security.jwt.JwtProvider.TOKEN_CATEGORY_ACCESS;
+import static org.myteam.server.auth.controller.ReIssueController.LOGOUT_PATH;
+import static org.myteam.server.auth.controller.ReIssueController.TOKEN_REISSUE_PATH;
+import static org.myteam.server.global.security.jwt.JwtProvider.*;
+import static org.myteam.server.global.util.cookie.CookieUtil.createCookie;
+import static org.myteam.server.global.util.domain.DomainUtil.extractDomain;
 import static org.myteam.server.member.domain.MemberStatus.*;
 
 @Slf4j
@@ -29,15 +35,19 @@ import static org.myteam.server.member.domain.MemberStatus.*;
 public class CustomOauth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     @Value("${FRONT_URL:http://localhost:3000}")
     private String frontUrl;
+    private final String frontSignUpPath = "/sign"; // 프론트 회원가입 주소
     private final JwtProvider jwtProvider;
     private final MemberJpaRepository memberJpaRepository;
+    private final ReIssueService reIssueService;
 
-    public CustomOauth2SuccessHandler(JwtProvider jwtProvider, MemberJpaRepository memberJpaRepository) {
+    public CustomOauth2SuccessHandler(JwtProvider jwtProvider, MemberJpaRepository memberJpaRepository, ReIssueService reIssueService) {
         this.jwtProvider = jwtProvider;
         this.memberJpaRepository = memberJpaRepository;
+        this.reIssueService = reIssueService;
     }
 
     @Override
+    @Transactional
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         log.info("onAuthenticationSuccess : Oauth 인증 성공");
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
@@ -54,10 +64,27 @@ public class CustomOauth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
         //유저확인
         Member member = memberJpaRepository.findByEmail(email).orElse(null);
 
-        if (member == null || status.equals(PENDING.name())) {
+        if (status.equals(PENDING.name())) {
             log.warn("PENDING 상태인 경우 로그인이 불가능합니다");
-            // sendErrorResponse(response, HttpStatus.FORBIDDEN, "PENDING 상태인 경우 로그인이 불가능합니다");
-            response.sendRedirect(frontUrl + "?status=" + PENDING.name() + "&email=" + email);
+
+            // X-Refresh-Token
+            String refreshToken = jwtProvider.generateToken(TOKEN_CATEGORY_REFRESH, Duration.ofMinutes(5), member.getPublicId(), member.getRole().name(), member.getStatus().name());
+            String cookieValue = URLEncoder.encode(TOKEN_PREFIX + refreshToken, StandardCharsets.UTF_8);
+
+            reIssueService.deleteByPublicId(member.getPublicId());
+            reIssueService.addRefreshEntity(member.getPublicId(), refreshToken, Duration.ofMinutes(5));
+
+            log.warn("cookieValue refreshToken 확인용: {}", refreshToken);
+            log.warn("cookieValue 쿠키 확인용: {}", cookieValue);
+            log.warn("cookieValue PublicId 확인용: {}", member.getPublicId());
+
+            // 24 시간 유효한 리프레시 토큰을 생성
+            response.addCookie(createCookie(REFRESH_TOKEN_KEY, cookieValue, TOKEN_REISSUE_PATH, 24 * 60 * 60, true, extractDomain(request.getServerName())));
+            response.addCookie(createCookie(REFRESH_TOKEN_KEY, cookieValue, LOGOUT_PATH, 24 * 60 * 60, true, extractDomain(request.getServerName())));
+            String redirectUrl = String.format("%s%s?status=%s&email=%s",
+                    frontUrl, frontSignUpPath, PENDING.name(), email);
+            log.info("redirectUrl: {}", redirectUrl);
+            response.sendRedirect(redirectUrl);
             return;
         } else if (status.equals(INACTIVE.name())) {
             log.warn("INACTIVE 상태인 경우 로그인이 불가능합니다");
@@ -80,7 +107,7 @@ public class CustomOauth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
         log.debug("print accessToken: {}", accessToken);
         // log.debug("print refreshToken: {}", refreshToken);
         log.debug("print frontUrl: {}", frontUrl);
-        response.sendRedirect(frontUrl + "?accessToken=" + URLEncoder.encode(accessToken, StandardCharsets.UTF_8));
+        response.sendRedirect(frontUrl);
         log.debug("Oauth 로그인에 성공하였습니다.");
     }
 }


### PR DESCRIPTION
## 기능 설명
 - OauthMember 테이블 삭제
 - 소셜 로그인 성공 시 PENDING 상태로 멤버 테이블에 저장되도록 수정
 - FRONT_URL, BACKEND_URL 환경 변수 추가

## 작업 내용
 - OauthMember 테이블 삭제
 - 소셜 로그인 성공 시 PENDING 상태로 멤버 테이블에 저장되도록 수정
 - FRONT_URL, BACKEND_URL 환경 변수 추가

## 수정 사항

## 추가 작업 예정
