### PR TITLE
chore: slack webhook url 생성자 주입으로 변경

### DIFF
--- a/src/main/java/org/myteam/server/util/slack/service/SlackService.java
+++ b/src/main/java/org/myteam/server/util/slack/service/SlackService.java
@@ -13,12 +13,15 @@ import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class SlackService {
 
-    @Value("${slack.webhook.url}")
     private final String webhookUrl;
     private final RestTemplate restTemplate;
+
+    public SlackService(RestTemplate restTemplate, @Value("${slack.webhook.url}") String webhookUrl) {
+        this.restTemplate = restTemplate;
+        this.webhookUrl = webhookUrl;
+    }
 
     public void sendSlackNotification(String message) {
         String payload = String.format("{\"text\":\"%s\"}", message);


### PR DESCRIPTION
## 기능 설명
* webhookurl을 생성자 주입으로 변경
## 작업 내용
* webhookurl을 생성자 주입으로 변경
## 수정 사항
* webhookurl을 생성자 주입으로 변경
## 추가 작업 예정
* aws에 띄워지는지 확인
* 슬랙에 보내는 포맷 차후 수정