### PR TITLE
feat: 게시글 생성,수정,상세조회,삭제 기능 추가

### DIFF
--- a/src/main/java/org/myteam/server/board/controller/BoardController.java
+++ b/src/main/java/org/myteam/server/board/controller/BoardController.java
@@ -1,0 +1,76 @@
+package org.myteam.server.board.controller;
+
+import static org.myteam.server.global.web.response.ResponseStatus.SUCCESS;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.myteam.server.board.controller.reponse.BoardResponse;
+import org.myteam.server.board.dto.BoardSaveRequest;
+import org.myteam.server.board.service.BoardService;
+import org.myteam.server.global.security.dto.CustomUserDetails;
+import org.myteam.server.global.web.response.ResponseDto;
+import org.myteam.server.util.ClientUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/board")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardService boardService;
+
+    /**
+     * 게시글 생성
+     */
+    @PostMapping
+    public ResponseEntity<ResponseDto<BoardResponse>> saveBoard(
+            @AuthenticationPrincipal final CustomUserDetails userDetails,
+            @Valid @RequestBody final BoardSaveRequest boardSaveRequest,
+            final HttpServletRequest request) {
+        final String clientIP = ClientUtils.getRemoteIP(request);
+        final BoardResponse response = boardService.saveBoard(boardSaveRequest, userDetails, clientIP);
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 생성 성공", response));
+    }
+
+    /**
+     * 게시글 수정
+     */
+    @PutMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<BoardResponse>> updateBoard(
+            @AuthenticationPrincipal final CustomUserDetails userDetails, @PathVariable final Long boardId,
+            @Valid @RequestBody final BoardSaveRequest boardSaveRequest) {
+        final BoardResponse response = boardService.updateBoard(boardSaveRequest, userDetails, boardId);
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 수정 성공", response));
+    }
+
+    /**
+     * 게시글 상세 조회
+     */
+    @GetMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<BoardResponse>> getBoard(@PathVariable final Long boardId) {
+        final BoardResponse response = boardService.getBoard(boardId);
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 조회 성공", response));
+    }
+
+    /**
+     * 게시글 삭제
+     */
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<Void>> deleteBoard(@PathVariable final Long boardId,
+                                                         @AuthenticationPrincipal final CustomUserDetails userDetails) {
+        boardService.deleteBoard(boardId, userDetails);
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "카테고리 삭제 성공", null));
+    }
+}

--- a/src/main/java/org/myteam/server/board/controller/reponse/BoardResponse.java
+++ b/src/main/java/org/myteam/server/board/controller/reponse/BoardResponse.java
@@ -1,0 +1,89 @@
+package org.myteam.server.board.controller.reponse;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import org.myteam.server.board.entity.Board;
+
+@Getter
+@Setter
+public class BoardResponse {
+    /**
+     * 카테고리 부모 id
+     */
+    private Long categoryParentId;
+    /**
+     * 카테고리 부모 명
+     */
+    private String categoryParentName;
+    /**
+     * 카테고리 id
+     */
+    private Long categoryId;
+    /**
+     * 카테고리명
+     */
+    private String categoryName;
+    /**
+     * 게시글 id
+     */
+    private Long boardId;
+    /**
+     * 작성자 id
+     */
+    private Long authorId;
+    /**
+     * 작성자 IP
+     */
+    private String clientIp;
+    /**
+     * 게시글 제목
+     */
+    private String title;
+    /**
+     * 게시글 내용
+     */
+    private String content;
+    /**
+     * 출처 링크
+     */
+    private String link;
+    /**
+     * 좋아요 수
+     */
+    private Integer likeCount;
+    /**
+     * 댓글 수
+     */
+    private Integer commentCount;
+    /**
+     * 조회 수
+     */
+    private Integer viewCount;
+    /**
+     * 작성 일시
+     */
+    private LocalDateTime createdAt;
+    /**
+     * 수정 일시
+     */
+    private LocalDateTime updatedAt;
+
+    public BoardResponse(Board board) {
+        this.boardId = board.getId();
+        this.categoryParentId = board.getCategory().getCategoryParentId();
+        this.categoryParentName = board.getCategory().getParentCategoryName();
+        this.categoryId = board.getCategory().getId();
+        this.categoryName = board.getCategory().getName();
+        this.authorId = board.getMember().getId();
+        this.clientIp = board.getCreatedIp();
+        this.title = board.getTitle();
+        this.content = board.getContent();
+        this.link = board.getLink();
+        this.likeCount = board.getBoardCount().getLikeCount();
+        this.commentCount = board.getBoardCount().getCommentCount();
+        this.viewCount = board.getBoardCount().getViewCount();
+        this.createdAt = board.getCreatedAt();
+        this.updatedAt = board.getUpdatedAt();
+    }
+}

--- a/src/main/java/org/myteam/server/board/controller/reponse/BoardResponse.java
+++ b/src/main/java/org/myteam/server/board/controller/reponse/BoardResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 import org.myteam.server.board.entity.Board;
+import org.myteam.server.board.entity.BoardCount;
 
 @Getter
 @Setter
@@ -69,7 +70,7 @@ public class BoardResponse {
      */
     private LocalDateTime updatedAt;
 
-    public BoardResponse(Board board) {
+    public BoardResponse(Board board, BoardCount boardCount) {
         this.boardId = board.getId();
         this.categoryParentId = board.getCategory().getCategoryParentId();
         this.categoryParentName = board.getCategory().getParentCategoryName();
@@ -80,9 +81,9 @@ public class BoardResponse {
         this.title = board.getTitle();
         this.content = board.getContent();
         this.link = board.getLink();
-        this.likeCount = board.getBoardCount().getLikeCount();
-        this.commentCount = board.getBoardCount().getCommentCount();
-        this.viewCount = board.getBoardCount().getViewCount();
+        this.likeCount = boardCount.getLikeCount();
+        this.commentCount = boardCount.getCommentCount();
+        this.viewCount = boardCount.getViewCount();
         this.createdAt = board.getCreatedAt();
         this.updatedAt = board.getUpdatedAt();
     }

--- a/src/main/java/org/myteam/server/board/dto/BoardSaveRequest.java
+++ b/src/main/java/org/myteam/server/board/dto/BoardSaveRequest.java
@@ -1,0 +1,32 @@
+package org.myteam.server.board.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BoardSaveRequest {
+    /**
+     * 카테고리 id
+     */
+    @NotNull(message = "카테고리를 선택해주세요")
+    private Long categoryId;
+    /**
+     * 제목
+     */
+    @NotBlank(message = "제목을 입력해주세요")
+    private String title;
+    /**
+     * 내용
+     */
+    @NotBlank(message = "내용을 입력해주세요")
+    private String content;
+    /**
+     * 출처 링크
+     */
+    private String link;
+}

--- a/src/main/java/org/myteam/server/board/entity/Board.java
+++ b/src/main/java/org/myteam/server/board/entity/Board.java
@@ -52,7 +52,8 @@ public class Board {
     private BoardCount boardCount;
 
     @Builder
-    public Board(Member member, Category category, String title, String content, String link, String createdIp) {
+    public Board(Member member, Category category, String title, String content, String link, String createdIp,
+                 BoardCount boardCount) {
         this.member = member;
         this.category = category;
         this.title = title;
@@ -61,6 +62,7 @@ public class Board {
         this.createdIp = createdIp;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
+        this.boardCount = boardCount;
     }
 
     public void updateBoard(BoardSaveRequest request, Category category) {

--- a/src/main/java/org/myteam/server/board/entity/Board.java
+++ b/src/main/java/org/myteam/server/board/entity/Board.java
@@ -1,0 +1,78 @@
+package org.myteam.server.board.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.board.dto.BoardSaveRequest;
+import org.myteam.server.member.entity.Member;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_board")
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    private String title;
+
+    private String content;
+
+    private String link;
+
+    private String createdIp;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @OneToOne(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private BoardCount boardCount;
+
+    @Builder
+    public Board(Member member, Category category, String title, String content, String link, String createdIp) {
+        this.member = member;
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.link = link;
+        this.createdIp = createdIp;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateBoard(BoardSaveRequest request, Category category) {
+        this.category = category;
+        this.title = request.getTitle();
+        this.content = request.getContent();
+        this.link = request.getLink();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public BoardCount createBoardCount(Board board) {
+        this.boardCount = BoardCount.builder().board(board).likeCount(0).commentCount(0).viewCount(0).build();
+        return boardCount;
+    }
+}

--- a/src/main/java/org/myteam/server/board/entity/Board.java
+++ b/src/main/java/org/myteam/server/board/entity/Board.java
@@ -70,9 +70,4 @@ public class Board {
         this.link = request.getLink();
         this.updatedAt = LocalDateTime.now();
     }
-
-    public BoardCount createBoardCount(Board board) {
-        this.boardCount = BoardCount.builder().board(board).likeCount(0).commentCount(0).viewCount(0).build();
-        return boardCount;
-    }
 }

--- a/src/main/java/org/myteam/server/board/entity/BoardCount.java
+++ b/src/main/java/org/myteam/server/board/entity/BoardCount.java
@@ -1,0 +1,41 @@
+package org.myteam.server.board.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_board_count")
+public class BoardCount {
+
+    @Id
+    private Long boardId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount = 0;
+
+    @Column(name = "view_count", nullable = false)
+    private Integer viewCount = 0;
+
+    @Column(name = "comment_count", nullable = false)
+    private Integer commentCount = 0;
+}

--- a/src/main/java/org/myteam/server/board/entity/BoardCount.java
+++ b/src/main/java/org/myteam/server/board/entity/BoardCount.java
@@ -16,7 +16,6 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_board_count")
@@ -38,4 +37,21 @@ public class BoardCount {
 
     @Column(name = "comment_count", nullable = false)
     private Integer commentCount = 0;
+
+    @Builder
+    public BoardCount(Board board, int likeCount, int commentCount, int viewCount) {
+        this.board = board;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.viewCount = viewCount;
+    }
+
+    public static BoardCount createBoardCount(Board board) {
+        return BoardCount.builder()
+                .board(board)
+                .likeCount(0)
+                .commentCount(0)
+                .viewCount(0)
+                .build();
+    }
 }

--- a/src/main/java/org/myteam/server/board/entity/BoardCount.java
+++ b/src/main/java/org/myteam/server/board/entity/BoardCount.java
@@ -47,11 +47,13 @@ public class BoardCount {
     }
 
     public static BoardCount createBoardCount(Board board) {
+        final int COUNT_SETTING_NUMBER = 0;
+        
         return BoardCount.builder()
                 .board(board)
-                .likeCount(0)
-                .commentCount(0)
-                .viewCount(0)
+                .likeCount(COUNT_SETTING_NUMBER)
+                .commentCount(COUNT_SETTING_NUMBER)
+                .viewCount(COUNT_SETTING_NUMBER)
                 .build();
     }
 }

--- a/src/main/java/org/myteam/server/board/entity/BoardCount.java
+++ b/src/main/java/org/myteam/server/board/entity/BoardCount.java
@@ -30,13 +30,13 @@ public class BoardCount {
     private Board board;
 
     @Column(name = "like_count", nullable = false)
-    private Integer likeCount = 0;
+    private int likeCount;
 
     @Column(name = "view_count", nullable = false)
-    private Integer viewCount = 0;
+    private int viewCount;
 
     @Column(name = "comment_count", nullable = false)
-    private Integer commentCount = 0;
+    private int commentCount;
 
     @Builder
     public BoardCount(Board board, int likeCount, int commentCount, int viewCount) {
@@ -48,7 +48,7 @@ public class BoardCount {
 
     public static BoardCount createBoardCount(Board board) {
         final int COUNT_SETTING_NUMBER = 0;
-        
+
         return BoardCount.builder()
                 .board(board)
                 .likeCount(COUNT_SETTING_NUMBER)

--- a/src/main/java/org/myteam/server/board/entity/Category.java
+++ b/src/main/java/org/myteam/server/board/entity/Category.java
@@ -1,15 +1,23 @@
 package org.myteam.server.board.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.myteam.server.board.dto.CategorySaveRequest;
 import org.myteam.server.global.domain.Base;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -45,6 +53,7 @@ public class Category extends Base {
 
     /**
      * 카테고리의 부모를 변경
+     *
      * @param parent 부모 카테고리
      */
     public void setParent(Category parent) {
@@ -54,6 +63,7 @@ public class Category extends Base {
 
     /**
      * 카테고리의 이름을 변경
+     *
      * @param name 카테고리 명
      */
     public void updateName(String name) {
@@ -62,6 +72,7 @@ public class Category extends Base {
 
     /**
      * 카테고리 순번을 변경
+     *
      * @param orderIndex 순번
      */
     public void updateOrderIndex(int orderIndex) {
@@ -70,6 +81,7 @@ public class Category extends Base {
 
     /**
      * 카테고리 링크를 변경
+     *
      * @param link 링크
      */
     public void updateLink(String link) {
@@ -82,12 +94,20 @@ public class Category extends Base {
     }
 
     /**
-     * 부모 카테고리의 ID 를 반환
-     * 부모가 없으면 null 을 반환
+     * 부모 카테고리의 ID 를 반환 부모가 없으면 null 을 반환
      *
      * @return 부모 카테고리 ID 또는 null
      */
     public Long getCategoryParentId() {
         return this.parent != null ? this.parent.getId() : null;
+    }
+
+    /**
+     * 부모 카테고리의 이름을 반환 부모가 없으면 null 을 반환
+     *
+     * @return 부모 카테고리 이름 또는 null
+     */
+    public String getParentCategoryName() {
+        return this.parent != null ? this.parent.getName() : null;
     }
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardCountRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardCountRepository.java
@@ -2,9 +2,7 @@ package org.myteam.server.board.repository;
 
 import org.myteam.server.board.entity.BoardCount;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface BoardCountRepository extends JpaRepository<BoardCount, Long> {
     void deleteByBoardId(Long id);
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardCountRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardCountRepository.java
@@ -1,0 +1,10 @@
+package org.myteam.server.board.repository;
+
+import org.myteam.server.board.entity.BoardCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardCountRepository extends JpaRepository<BoardCount, Long> {
+    void deleteByBoardId(Long id);
+}

--- a/src/main/java/org/myteam/server/board/repository/BoardRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardRepository.java
@@ -2,8 +2,6 @@ package org.myteam.server.board.repository;
 
 import org.myteam.server.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardRepository.java
@@ -1,0 +1,9 @@
+package org.myteam.server.board.repository;
+
+import org.myteam.server.board.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/org/myteam/server/board/service/BoardReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReadService.java
@@ -2,6 +2,8 @@ package org.myteam.server.board.service;
 
 import lombok.RequiredArgsConstructor;
 import org.myteam.server.board.entity.Board;
+import org.myteam.server.board.entity.BoardCount;
+import org.myteam.server.board.repository.BoardCountRepository;
 import org.myteam.server.board.repository.BoardRepository;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
@@ -14,9 +16,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class BoardReadService {
 
     private final BoardRepository boardRepository;
+    private final BoardCountRepository boardCountRepository;
 
-    public Board findById(long boardId) {
+    public Board BoardFindById(long boardId) {
         return boardRepository.findById(boardId)
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_NOT_FOUND));
+    }
+
+    public BoardCount BoardCountFindById(long boardId) {
+        return boardCountRepository.findById(boardId)
                 .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_NOT_FOUND));
     }
 }

--- a/src/main/java/org/myteam/server/board/service/BoardReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReadService.java
@@ -1,0 +1,22 @@
+package org.myteam.server.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.board.entity.Board;
+import org.myteam.server.board.repository.BoardRepository;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardReadService {
+
+    private final BoardRepository boardRepository;
+
+    public Board findById(long boardId) {
+        return boardRepository.findById(boardId)
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -38,8 +38,9 @@ public class BoardService {
         Category category = categoryReadService.findById(request.getCategoryId());
 
         Board board = makeBoard(category, member, clientIP, request);
+        BoardCount boardCount = boardReadService.BoardCountFindById(board.getId());
 
-        return new BoardResponse(board);
+        return new BoardResponse(board, boardCount);
     }
 
     /**
@@ -70,9 +71,10 @@ public class BoardService {
     @Transactional(readOnly = true)
     public BoardResponse getBoard(final Long boardId) {
 
-        Board board = boardReadService.findById(boardId);
+        Board board = boardReadService.BoardFindById(boardId);
+        BoardCount boardCount = boardReadService.BoardCountFindById(board.getId());
 
-        return new BoardResponse(board);
+        return new BoardResponse(board, boardCount);
     }
 
     /**
@@ -82,7 +84,7 @@ public class BoardService {
     public void deleteBoard(final Long boardId, final CustomUserDetails userDetails) {
 
         Member member = memberReadService.findById(userDetails.getPublicId());
-        Board board = boardReadService.findById(boardId);
+        Board board = boardReadService.BoardFindById(boardId);
 
         verifyBoardAuthor(board, member);
 
@@ -96,7 +98,7 @@ public class BoardService {
     public BoardResponse updateBoard(final BoardSaveRequest request, final CustomUserDetails userDetails,
                                      final Long boardId) {
 
-        Board board = boardReadService.findById(boardId);
+        Board board = boardReadService.BoardFindById(boardId);
         Member member = memberReadService.findById(userDetails.getPublicId());
 
         verifyBoardAuthor(board, member);
@@ -106,7 +108,8 @@ public class BoardService {
         board.updateBoard(request, category);
         boardRepository.save(board);
 
-        return new BoardResponse(board);
+        BoardCount boardCount = boardReadService.BoardCountFindById(board.getId());
+        return new BoardResponse(board, boardCount);
     }
 
     /**

--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -61,7 +61,7 @@ public class BoardService {
                 .build();
         boardRepository.save(board);
 
-        final BoardCount boardCount = board.createBoardCount(board);
+        final BoardCount boardCount = BoardCount.createBoardCount(board);
         boardCountRepository.save(boardCount);
 
         return board;

--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -110,7 +110,7 @@ public class BoardService {
     }
 
     /**
-     * 작성자와 일치 하는지 검사 (어드민 수정/삭제 허용)
+     * 작성자와 일치 하는지 검사 (어드민도 수정/삭제 허용)
      */
     private void verifyBoardAuthor(final Board board, final Member member) {
         if (!board.getMember().getId().equals(member.getId())) {

--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -1,0 +1,133 @@
+package org.myteam.server.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.board.controller.reponse.BoardResponse;
+import org.myteam.server.board.dto.BoardSaveRequest;
+import org.myteam.server.board.entity.Board;
+import org.myteam.server.board.entity.BoardCount;
+import org.myteam.server.board.entity.Category;
+import org.myteam.server.board.repository.BoardCountRepository;
+import org.myteam.server.board.repository.BoardRepository;
+import org.myteam.server.board.repository.CategoryRepository;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.global.security.dto.CustomUserDetails;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+    private final BoardCountRepository boardCountRepository;
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 게시글 작성
+     */
+    @Transactional
+    public BoardResponse saveBoard(final BoardSaveRequest request, final CustomUserDetails userDetails,
+                                   final String clientIP) {
+
+        // 회원 조회
+        final Member member = memberRepository.findByPublicId(userDetails.getPublicId())
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.USER_NOT_FOUND));
+
+        // 카테고리 조회
+        final Category category = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        final Board board = makeBoard(category, member, clientIP, request);
+
+        return new BoardResponse(board);
+    }
+
+    /**
+     * 게시글, 게시글 카운트 생성
+     */
+    private Board makeBoard(final Category category, final Member member, final String clientIP,
+                            final BoardSaveRequest request) {
+        final Board board = Board.builder()
+                .category(category)
+                .member(member)
+                .createdIp(clientIP)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .link(request.getLink())
+                .build();
+        boardRepository.save(board);
+
+        final BoardCount boardCount = board.createBoardCount(board);
+        boardCountRepository.save(boardCount);
+
+        return board;
+    }
+
+    /**
+     * 게시글 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public BoardResponse getBoard(final Long boardId) {
+
+        final Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_NOT_FOUND));
+
+        return new BoardResponse(board);
+    }
+
+    /**
+     * 게시글 삭제
+     */
+    @Transactional
+    public void deleteBoard(final Long boardId, final CustomUserDetails userDetails) {
+        final Member member = memberRepository.findByPublicId(userDetails.getPublicId())
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.USER_NOT_FOUND));
+
+        final Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_NOT_FOUND));
+
+        verifyBoardAuthor(board, member);
+
+        boardCountRepository.deleteByBoardId(board.getId());
+        boardRepository.delete(board);
+    }
+
+    /**
+     * 게시글 수정
+     */
+    public BoardResponse updateBoard(final BoardSaveRequest request, final CustomUserDetails userDetails,
+                                     final Long boardId) {
+
+        final Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_NOT_FOUND));
+
+        final Member member = memberRepository.findByPublicId(userDetails.getPublicId())
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.USER_NOT_FOUND));
+
+        verifyBoardAuthor(board, member);
+
+        // 카테고리 조회
+        final Category category = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.CATEGORY_NOT_FOUND));
+
+        board.updateBoard(request, category);
+        boardRepository.save(board);
+
+        return new BoardResponse(board);
+    }
+
+    /**
+     * 작성자와 일치 하는지 검사 (어드민 수정/삭제 허용)
+     */
+    private void verifyBoardAuthor(final Board board, final Member member) {
+        if (!board.getMember().getId().equals(member.getId())) {
+            if (!member.isAdmin()) {
+                throw new PlayHiveException(ErrorCode.POST_AUTHOR_MISMATCH);
+            }
+        }
+    }
+}

--- a/src/main/java/org/myteam/server/board/service/CategoryReadService.java
+++ b/src/main/java/org/myteam/server/board/service/CategoryReadService.java
@@ -1,0 +1,22 @@
+package org.myteam.server.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.board.entity.Category;
+import org.myteam.server.board.repository.CategoryRepository;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryReadService {
+
+    private final CategoryRepository categoryRepository;
+
+    public Category findById(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.CATEGORY_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/myteam/server/global/exception/ErrorCode.java
+++ b/src/main/java/org/myteam/server/global/exception/ErrorCode.java
@@ -31,10 +31,14 @@ public enum ErrorCode {
     ACCOUNT_DISABLED(HttpStatus.FORBIDDEN, "Account disabled"),
     ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "Account locked"),
     NO_PERMISSION(HttpStatus.FORBIDDEN, "This account has no permission"),
+    POST_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN,
+            "You are not the author of this post. Only the author can modify or delete it."),
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "User not found"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "Resource not found"),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "Category not found"),
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "Board not found"),
 
     // 409 Conflict,
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "User already exists"),

--- a/src/main/java/org/myteam/server/member/service/MemberReadService.java
+++ b/src/main/java/org/myteam/server/member/service/MemberReadService.java
@@ -1,0 +1,23 @@
+package org.myteam.server.member.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberReadService {
+
+    private final MemberRepository memberRepository;
+
+    public Member findById(UUID publicId) {
+        return memberRepository.findByPublicId(publicId)
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/myteam/server/util/ClientUtils.java
+++ b/src/main/java/org/myteam/server/util/ClientUtils.java
@@ -1,0 +1,29 @@
+package org.myteam.server.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * IP를 가져오기 위한 Utils
+ */
+public class ClientUtils {
+
+    public static String getRemoteIP(HttpServletRequest request) {
+        String ip = request.getHeader("X-FORWARDED-FOR");
+
+        //proxy 환경일 경우
+        if (ip == null || ip.length() == 0) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+
+        //웹로직 서버일 경우
+        if (ip == null || ip.length() == 0) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+
+        if (ip == null || ip.length() == 0) {
+            ip = request.getRemoteAddr();
+        }
+
+        return ip;
+    }
+}

--- a/src/main/java/org/myteam/server/util/ClientUtils.java
+++ b/src/main/java/org/myteam/server/util/ClientUtils.java
@@ -10,17 +10,19 @@ public class ClientUtils {
     public static String getRemoteIP(HttpServletRequest request) {
         String ip = request.getHeader("X-FORWARDED-FOR");
 
-        //proxy 환경일 경우
-        if (ip == null || ip.length() == 0) {
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
             ip = request.getHeader("Proxy-Client-IP");
         }
-
-        //웹로직 서버일 경우
-        if (ip == null || ip.length() == 0) {
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
             ip = request.getHeader("WL-Proxy-Client-IP");
         }
-
-        if (ip == null || ip.length() == 0) {
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
             ip = request.getRemoteAddr();
         }
 


### PR DESCRIPTION
## 기능 설명
- 게시판(p_board) CRUD 기능 추가

## 작업 내용
- 게시글 생성, 수정, 상세 조회, 삭제 기능 추가하였습니다.
- 어드민이 수정/삭제 가능하게 작업했습니다.

## 추가 작업 예정
- 게시판 검색 API, 게시글의 내용 작성 시 필요한 파일 업로드 API, 댓글 관련 API, 좋아요 관련 API 작업 예정입니다.
- API명세서 작성 예정입니다!
 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
