### PR TITLE
chore: 게시글 삭제 성공 시 메시지 수정

### DIFF
--- a/src/main/java/org/myteam/server/board/controller/BoardController.java
+++ b/src/main/java/org/myteam/server/board/controller/BoardController.java
@@ -71,6 +71,6 @@ public class BoardController {
     public ResponseEntity<ResponseDto<Void>> deleteBoard(@PathVariable final Long boardId,
                                                          @AuthenticationPrincipal final CustomUserDetails userDetails) {
         boardService.deleteBoard(boardId, userDetails);
-        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "카테고리 삭제 성공", null));
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 삭제 성공", null));
     }
 }

--- a/src/main/java/org/myteam/server/util/ClientUtils.java
+++ b/src/main/java/org/myteam/server/util/ClientUtils.java
@@ -10,19 +10,19 @@ public class ClientUtils {
     public static String getRemoteIP(HttpServletRequest request) {
         String ip = request.getHeader("X-FORWARDED-FOR");
 
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
             ip = request.getHeader("Proxy-Client-IP");
         }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
             ip = request.getHeader("WL-Proxy-Client-IP");
         }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
             ip = request.getHeader("HTTP_CLIENT_IP");
         }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
             ip = request.getHeader("HTTP_X_FORWARDED_FOR");
         }
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+        if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
             ip = request.getRemoteAddr();
         }
 


### PR DESCRIPTION
## 기능 설명
- 게시글 삭제 성공 시 메시지 수정
## 작업 내용
- 삭제 성공 시 메시지를 '카테고리 삭제 성공' -> '게시글 삭제 성공' 으로 수정하였습니다.
- 상기님이 리뷰주셨던 ClientUtils에서 .isEmpty()로 수정했습니다.
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
