### PR TITLE
fix : 리프레시 토큰 발급 시 쿠키에 베리어 문자열 제거 및 인코딩하던 로직 제거

### DIFF
--- a/src/main/java/org/myteam/server/auth/controller/ReIssueController.java
+++ b/src/main/java/org/myteam/server/auth/controller/ReIssueController.java
@@ -11,9 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-
 import static org.myteam.server.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
 import static org.myteam.server.global.security.jwt.JwtProvider.*;
 import static org.myteam.server.global.util.cookie.CookieUtil.createCookie;
@@ -48,7 +45,7 @@ public class ReIssueController {
             // Refresh Token 쿠키 추가
             response.addCookie(createCookie(
                     REFRESH_TOKEN_KEY,
-                    URLEncoder.encode(TOKEN_PREFIX + tokens.getRefreshToken(), StandardCharsets.UTF_8),
+                    tokens.getRefreshToken(),
                     TOKEN_REISSUE_PATH,
                     24 * 60 * 60,
                     true,
@@ -57,7 +54,7 @@ public class ReIssueController {
 
             response.addCookie(createCookie(
                     REFRESH_TOKEN_KEY,
-                    URLEncoder.encode(TOKEN_PREFIX + tokens.getRefreshToken(), StandardCharsets.UTF_8),
+                    tokens.getRefreshToken(),
                     LOGOUT_PATH,
                     24 * 60 * 60,
                     true,

--- a/src/main/java/org/myteam/server/oauth2/handler/CustomOauth2SuccessHandler.java
+++ b/src/main/java/org/myteam/server/oauth2/handler/CustomOauth2SuccessHandler.java
@@ -17,8 +17,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
@@ -70,18 +68,16 @@ public class CustomOauth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
             // X-Refresh-Token
             String refreshToken = jwtProvider.generateToken(TOKEN_CATEGORY_REFRESH, Duration.ofMinutes(5), member.getPublicId(), member.getRole().name(), member.getStatus().name());
-            String cookieValue = URLEncoder.encode(TOKEN_PREFIX + refreshToken, StandardCharsets.UTF_8);
 
             reIssueService.deleteByPublicId(member.getPublicId());
             reIssueService.addRefreshEntity(member.getPublicId(), refreshToken, Duration.ofMinutes(5));
 
             log.warn("cookieValue refreshToken 확인용: {}", refreshToken);
-            log.warn("cookieValue 쿠키 확인용: {}", cookieValue);
             log.warn("cookieValue PublicId 확인용: {}", member.getPublicId());
 
             // 24 시간 유효한 리프레시 토큰을 생성
-            response.addCookie(createCookie(REFRESH_TOKEN_KEY, cookieValue, TOKEN_REISSUE_PATH, 24 * 60 * 60, true, extractDomain(request.getServerName())));
-            response.addCookie(createCookie(REFRESH_TOKEN_KEY, cookieValue, LOGOUT_PATH, 24 * 60 * 60, true, extractDomain(request.getServerName())));
+            response.addCookie(createCookie(REFRESH_TOKEN_KEY, refreshToken, TOKEN_REISSUE_PATH, 24 * 60 * 60, true, extractDomain(request.getServerName())));
+            response.addCookie(createCookie(REFRESH_TOKEN_KEY, refreshToken, LOGOUT_PATH, 24 * 60 * 60, true, extractDomain(request.getServerName())));
             String redirectUrl = String.format("%s%s?status=%s&email=%s",
                     frontUrl, frontSignUpPath, PENDING.name(), email);
             log.info("redirectUrl: {}", redirectUrl);


### PR DESCRIPTION
## 기능 설명
fix : 리프레시 토큰 발급 시 쿠키에 베리어 문자열 제거 및 인코딩하던 로직 제거

## 작업 내용
리프레시 토큰 발급 시 쿠키에 베리어 문자열(Bearer) 추가 되었던 부분 제거함

## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [O] 단위 테스트 확인(포스트맨 등..)
- [O] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
