### PR TITLE
fix: kafka 힙 메모리 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,9 +49,11 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_HEAP_OPTS: "-Xms256M -Xmx512M" # JVM 힙 메모리 최소/최대 설정
     depends_on:
       - zookeeper
     restart: always


### PR DESCRIPTION
## 기능 설명
- 
## 작업 내용
- 도커 컴포즈 kafka 힙 메모리 설정
## 수정 사항
- kafka의 JVM 힙 메모리 설정
## 추가 작업 예정
- AWS 로그 보면서 에러 확인
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
