### PR TITLE
epic: 뉴스 대댓글기능

### DIFF
--- a/src/main/java/org/myteam/server/global/exception/ErrorCode.java
+++ b/src/main/java/org/myteam/server/global/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     BAN_NOT_FOUND(HttpStatus.NOT_FOUND, "Ban not found"),
     NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "News not found"),
     NEWS_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "New Comment not found"),
+    NEWS_REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "New Reply not found"),
 
     // 409 Conflict,
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "User already exists"),

--- a/src/main/java/org/myteam/server/news/controller/NewsReplyController.java
+++ b/src/main/java/org/myteam/server/news/controller/NewsReplyController.java
@@ -1,0 +1,71 @@
+package org.myteam.server.news.controller;
+
+import static org.myteam.server.global.web.response.ResponseStatus.*;
+
+import org.myteam.server.global.web.response.ResponseDto;
+import org.myteam.server.news.dto.controller.request.NewsCommentRequest;
+import org.myteam.server.news.dto.controller.request.NewsReplyRequest;
+import org.myteam.server.news.dto.controller.request.NewsReplySaveRequest;
+import org.myteam.server.news.dto.controller.request.NewsReplyUpdateRequest;
+import org.myteam.server.news.dto.service.response.NewsReplyListResponse;
+import org.myteam.server.news.dto.service.response.NewsReplyResponse;
+import org.myteam.server.news.service.NewsReplyReadService;
+import org.myteam.server.news.service.NewsReplyService;
+import org.myteam.server.util.ClientUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/news/reply")
+public class NewsReplyController {
+
+	private final NewsReplyService newsReplyService;
+	private final NewsReplyReadService newsReplyReadService;
+
+	@PostMapping
+	private ResponseEntity<ResponseDto<NewsReplyResponse>> save(
+		@RequestBody @Valid NewsReplySaveRequest newsSaveRequest, HttpServletRequest request) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"뉴스 대댓글 저장 성공",
+			newsReplyService.save(newsSaveRequest.toServiceRequest(ClientUtils.getRemoteIP(request)))));
+	}
+
+	@GetMapping
+	private ResponseEntity<ResponseDto<NewsReplyListResponse>> findByNewsId(
+		@RequestBody @Valid NewsReplyRequest newsReplyRequest) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"뉴스 대댓글 조회 성공",
+			newsReplyReadService.findByNewsCommentId(newsReplyRequest.toServiceRequest())));
+	}
+
+	@PatchMapping
+	private ResponseEntity<ResponseDto<Long>> update(
+		@RequestBody @Valid NewsReplyUpdateRequest newsReplyUpdateRequest) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"뉴스 대댓글 수정 성공",
+			newsReplyService.update(newsReplyUpdateRequest.toServiceRequest())));
+	}
+
+	@DeleteMapping("/{newsReplyId}")
+	private ResponseEntity<ResponseDto<Long>> delete(@PathVariable Long newsReplyId) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"뉴스 대댓글 삭제 성공",
+			newsReplyService.delete(newsReplyId)));
+	}
+}

--- a/src/main/java/org/myteam/server/news/domain/NewsReply.java
+++ b/src/main/java/org/myteam/server/news/domain/NewsReply.java
@@ -1,0 +1,61 @@
+package org.myteam.server.news.domain;
+
+import org.myteam.server.global.domain.Base;
+import org.myteam.server.member.entity.Member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_news_reply")
+public class NewsReply extends Base {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private NewsComment newsComment;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member member;
+
+	private String comment;
+
+	private String ip;
+
+	@Builder
+	public NewsReply(Long id, NewsComment newsComment, Member member, String comment, String ip) {
+		this.id = id;
+		this.newsComment = newsComment;
+		this.member = member;
+		this.comment = comment;
+		this.ip = ip;
+	}
+
+	public void confirmMember(Member member) {
+		this.member.confirmMemberEquals(member);
+	}
+
+	public void updateComment(String comment) {
+		this.comment = comment;
+	}
+
+	public static NewsReply createNewsReply(NewsComment newsComment, Member member, String comment, String ip) {
+		return NewsReply.builder()
+			.newsComment(newsComment)
+			.member(member)
+			.comment(comment)
+			.ip(ip)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/controller/request/NewsReplyRequest.java
+++ b/src/main/java/org/myteam/server/news/dto/controller/request/NewsReplyRequest.java
@@ -1,0 +1,32 @@
+package org.myteam.server.news.dto.controller.request;
+
+import org.myteam.server.global.page.request.PageInfoRequest;
+import org.myteam.server.news.dto.service.request.NewsCommentServiceRequest;
+import org.myteam.server.news.dto.service.request.NewsReplyServiceRequest;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplyRequest extends PageInfoRequest {
+
+	@NotNull(message = "뉴스 대댓글 ID는 필수입니다.")
+	private Long newsCommentId;
+
+	@Builder
+	public NewsReplyRequest(Long newsCommentId, int page, int size) {
+		super(page, size);
+		this.newsCommentId = newsCommentId;
+	}
+
+	public NewsReplyServiceRequest toServiceRequest() {
+		return NewsReplyServiceRequest.builder()
+			.newsCommentId(newsCommentId)
+			.size(getSize())
+			.page(getPage())
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/controller/request/NewsReplySaveRequest.java
+++ b/src/main/java/org/myteam/server/news/dto/controller/request/NewsReplySaveRequest.java
@@ -1,0 +1,32 @@
+package org.myteam.server.news.dto.controller.request;
+
+import org.myteam.server.news.dto.service.request.NewsReplySaveServiceRequest;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplySaveRequest {
+
+	@NotNull(message = "뉴스 댓글 ID는 필수입니다.")
+	private Long newsCommentId;
+	@NotNull(message = "뉴스 대댓글은 필수입니다.")
+	private String comment;
+
+	@Builder
+	public NewsReplySaveRequest(Long newsCommentId, String comment) {
+		this.newsCommentId = newsCommentId;
+		this.comment = comment;
+	}
+
+	public NewsReplySaveServiceRequest toServiceRequest(String ip) {
+		return NewsReplySaveServiceRequest.builder()
+			.newsCommentId(newsCommentId)
+			.comment(comment)
+			.ip(ip)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/controller/request/NewsReplyUpdateRequest.java
+++ b/src/main/java/org/myteam/server/news/dto/controller/request/NewsReplyUpdateRequest.java
@@ -1,0 +1,31 @@
+package org.myteam.server.news.dto.controller.request;
+
+import org.myteam.server.news.dto.service.request.NewsReplyUpdateServiceRequest;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplyUpdateRequest {
+
+	@NotNull(message = "뉴스 대댓글 ID는 필수입니다.")
+	private Long newsReplyId;
+	@NotNull(message = "뉴스 대댓글 내용은 필수입니다.")
+	private String comment;
+
+	@Builder
+	public NewsReplyUpdateRequest(Long newsReplyId, String comment) {
+		this.newsReplyId = newsReplyId;
+		this.comment = comment;
+	}
+
+	public NewsReplyUpdateServiceRequest toServiceRequest() {
+		return NewsReplyUpdateServiceRequest.builder()
+			.newsReplyId(newsReplyId)
+			.comment(comment)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/repository/NewsReplyDto.java
+++ b/src/main/java/org/myteam/server/news/dto/repository/NewsReplyDto.java
@@ -7,18 +7,19 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class NewsCommentDto {
+public class NewsReplyDto {
 
+	private Long newsReplyId;
 	private Long newsCommentId;
-	private Long newsId;
-	private NewsCommentMemberDto memberDto;
+	private NewsReplyMemberDto memberDto;
 	private String comment;
 	private String ip;
 	private LocalDateTime createTime;
 
-	public NewsCommentDto(Long newsCommentId, Long newsId, NewsCommentMemberDto memberDto, String comment, String ip, LocalDateTime createTime) {
+	public NewsReplyDto(Long newsReplyId, Long newsCommentId, NewsReplyMemberDto memberDto, String comment,
+		String ip, LocalDateTime createTime) {
+		this.newsReplyId = newsReplyId;
 		this.newsCommentId = newsCommentId;
-		this.newsId = newsId;
 		this.memberDto = memberDto;
 		this.comment = comment;
 		this.ip = ip;

--- a/src/main/java/org/myteam/server/news/dto/repository/NewsReplyMemberDto.java
+++ b/src/main/java/org/myteam/server/news/dto/repository/NewsReplyMemberDto.java
@@ -1,0 +1,16 @@
+package org.myteam.server.news.dto.repository;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplyMemberDto {
+	private Long id;
+	private String nickName;
+
+	public NewsReplyMemberDto(Long id, String nickName) {
+		this.id = id;
+		this.nickName = nickName;
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/service/request/NewsReplySaveServiceRequest.java
+++ b/src/main/java/org/myteam/server/news/dto/service/request/NewsReplySaveServiceRequest.java
@@ -1,0 +1,20 @@
+package org.myteam.server.news.dto.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplySaveServiceRequest {
+	private Long newsCommentId;
+	private String comment;
+	private String ip;
+
+	@Builder
+	public NewsReplySaveServiceRequest(Long newsCommentId, String comment, String ip) {
+		this.newsCommentId = newsCommentId;
+		this.comment = comment;
+		this.ip = ip;
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/service/request/NewsReplyServiceRequest.java
+++ b/src/main/java/org/myteam/server/news/dto/service/request/NewsReplyServiceRequest.java
@@ -1,0 +1,20 @@
+package org.myteam.server.news.dto.service.request;
+
+import org.myteam.server.global.page.request.PageInfoServiceRequest;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplyServiceRequest extends PageInfoServiceRequest {
+
+	private Long newsCommentId;
+
+	@Builder
+	public NewsReplyServiceRequest(Long newsCommentId, int size, int page) {
+		super(page, size);
+		this.newsCommentId = newsCommentId;
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/service/request/NewsReplyUpdateServiceRequest.java
+++ b/src/main/java/org/myteam/server/news/dto/service/request/NewsReplyUpdateServiceRequest.java
@@ -1,0 +1,19 @@
+package org.myteam.server.news.dto.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplyUpdateServiceRequest {
+
+	private Long newsReplyId;
+	private String comment;
+
+	@Builder
+	public NewsReplyUpdateServiceRequest(Long newsReplyId, String comment) {
+		this.newsReplyId = newsReplyId;
+		this.comment = comment;
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/service/response/NewsReplyListResponse.java
+++ b/src/main/java/org/myteam/server/news/dto/service/response/NewsReplyListResponse.java
@@ -1,0 +1,26 @@
+package org.myteam.server.news.dto.service.response;
+
+import org.myteam.server.global.page.response.PageCustomResponse;
+import org.myteam.server.news.dto.repository.NewsReplyDto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplyListResponse {
+
+	private PageCustomResponse<NewsReplyDto> list;
+
+	@Builder
+	public NewsReplyListResponse(PageCustomResponse<NewsReplyDto> list) {
+		this.list = list;
+	}
+
+	public static NewsReplyListResponse createResponse(PageCustomResponse<NewsReplyDto> list) {
+		return NewsReplyListResponse.builder()
+			.list(list)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/service/response/NewsReplyMemberResponse.java
+++ b/src/main/java/org/myteam/server/news/dto/service/response/NewsReplyMemberResponse.java
@@ -1,0 +1,19 @@
+package org.myteam.server.news.dto.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplyMemberResponse {
+
+	private Long memberId;
+	private String nickName;
+
+	@Builder
+	public NewsReplyMemberResponse(Long memberId, String nickName) {
+		this.memberId = memberId;
+		this.nickName = nickName;
+	}
+}

--- a/src/main/java/org/myteam/server/news/dto/service/response/NewsReplyResponse.java
+++ b/src/main/java/org/myteam/server/news/dto/service/response/NewsReplyResponse.java
@@ -1,0 +1,46 @@
+package org.myteam.server.news.dto.service.response;
+
+import java.time.LocalDateTime;
+
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.domain.NewsReply;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewsReplyResponse {
+
+	private Long newsReplyId;
+	private Long newsCommentId;
+	private NewsReplyMemberResponse member;
+	private String comment;
+	private LocalDateTime createDate;
+
+	@Builder
+	public NewsReplyResponse(Long newsReplyId, Long newsCommentId, NewsReplyMemberResponse member, String comment,
+		LocalDateTime createDate) {
+		this.newsReplyId = newsReplyId;
+		this.newsCommentId = newsCommentId;
+		this.member = member;
+		this.comment = comment;
+		this.createDate = createDate;
+	}
+
+	public static NewsReplyResponse createResponse(NewsReply newsReply, Member member) {
+		return NewsReplyResponse.builder()
+			.newsReplyId(newsReply.getId())
+			.newsCommentId(newsReply.getNewsComment().getId())
+			.member(
+				NewsReplyMemberResponse.builder()
+					.memberId(member.getId())
+					.nickName(member.getNickname())
+					.build()
+			)
+			.comment(newsReply.getComment())
+			.createDate(newsReply.getCreateDate())
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/news/repository/NewsCommentQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/repository/NewsCommentQueryRepository.java
@@ -34,7 +34,8 @@ public class NewsCommentQueryRepository {
 					newsComment.member.nickname
 				),
 				newsComment.comment,
-				newsComment.ip
+				newsComment.ip,
+				newsComment.createDate
 			))
 			.from(newsComment)
 			.where(

--- a/src/main/java/org/myteam/server/news/repository/NewsCommentRepository.java
+++ b/src/main/java/org/myteam/server/news/repository/NewsCommentRepository.java
@@ -1,12 +1,9 @@
 package org.myteam.server.news.repository;
 
-import java.util.List;
-
 import org.myteam.server.news.domain.NewsComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NewsCommentRepository extends JpaRepository<NewsComment, Long> {
-	List<NewsComment> findByNewsId(Long newsId);
 }

--- a/src/main/java/org/myteam/server/news/repository/NewsReplyQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/repository/NewsReplyQueryRepository.java
@@ -1,0 +1,70 @@
+package org.myteam.server.news.repository;
+
+import static java.util.Optional.*;
+import static org.myteam.server.news.domain.QNewsComment.*;
+import static org.myteam.server.news.domain.QNewsReply.*;
+
+import java.util.List;
+
+import org.myteam.server.news.dto.repository.NewsReplyDto;
+import org.myteam.server.news.dto.repository.NewsReplyMemberDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class NewsReplyQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public Page<NewsReplyDto> getNewsReplyList(Long newsCommentId, Pageable pageable) {
+		List<NewsReplyDto> content = queryFactory
+			.select(Projections.constructor(NewsReplyDto.class,
+				newsReply.id,
+				newsReply.newsComment.id,
+				Projections.constructor(NewsReplyMemberDto.class,
+					newsReply.member.id,
+					newsReply.member.nickname
+				),
+				newsReply.comment,
+				newsReply.ip,
+				newsReply.createDate
+			))
+			.from(newsReply)
+			.where(
+				isNewsCommentEqualTo(newsCommentId)
+			)
+			.orderBy(newsReply.createDate.asc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		long total = getTotalNewsCount(newsCommentId);
+
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	private long getTotalNewsCount(Long newsCommentId) {
+		return ofNullable(
+			queryFactory
+				.select(newsReply.count())
+				.from(newsReply)
+				.where(
+					isNewsCommentEqualTo(newsCommentId)
+				)
+				.fetchOne()
+		).orElse(0L);
+	}
+
+	private BooleanExpression isNewsCommentEqualTo(Long newsId) {
+		return newsReply.newsComment.id.eq(newsId);
+	}
+}

--- a/src/main/java/org/myteam/server/news/repository/NewsReplyRepository.java
+++ b/src/main/java/org/myteam/server/news/repository/NewsReplyRepository.java
@@ -1,0 +1,9 @@
+package org.myteam.server.news.repository;
+
+import org.myteam.server.news.domain.NewsReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NewsReplyRepository extends JpaRepository<NewsReply, Long> {
+}

--- a/src/main/java/org/myteam/server/news/service/NewsReplyReadService.java
+++ b/src/main/java/org/myteam/server/news/service/NewsReplyReadService.java
@@ -1,0 +1,40 @@
+package org.myteam.server.news.service;
+
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.global.page.response.PageCustomResponse;
+import org.myteam.server.news.domain.NewsReply;
+import org.myteam.server.news.dto.repository.NewsReplyDto;
+import org.myteam.server.news.dto.service.request.NewsReplyServiceRequest;
+import org.myteam.server.news.dto.service.response.NewsReplyListResponse;
+import org.myteam.server.news.repository.NewsReplyQueryRepository;
+import org.myteam.server.news.repository.NewsReplyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NewsReplyReadService {
+
+	private final NewsReplyRepository newsReplyRepository;
+	private final NewsReplyQueryRepository newsReplyQueryRepository;
+
+	public NewsReplyListResponse findByNewsCommentId(NewsReplyServiceRequest newsReplyServiceRequest) {
+		Page<NewsReplyDto> list = newsReplyQueryRepository.getNewsReplyList(
+			newsReplyServiceRequest.getNewsCommentId(),
+			newsReplyServiceRequest.toPageable()
+		);
+
+		return NewsReplyListResponse.createResponse(PageCustomResponse.of(list));
+	}
+
+	public NewsReply findById(Long newsReplyId) {
+		return newsReplyRepository.findById(newsReplyId)
+			.orElseThrow(() -> new PlayHiveException(ErrorCode.NEWS_REPLY_NOT_FOUND));
+	}
+
+}

--- a/src/main/java/org/myteam/server/news/service/NewsReplyService.java
+++ b/src/main/java/org/myteam/server/news/service/NewsReplyService.java
@@ -1,0 +1,60 @@
+package org.myteam.server.news.service;
+
+import static org.myteam.server.news.domain.QNewsComment.*;
+
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.service.SecurityReadService;
+import org.myteam.server.news.domain.NewsComment;
+import org.myteam.server.news.domain.NewsReply;
+import org.myteam.server.news.dto.service.request.NewsCommentSaveServiceRequest;
+import org.myteam.server.news.dto.service.request.NewsCommentUpdateServiceRequest;
+import org.myteam.server.news.dto.service.request.NewsReplySaveServiceRequest;
+import org.myteam.server.news.dto.service.request.NewsReplyUpdateServiceRequest;
+import org.myteam.server.news.dto.service.response.NewsReplyResponse;
+import org.myteam.server.news.repository.NewsReplyRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NewsReplyService {
+
+	private final NewsReplyRepository newsReplyRepository;
+	private final NewsReplyReadService newsReplyReadService;
+	private final NewsCommentReadService newsCommentReadService;
+	private final SecurityReadService securityReadService;
+
+	public NewsReplyResponse save(NewsReplySaveServiceRequest newsReplySaveServiceRequest) {
+		NewsComment newsComment = newsCommentReadService.findById(newsReplySaveServiceRequest.getNewsCommentId());
+		Member member = securityReadService.getMember();
+
+		return NewsReplyResponse.createResponse(
+			newsReplyRepository.save(
+				NewsReply.createNewsReply(newsComment, member, newsReplySaveServiceRequest.getComment(),
+					newsReplySaveServiceRequest.getIp())), member
+		);
+	}
+
+	public Long update(NewsReplyUpdateServiceRequest newsReplyUpdateServiceRequest) {
+		Member member = securityReadService.getMember();
+		NewsReply newsReply = newsReplyReadService.findById(newsReplyUpdateServiceRequest.getNewsReplyId());
+
+		newsReply.confirmMember(member);
+		newsReply.updateComment(newsReplyUpdateServiceRequest.getComment());
+
+		return newsReply.getId();
+	}
+
+	public Long delete(Long newsReplyId) {
+		Member member = securityReadService.getMember();
+		NewsReply newsReply = newsReplyReadService.findById(newsReplyId);
+
+		newsReply.confirmMember(member);
+
+		newsReplyRepository.deleteById(newsReplyId);
+		return newsReply.getId();
+	}
+}

--- a/src/test/java/org/myteam/server/ControllerTestSupport.java
+++ b/src/test/java/org/myteam/server/ControllerTestSupport.java
@@ -2,9 +2,12 @@ package org.myteam.server;
 
 import org.myteam.server.news.controller.NewsCommentController;
 import org.myteam.server.news.controller.NewsController;
+import org.myteam.server.news.controller.NewsReplyController;
 import org.myteam.server.news.service.NewsCommentReadService;
 import org.myteam.server.news.service.NewsCommentService;
 import org.myteam.server.news.service.NewsReadService;
+import org.myteam.server.news.service.NewsReplyReadService;
+import org.myteam.server.news.service.NewsReplyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -17,7 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @ActiveProfiles("test")
 @WebMvcTest(controllers = {
 	NewsController.class,
-	NewsCommentController.class
+	NewsCommentController.class,
+	NewsReplyController.class
 })
 @MockBean(JpaMetamodelMappingContext.class)
 public abstract class ControllerTestSupport {
@@ -36,6 +40,12 @@ public abstract class ControllerTestSupport {
 
 	@MockBean
 	protected NewsCommentReadService newsCommentReadService;
+
+	@MockBean
+	protected NewsReplyService newsReplyService;
+
+	@MockBean
+	protected NewsReplyReadService newsReplyReadService;
 
 }
 

--- a/src/test/java/org/myteam/server/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/IntegrationTestSupport.java
@@ -14,8 +14,10 @@ import org.myteam.server.news.domain.News;
 import org.myteam.server.news.domain.NewsCategory;
 import org.myteam.server.news.domain.NewsComment;
 import org.myteam.server.news.domain.NewsCount;
+import org.myteam.server.news.domain.NewsReply;
 import org.myteam.server.news.repository.NewsCommentRepository;
 import org.myteam.server.news.repository.NewsCountRepository;
+import org.myteam.server.news.repository.NewsReplyRepository;
 import org.myteam.server.news.repository.NewsRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,6 +34,8 @@ public abstract class IntegrationTestSupport {
 	protected NewsCountRepository newsCountRepository;
 	@Autowired
 	protected NewsCommentRepository newsCommentRepository;
+	@Autowired
+	protected NewsReplyRepository newsReplyRepository;
 	@Autowired
 	protected MemberJpaRepository memberJpaRepository;
 	@MockBean
@@ -80,6 +84,17 @@ public abstract class IntegrationTestSupport {
 		return newsCommentRepository.save(
 			NewsComment.builder()
 				.news(news)
+				.member(member)
+				.comment(comment)
+				.ip("1.1.1.1")
+				.build()
+		);
+	}
+
+	protected NewsReply createNewsReply(NewsComment newsComment, Member member, String comment) {
+		return newsReplyRepository.save(
+			NewsReply.builder()
+				.newsComment(newsComment)
 				.member(member)
 				.comment(comment)
 				.ip("1.1.1.1")

--- a/src/test/java/org/myteam/server/news/controller/NewsReplyControllerTest.java
+++ b/src/test/java/org/myteam/server/news/controller/NewsReplyControllerTest.java
@@ -1,0 +1,224 @@
+package org.myteam.server.news.controller;
+
+import static org.myteam.server.global.web.response.ResponseStatus.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.ControllerTestSupport;
+import org.myteam.server.news.dto.controller.request.NewsReplyRequest;
+import org.myteam.server.news.dto.controller.request.NewsReplySaveRequest;
+import org.myteam.server.news.dto.controller.request.NewsReplyUpdateRequest;
+import org.springframework.security.test.context.support.WithMockUser;
+
+class NewsReplyControllerTest extends ControllerTestSupport {
+
+	@DisplayName("뉴스 대댓글을 저장한다.")
+	@Test
+	@WithMockUser
+	void saveTest() throws Exception {
+		// given
+		NewsReplySaveRequest newsCommentSaveRequest = NewsReplySaveRequest.builder()
+			.newsCommentId(1L)
+			.comment("대댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/news/reply")
+					.content(objectMapper.writeValueAsString(newsCommentSaveRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("뉴스 대댓글 저장 성공"));
+	}
+
+	@DisplayName("뉴스 대댓글을 저장시 뉴스ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void saveWithoutNewsIdTest() throws Exception {
+		// given
+		NewsReplySaveRequest newsCommentSaveRequest = NewsReplySaveRequest.builder()
+			.comment("대댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/news/reply")
+					.content(objectMapper.writeValueAsString(newsCommentSaveRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("뉴스 댓글 ID는 필수입니다."));
+	}
+
+	@DisplayName("뉴스 대댓글을 저장시 뉴스ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void saveWithoutCommentTest() throws Exception {
+		// given
+		NewsReplySaveRequest newsCommentSaveRequest = NewsReplySaveRequest.builder()
+			.newsCommentId(1L)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/news/reply")
+					.content(objectMapper.writeValueAsString(newsCommentSaveRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("뉴스 대댓글은 필수입니다."));
+	}
+
+	@DisplayName("뉴스 대댓글 목록을 조회한다.")
+	@Test
+	@WithMockUser
+	void findAllTest() throws Exception {
+		// given
+		NewsReplyRequest newsCommentRequest = NewsReplyRequest.builder()
+			.page(1)
+			.size(10)
+			.newsCommentId(1L)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				get("/api/news/reply")
+					.content(objectMapper.writeValueAsString(newsCommentRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("뉴스 대댓글 조회 성공"));
+	}
+
+	@DisplayName("뉴스목록을 조회시 뉴스ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void findAllWithoutOrderTypeTest() throws Exception {
+		// given
+		NewsReplyRequest newsRequest = NewsReplyRequest.builder()
+			.page(1)
+			.size(10)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				get("/api/news/reply")
+					.content(objectMapper.writeValueAsString(newsRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("뉴스 대댓글 ID는 필수입니다."));
+	}
+
+	@DisplayName("뉴스 대댓글을 수정한다.")
+	@Test
+	@WithMockUser
+	void updateTest() throws Exception {
+		// given
+		NewsReplyUpdateRequest newsCommentUpdateRequest = NewsReplyUpdateRequest.builder()
+			.newsReplyId(1L)
+			.comment("뉴스 대댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/news/reply")
+					.content(objectMapper.writeValueAsString(newsCommentUpdateRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("뉴스 대댓글 수정 성공"));
+	}
+
+	@DisplayName("뉴스 대댓글을 수정시 뉴스대댓글ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void updateWithoutCommentIdTest() throws Exception {
+		// given
+		NewsReplyUpdateRequest newsCommentUpdateRequest = NewsReplyUpdateRequest.builder()
+			.comment("뉴스 대댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/news/reply")
+					.content(objectMapper.writeValueAsString(newsCommentUpdateRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("뉴스 대댓글 ID는 필수입니다."));
+	}
+
+	@DisplayName("뉴스 대댓글을 수정시 대댓글 내용은 필수이다.")
+	@Test
+	@WithMockUser
+	void updateWithoutCommentTest() throws Exception {
+		// given
+		NewsReplyUpdateRequest newsCommentUpdateRequest = NewsReplyUpdateRequest.builder()
+			.newsReplyId(1L)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/news/reply")
+					.content(objectMapper.writeValueAsString(newsCommentUpdateRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("뉴스 대댓글 내용은 필수입니다."));
+	}
+
+	@DisplayName("뉴스 대댓글을 삭제한다.")
+	@Test
+	@WithMockUser
+	void deleteTest() throws Exception {
+		// given
+		// when // then
+		mockMvc.perform(
+				delete("/api/news/reply/{newsReplyId}", 1L)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("뉴스 대댓글 삭제 성공"));
+	}
+}

--- a/src/test/java/org/myteam/server/news/service/NewsReplyReadServiceTest.java
+++ b/src/test/java/org/myteam/server/news/service/NewsReplyReadServiceTest.java
@@ -1,0 +1,108 @@
+package org.myteam.server.news.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.global.page.response.PageableCustomResponse;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.domain.News;
+import org.myteam.server.news.domain.NewsCategory;
+import org.myteam.server.news.domain.NewsComment;
+import org.myteam.server.news.domain.NewsReply;
+import org.myteam.server.news.dto.repository.NewsReplyDto;
+import org.myteam.server.news.dto.service.request.NewsReplyServiceRequest;
+import org.myteam.server.news.dto.service.response.NewsReplyListResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class NewsReplyReadServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private NewsReplyReadService newsReplyReadService;
+
+	@AfterEach
+	void tearDown() {
+		newsReplyRepository.deleteAllInBatch();
+		newsCommentRepository.deleteAllInBatch();
+		newsCountRepository.deleteAllInBatch();
+		newsRepository.deleteAllInBatch();
+		memberJpaRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("뉴스 대댓글 ID로 뉴스 대댓글을 조회한다.")
+	@Test
+	void findByIdTest() {
+		News news = createNews(1, NewsCategory.BASEBALL, 10);
+		Member member = createMember(1);
+
+		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트");
+
+		NewsReply newsReply = createNewsReply(newsComment, member, "뉴스 대댓글 테스트");
+
+		NewsReply findNewsReply = newsReplyReadService.findById(newsReply.getId());
+
+		assertThat(findNewsReply)
+			.extracting("id", "newsComment.id", "member.id", "comment")
+			.contains(newsReply.getId(), newsComment.getId(), member.getId(), "뉴스 대댓글 테스트");
+	}
+
+	@DisplayName("뉴스 댓글 ID로 조회시 존재하지 않으면 예외가 발생한다.")
+	@Test
+	void findByIdNotExistThrowExceptionTest() {
+		assertThatThrownBy(() -> newsReplyReadService.findById(1L))
+			.isInstanceOf(PlayHiveException.class)
+			.hasMessage(ErrorCode.NEWS_REPLY_NOT_FOUND.getMsg());
+	}
+
+	@DisplayName("댓글ID로 대댓글리스트를 조회한다.")
+	@Test
+	void findByNewsIdTest() {
+		News news = createNews(1, NewsCategory.BASEBALL, 10);
+		Member member1 = createMember(1);
+		Member member2 = createMember(1);
+
+		NewsComment newsComment1 = craeteNewsComment(news, member1, "뉴스 댓글 테스트1");
+
+		NewsReply newsReply1 = createNewsReply(newsComment1, member1, "뉴스 대댓글 테스트1");
+		NewsReply newsReply2 = createNewsReply(newsComment1, member2, "뉴스 대댓글 테스트2");
+		NewsReply newsReply3 = createNewsReply(newsComment1, member2, "뉴스 대댓글 테스트3");
+
+		NewsReplyServiceRequest newsReplyServiceRequest = NewsReplyServiceRequest.builder()
+			.newsCommentId(newsComment1.getId())
+			.page(1)
+			.size(2)
+			.build();
+
+		NewsReplyListResponse newsReplyListResponse = newsReplyReadService.findByNewsCommentId(
+			newsReplyServiceRequest);
+
+		List<NewsReplyDto> newsReplyList = newsReplyListResponse.getList().getContent();
+		PageableCustomResponse pageInfo = newsReplyListResponse.getList().getPageInfo();
+
+		assertAll(
+			() -> assertThat(pageInfo)
+				.extracting("currentPage", "totalPage", "totalElement")
+				.containsExactlyInAnyOrder(
+					1, 2, 3L
+				),
+			() -> assertThat(newsReplyList)
+				.extracting("newsReplyId", "newsCommentId", "memberDto.id", "memberDto.nickName", "comment")
+				.contains(
+					Tuple.tuple(newsReply1.getId(), newsReply1.getNewsComment().getId(), newsReply1.getMember().getId(),
+						"test",
+						"뉴스 대댓글 테스트1"),
+					Tuple.tuple(newsReply2.getId(), newsReply2.getNewsComment().getId(), newsReply2.getMember().getId(),
+						"test",
+						"뉴스 대댓글 테스트2")
+				)
+		);
+	}
+}

--- a/src/test/java/org/myteam/server/news/service/NewsReplyServiceTest.java
+++ b/src/test/java/org/myteam/server/news/service/NewsReplyServiceTest.java
@@ -1,0 +1,93 @@
+package org.myteam.server.news.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.domain.News;
+import org.myteam.server.news.domain.NewsCategory;
+import org.myteam.server.news.domain.NewsComment;
+import org.myteam.server.news.domain.NewsReply;
+import org.myteam.server.news.dto.service.request.NewsCommentSaveServiceRequest;
+import org.myteam.server.news.dto.service.request.NewsCommentUpdateServiceRequest;
+import org.myteam.server.news.dto.service.request.NewsReplySaveServiceRequest;
+import org.myteam.server.news.dto.service.request.NewsReplyUpdateServiceRequest;
+import org.myteam.server.news.dto.service.response.NewsCommentResponse;
+import org.myteam.server.news.dto.service.response.NewsReplyResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class NewsReplyServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private NewsReplyService newsReplyService;
+
+	@AfterEach
+	void tearDown() {
+		newsReplyRepository.deleteAllInBatch();
+		newsCommentRepository.deleteAllInBatch();
+		newsCountRepository.deleteAllInBatch();
+		newsRepository.deleteAllInBatch();
+		memberJpaRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("뉴스댓글을 저장한다.")
+	@Test
+	void saveTest() {
+		News news = createNews(1, NewsCategory.BASEBALL, 10);
+		Member member = createMember(1);
+		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트1");
+
+		NewsReplySaveServiceRequest newsReplySaveServiceRequest = NewsReplySaveServiceRequest.builder()
+			.newsCommentId(newsComment.getId())
+			.comment("대댓글 테스트")
+			.ip("1.1.1.1")
+			.build();
+
+		NewsReplyResponse newsReplyResponse = newsReplyService.save(newsReplySaveServiceRequest);
+
+		assertThat(newsReplyRepository.findById(newsReplyResponse.getNewsCommentId()).get())
+			.extracting("id", "newsComment.id", "member.id", "comment", "ip")
+			.contains(newsReplyResponse.getNewsReplyId(), newsComment.getId(), member.getId(), "대댓글 테스트", "1.1.1.1");
+	}
+
+	@DisplayName("뉴스 대댓글을 수정한다.")
+	@Test
+	void updateTest() {
+		News news = createNews(1, NewsCategory.BASEBALL, 10);
+		Member member = createMember(1);
+		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트");
+		NewsReply newsReply = createNewsReply(newsComment, member, "뉴스 대댓글 테스트");
+
+		NewsReplyUpdateServiceRequest newsReplyUpdateServiceRequest = NewsReplyUpdateServiceRequest.builder()
+			.newsReplyId(newsReply.getId())
+			.comment("뉴스 대댓글 수정 테스트")
+			.build();
+
+		Long updatedReplyId = newsReplyService.update(newsReplyUpdateServiceRequest);
+
+		assertThat(newsReplyRepository.findById(updatedReplyId).get())
+			.extracting("id", "newsComment.id", "member.id", "comment", "ip")
+			.contains(newsReply.getId(), newsComment.getId(), member.getId(), "뉴스 대댓글 수정 테스트", "1.1.1.1");
+	}
+
+	@DisplayName("뉴스 대댓글을 삭제한다.")
+	@Test
+	void deleteTest() {
+		News news = createNews(1, NewsCategory.BASEBALL, 10);
+		Member member = createMember(1);
+
+		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트");
+		NewsReply newsReply = createNewsReply(newsComment, member, "뉴스 대댓글 테스트");
+		Long deletedReplyId = newsReplyService.delete(newsReply.getId());
+
+		assertThatThrownBy(() -> newsReplyService.delete(deletedReplyId))
+			.isInstanceOf(PlayHiveException.class)
+			.hasMessage(ErrorCode.NEWS_REPLY_NOT_FOUND.getMsg());
+	}
+
+}


### PR DESCRIPTION
## 기능 설명
- 뉴스 댓글에 대댓글 기능
## 작업 내용
- NewsReplyController
- NewsReplyService
- NewsReply Entity 생성
## 수정 사항
- 
## 추가 작업 예정
- 마이페이지 댓글 리스트 작업
- 뉴스, 댓글, 대댓글 추천, 좋아요 작업
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
