### PR TITLE
feat: 게시글 CRUD 코드 수정

### DIFF
--- a/src/main/java/org/myteam/server/board/controller/BoardController.java
+++ b/src/main/java/org/myteam/server/board/controller/BoardController.java
@@ -56,15 +56,6 @@ public class BoardController {
     }
 
     /**
-     * 게시글 상세 조회
-     */
-    @GetMapping("/{boardId}")
-    public ResponseEntity<ResponseDto<BoardResponse>> getBoard(@PathVariable final Long boardId) {
-        final BoardResponse response = boardService.getBoard(boardId);
-        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 조회 성공", response));
-    }
-
-    /**
      * 게시글 삭제
      */
     @DeleteMapping("/{boardId}")
@@ -72,5 +63,14 @@ public class BoardController {
                                                          @AuthenticationPrincipal final CustomUserDetails userDetails) {
         boardService.deleteBoard(boardId, userDetails);
         return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 삭제 성공", null));
+    }
+
+    /**
+     * 게시글 상세 조회
+     */
+    @GetMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<BoardResponse>> getBoard(@PathVariable final Long boardId) {
+        final BoardResponse response = boardService.getBoard(boardId);
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 조회 성공", response));
     }
 }

--- a/src/main/java/org/myteam/server/board/controller/reponse/BoardResponse.java
+++ b/src/main/java/org/myteam/server/board/controller/reponse/BoardResponse.java
@@ -3,28 +3,22 @@ package org.myteam.server.board.controller.reponse;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
-import org.myteam.server.board.entity.Board;
-import org.myteam.server.board.entity.BoardCount;
+import org.myteam.server.board.domain.Board;
+import org.myteam.server.board.domain.BoardCount;
+import org.myteam.server.board.domain.BoardType;
+import org.myteam.server.board.domain.CategoryType;
 
 @Getter
 @Setter
 public class BoardResponse {
     /**
-     * 카테고리 부모 id
+     * 게시판 타입
      */
-    private Long categoryParentId;
+    private BoardType boardType;
     /**
-     * 카테고리 부모 명
+     * 카테고리 타입
      */
-    private String categoryParentName;
-    /**
-     * 카테고리 id
-     */
-    private Long categoryId;
-    /**
-     * 카테고리명
-     */
-    private String categoryName;
+    private CategoryType categoryType;
     /**
      * 게시글 id
      */
@@ -71,11 +65,9 @@ public class BoardResponse {
     private LocalDateTime updatedAt;
 
     public BoardResponse(Board board, BoardCount boardCount) {
+        this.boardType = board.getBoardType();
+        this.categoryType = board.getCategoryType();
         this.boardId = board.getId();
-        this.categoryParentId = board.getCategory().getCategoryParentId();
-        this.categoryParentName = board.getCategory().getParentCategoryName();
-        this.categoryId = board.getCategory().getId();
-        this.categoryName = board.getCategory().getName();
         this.authorId = board.getMember().getId();
         this.clientIp = board.getCreatedIp();
         this.title = board.getTitle();

--- a/src/main/java/org/myteam/server/board/controller/reponse/CategoryResponse.java
+++ b/src/main/java/org/myteam/server/board/controller/reponse/CategoryResponse.java
@@ -1,10 +1,9 @@
 package org.myteam.server.board.controller.reponse;
 
-import lombok.Getter;
-import org.myteam.server.board.entity.Category;
-
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Getter;
+import org.myteam.server.board.domain.Category;
 
 @Getter
 public class CategoryResponse {
@@ -16,7 +15,8 @@ public class CategoryResponse {
     private List<CategoryResponse> children;
     private String link;
 
-    public CategoryResponse(Long id, String name, Integer orderIndex, Integer depth, Long parentId, List<CategoryResponse> children, String link) {
+    public CategoryResponse(Long id, String name, Integer orderIndex, Integer depth, Long parentId,
+                            List<CategoryResponse> children, String link) {
         this.id = id;
         this.name = name;
         this.orderIndex = orderIndex;
@@ -37,7 +37,9 @@ public class CategoryResponse {
     }
 
     public static CategoryResponse fromWithoutChildren(Category entity) {
-        if (entity == null) return null;
+        if (entity == null) {
+            return null;
+        }
 
         return new CategoryResponse(
                 entity.getId(),

--- a/src/main/java/org/myteam/server/board/domain/Board.java
+++ b/src/main/java/org/myteam/server/board/domain/Board.java
@@ -2,6 +2,8 @@ package org.myteam.server.board.domain;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -32,8 +34,10 @@ public class Board {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Enumerated(EnumType.STRING)
     private BoardType boardType;
 
+    @Enumerated(EnumType.STRING)
     private CategoryType categoryType;
 
     private String title;
@@ -74,5 +78,9 @@ public class Board {
         this.content = request.getContent();
         this.link = request.getLink();
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public boolean isAuthor(Member member) {
+        return this.member.equals(member);
     }
 }

--- a/src/main/java/org/myteam/server/board/domain/Board.java
+++ b/src/main/java/org/myteam/server/board/domain/Board.java
@@ -1,4 +1,4 @@
-package org.myteam.server.board.entity;
+package org.myteam.server.board.domain;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -32,9 +32,9 @@ public class Board {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id")
-    private Category category;
+    private BoardType boardType;
+
+    private CategoryType categoryType;
 
     private String title;
 
@@ -52,10 +52,12 @@ public class Board {
     private BoardCount boardCount;
 
     @Builder
-    public Board(Member member, Category category, String title, String content, String link, String createdIp,
+    public Board(Member member, BoardType boardType, CategoryType categoryType, String title, String content,
+                 String link, String createdIp,
                  BoardCount boardCount) {
         this.member = member;
-        this.category = category;
+        this.boardType = boardType;
+        this.categoryType = categoryType;
         this.title = title;
         this.content = content;
         this.link = link;
@@ -65,8 +67,9 @@ public class Board {
         this.boardCount = boardCount;
     }
 
-    public void updateBoard(BoardSaveRequest request, Category category) {
-        this.category = category;
+    public void updateBoard(BoardSaveRequest request) {
+        this.boardType = request.getBoardType();
+        this.categoryType = request.getCategoryType();
         this.title = request.getTitle();
         this.content = request.getContent();
         this.link = request.getLink();

--- a/src/main/java/org/myteam/server/board/domain/BoardCount.java
+++ b/src/main/java/org/myteam/server/board/domain/BoardCount.java
@@ -1,4 +1,4 @@
-package org.myteam.server.board.entity;
+package org.myteam.server.board.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/org/myteam/server/board/domain/BoardType.java
+++ b/src/main/java/org/myteam/server/board/domain/BoardType.java
@@ -1,0 +1,16 @@
+package org.myteam.server.board.domain;
+
+public enum BoardType {
+    /**
+     * e-sports
+     */
+    E_SPORTS,
+    /**
+     * 야구
+     */
+    BASEBALL,
+    /**
+     * 축구
+     */
+    FOOTBALL
+}

--- a/src/main/java/org/myteam/server/board/domain/BoardType.java
+++ b/src/main/java/org/myteam/server/board/domain/BoardType.java
@@ -12,5 +12,9 @@ public enum BoardType {
     /**
      * 축구
      */
-    FOOTBALL
+    FOOTBALL;
+
+    public boolean isEsports() {
+        return this.equals(E_SPORTS);
+    }
 }

--- a/src/main/java/org/myteam/server/board/domain/Category.java
+++ b/src/main/java/org/myteam/server/board/domain/Category.java
@@ -1,4 +1,4 @@
-package org.myteam.server.board.entity;
+package org.myteam.server.board.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/org/myteam/server/board/domain/CategoryType.java
+++ b/src/main/java/org/myteam/server/board/domain/CategoryType.java
@@ -1,5 +1,8 @@
 package org.myteam.server.board.domain;
 
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+
 public enum CategoryType {
     /**
      * 자유
@@ -24,5 +27,11 @@ public enum CategoryType {
     /**
      * 플레이 팁 (e-sports)
      */
-    PLAY_TIP
+    PLAY_TIP;
+
+    public void confirmEsports() {
+        if (this.equals(PLAY_TIP) || this.equals(RECORD_VERIFICATION)) {
+            throw new PlayHiveException(ErrorCode.INVALID_TYPE);
+        }
+    }
 }

--- a/src/main/java/org/myteam/server/board/domain/CategoryType.java
+++ b/src/main/java/org/myteam/server/board/domain/CategoryType.java
@@ -23,14 +23,14 @@ public enum CategoryType {
     /**
      * 전적 인증 (e-sports)
      */
-    RECORD_VERIFICATION,
+    VERIFICATION,
     /**
      * 플레이 팁 (e-sports)
      */
-    PLAY_TIP;
+    TIP;
 
     public void confirmEsports() {
-        if (this.equals(PLAY_TIP) || this.equals(RECORD_VERIFICATION)) {
+        if (this.equals(TIP) || this.equals(VERIFICATION)) {
             throw new PlayHiveException(ErrorCode.INVALID_TYPE);
         }
     }

--- a/src/main/java/org/myteam/server/board/domain/CategoryType.java
+++ b/src/main/java/org/myteam/server/board/domain/CategoryType.java
@@ -1,0 +1,28 @@
+package org.myteam.server.board.domain;
+
+public enum CategoryType {
+    /**
+     * 자유
+     */
+    FREE,
+    /**
+     * 질문
+     */
+    QUESTION,
+    /**
+     * 이슈
+     */
+    ISSUE,
+    /**
+     * 개선 요청
+     */
+    SUGGESTION,
+    /**
+     * 전적 인증 (e-sports)
+     */
+    RECORD_VERIFICATION,
+    /**
+     * 플레이 팁 (e-sports)
+     */
+    PLAY_TIP
+}

--- a/src/main/java/org/myteam/server/board/dto/BoardSaveRequest.java
+++ b/src/main/java/org/myteam/server/board/dto/BoardSaveRequest.java
@@ -4,12 +4,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.myteam.server.board.domain.BoardType;
 import org.myteam.server.board.domain.CategoryType;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class BoardSaveRequest {
     /**

--- a/src/main/java/org/myteam/server/board/dto/BoardSaveRequest.java
+++ b/src/main/java/org/myteam/server/board/dto/BoardSaveRequest.java
@@ -5,16 +5,23 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.myteam.server.board.domain.BoardType;
+import org.myteam.server.board.domain.CategoryType;
 
 @Getter
 @Setter
 @NoArgsConstructor
 public class BoardSaveRequest {
     /**
-     * 카테고리 id
+     * 게시판 타입
+     */
+    @NotNull(message = "게시판 타입을 선택해주세요")
+    private BoardType boardType;
+    /**
+     * 카테고리 타입
      */
     @NotNull(message = "카테고리를 선택해주세요")
-    private Long categoryId;
+    private CategoryType categoryType;
     /**
      * 제목
      */

--- a/src/main/java/org/myteam/server/board/repository/BoardCountRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardCountRepository.java
@@ -1,6 +1,6 @@
 package org.myteam.server.board.repository;
 
-import org.myteam.server.board.entity.BoardCount;
+import org.myteam.server.board.domain.BoardCount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardCountRepository extends JpaRepository<BoardCount, Long> {

--- a/src/main/java/org/myteam/server/board/repository/BoardRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardRepository.java
@@ -1,6 +1,6 @@
 package org.myteam.server.board.repository;
 
-import org.myteam.server.board.entity.Board;
+import org.myteam.server.board.domain.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {

--- a/src/main/java/org/myteam/server/board/repository/CategoryJpaRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/CategoryJpaRepository.java
@@ -1,17 +1,20 @@
 package org.myteam.server.board.repository;
 
-import org.myteam.server.board.entity.Category;
+import java.util.List;
+import java.util.Optional;
+import org.myteam.server.board.domain.Category;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface CategoryJpaRepository extends JpaRepository<Category, Long> {
     List<Category> findByParentIsNull();
+
     List<Category> findByParentIsNull(Sort sort);
+
     // List<Category> findByParentId(Long parentId);
     Optional<Category> findByParentIdAndOrderIndex(Long parentId, int orderIndex);
+
     Optional<Category> findById(long id);
+
     boolean existsByParentId(Long parentId);
 }

--- a/src/main/java/org/myteam/server/board/repository/CategoryRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/CategoryRepository.java
@@ -1,15 +1,19 @@
 package org.myteam.server.board.repository;
 
-import org.myteam.server.board.entity.Category;
-
 import java.util.List;
 import java.util.Optional;
+import org.myteam.server.board.domain.Category;
 
 public interface CategoryRepository {
     List<Category> listByParentIsNull();
+
     List<Category> listSortedByParentIsNull();
+
     Optional<Category> findByParentIdAndOrderIndex(Long parentId, int orderIndex);
+
     Category getByParentIdAndOrderIndex(Long parentId, int orderIndex);
+
     Optional<Category> findById(long id);
+
     Category getById(long id);
 }

--- a/src/main/java/org/myteam/server/board/repository/CategoryRepositoryImpl.java
+++ b/src/main/java/org/myteam/server/board/repository/CategoryRepositoryImpl.java
@@ -1,15 +1,14 @@
 package org.myteam.server.board.repository;
 
-import lombok.RequiredArgsConstructor;
-import org.myteam.server.board.entity.Category;
-import org.myteam.server.global.exception.PlayHiveException;
-import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Repository;
+import static org.myteam.server.global.exception.ErrorCode.RESOURCE_NOT_FOUND;
 
 import java.util.List;
 import java.util.Optional;
-
-import static org.myteam.server.global.exception.ErrorCode.RESOURCE_NOT_FOUND;
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.board.domain.Category;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -28,10 +27,9 @@ public class CategoryRepositoryImpl implements CategoryRepository {
     }
 
     /**
-     * 부모 Id 파라미터 와 순번 항목 파라미터으로 존재하는 카테고리가 있는지 조회한다.
-     * 부모 Id 가 Null 인 경우 최상단 카테고리 조회
+     * 부모 Id 파라미터 와 순번 항목 파라미터으로 존재하는 카테고리가 있는지 조회한다. 부모 Id 가 Null 인 경우 최상단 카테고리 조회
      *
-     * @param parentId 부모 Id
+     * @param parentId   부모 Id
      * @param orderIndex 카테고리 순번
      * @return
      */
@@ -41,17 +39,17 @@ public class CategoryRepositoryImpl implements CategoryRepository {
     }
 
     /**
-     * 부모 Id 파라미터 와 순번 항목 파라미터으로 존재하는 카테고리가 있는지 조회한다.
-     * 부모 Id 가 Null 인 경우 최상단 카테고리 조회
+     * 부모 Id 파라미터 와 순번 항목 파라미터으로 존재하는 카테고리가 있는지 조회한다. 부모 Id 가 Null 인 경우 최상단 카테고리 조회
      *
-     * @param parentId 부모 Id
+     * @param parentId   부모 Id
      * @param orderIndex 카테고리 순번
      * @return
      */
     @Override
     public Category getByParentIdAndOrderIndex(Long parentId, int orderIndex) {
         return categoryJpaRepository.findByParentIdAndOrderIndex(parentId, orderIndex)
-                .orElseThrow(() -> new PlayHiveException(RESOURCE_NOT_FOUND, "parentId -> " + parentId + ", orderIndex -> " + orderIndex + " 는 존재하지 않는 카테고리 입니다"));
+                .orElseThrow(() -> new PlayHiveException(RESOURCE_NOT_FOUND,
+                        "parentId -> " + parentId + ", orderIndex -> " + orderIndex + " 는 존재하지 않는 카테고리 입니다"));
     }
 
     @Override

--- a/src/main/java/org/myteam/server/board/repository/querydsl/CategoryQuerydslRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/querydsl/CategoryQuerydslRepository.java
@@ -1,15 +1,14 @@
 package org.myteam.server.board.repository.querydsl;
 
+import static org.myteam.server.global.exception.ErrorCode.RESOURCE_NOT_FOUND;
+
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.myteam.server.board.entity.Category;
-import org.myteam.server.board.entity.QCategory;
+import org.myteam.server.board.domain.Category;
+import org.myteam.server.board.domain.QCategory;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-
-import static org.myteam.server.global.exception.ErrorCode.RESOURCE_NOT_FOUND;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/org/myteam/server/board/repository/querydsl/CategoryRepositoryCustom.java
+++ b/src/main/java/org/myteam/server/board/repository/querydsl/CategoryRepositoryCustom.java
@@ -1,11 +1,12 @@
 package org.myteam.server.board.repository.querydsl;
 
-import org.myteam.server.board.entity.Category;
-
 import java.util.List;
+import org.myteam.server.board.domain.Category;
 
 public interface CategoryRepositoryCustom {
     List<Category> listSortedWithHierarchy();
+
     List<Category> listSortedRootCategories();
+
     Category getWithSortedChildrenById(Long id);
 }

--- a/src/main/java/org/myteam/server/board/service/BoardReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReadService.java
@@ -1,8 +1,8 @@
 package org.myteam.server.board.service;
 
 import lombok.RequiredArgsConstructor;
-import org.myteam.server.board.entity.Board;
-import org.myteam.server.board.entity.BoardCount;
+import org.myteam.server.board.domain.Board;
+import org.myteam.server.board.domain.BoardCount;
 import org.myteam.server.board.repository.BoardCountRepository;
 import org.myteam.server.board.repository.BoardRepository;
 import org.myteam.server.global.exception.ErrorCode;

--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -2,10 +2,11 @@ package org.myteam.server.board.service;
 
 import lombok.RequiredArgsConstructor;
 import org.myteam.server.board.controller.reponse.BoardResponse;
+import org.myteam.server.board.domain.Board;
+import org.myteam.server.board.domain.BoardCount;
+import org.myteam.server.board.domain.BoardType;
+import org.myteam.server.board.domain.CategoryType;
 import org.myteam.server.board.dto.BoardSaveRequest;
-import org.myteam.server.board.entity.Board;
-import org.myteam.server.board.entity.BoardCount;
-import org.myteam.server.board.entity.Category;
 import org.myteam.server.board.repository.BoardCountRepository;
 import org.myteam.server.board.repository.BoardRepository;
 import org.myteam.server.global.exception.ErrorCode;
@@ -25,7 +26,6 @@ public class BoardService {
 
     private final BoardReadService boardReadService;
     private final MemberReadService memberReadService;
-    private final CategoryReadService categoryReadService;
 
     /**
      * 게시글 작성
@@ -35,9 +35,9 @@ public class BoardService {
                                    final String clientIP) {
 
         Member member = memberReadService.findById(userDetails.getPublicId());
-        Category category = categoryReadService.findById(request.getCategoryId());
+        verifyBoardTypeAndCategoryType(request.getBoardType(), request.getCategoryType());
 
-        Board board = makeBoard(category, member, clientIP, request);
+        Board board = makeBoard(member, clientIP, request);
         BoardCount boardCount = boardReadService.BoardCountFindById(board.getId());
 
         return new BoardResponse(board, boardCount);
@@ -46,12 +46,13 @@ public class BoardService {
     /**
      * 게시글, 게시글 카운트 생성
      */
-    private Board makeBoard(final Category category, final Member member, final String clientIP,
+    private Board makeBoard(final Member member, final String clientIP,
                             final BoardSaveRequest request) {
 
         final Board board = Board.builder()
-                .category(category)
                 .member(member)
+                .boardType(request.getBoardType())
+                .categoryType(request.getCategoryType())
                 .createdIp(clientIP)
                 .title(request.getTitle())
                 .content(request.getContent())
@@ -102,10 +103,9 @@ public class BoardService {
         Member member = memberReadService.findById(userDetails.getPublicId());
 
         verifyBoardAuthor(board, member);
+        verifyBoardTypeAndCategoryType(request.getBoardType(), request.getCategoryType());
 
-        Category category = categoryReadService.findById(request.getCategoryId());
-
-        board.updateBoard(request, category);
+        board.updateBoard(request);
         boardRepository.save(board);
 
         BoardCount boardCount = boardReadService.BoardCountFindById(board.getId());
@@ -113,9 +113,20 @@ public class BoardService {
     }
 
     /**
+     * 게시판에 맞는 카테고리를 선택했는지 검사 ex) 전적 인증, 플레이팁은 e-sport 게시판에서만 사용
+     */
+    private void verifyBoardTypeAndCategoryType(BoardType boardType, CategoryType categoryType) {
+        if (!boardType.equals(BoardType.E_SPORTS)) {
+            if (categoryType.equals(CategoryType.PLAY_TIP) || categoryType.equals(CategoryType.RECORD_VERIFICATION)) {
+                throw new PlayHiveException(ErrorCode.INVALID_TYPE);
+            }
+        }
+    }
+
+    /**
      * 작성자와 일치 하는지 검사 (어드민도 수정/삭제 허용)
      */
-    private void verifyBoardAuthor(final Board board, final Member member) {
+    private void verifyBoardAuthor(Board board, Member member) {
         if (!board.getMember().getId().equals(member.getId())) {
             if (!member.isAdmin()) {
                 throw new PlayHiveException(ErrorCode.POST_AUTHOR_MISMATCH);

--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -96,6 +96,7 @@ public class BoardService {
     /**
      * 게시글 수정
      */
+    @Transactional
     public BoardResponse updateBoard(final BoardSaveRequest request, final CustomUserDetails userDetails,
                                      final Long boardId) {
 

--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -116,10 +116,8 @@ public class BoardService {
      * 게시판에 맞는 카테고리를 선택했는지 검사 ex) 전적 인증, 플레이팁은 e-sport 게시판에서만 사용
      */
     private void verifyBoardTypeAndCategoryType(BoardType boardType, CategoryType categoryType) {
-        if (!boardType.equals(BoardType.E_SPORTS)) {
-            if (categoryType.equals(CategoryType.PLAY_TIP) || categoryType.equals(CategoryType.RECORD_VERIFICATION)) {
-                throw new PlayHiveException(ErrorCode.INVALID_TYPE);
-            }
+        if (!boardType.isEsports()) {
+            categoryType.confirmEsports();
         }
     }
 
@@ -127,7 +125,7 @@ public class BoardService {
      * 작성자와 일치 하는지 검사 (어드민도 수정/삭제 허용)
      */
     private void verifyBoardAuthor(Board board, Member member) {
-        if (!board.getMember().getId().equals(member.getId())) {
+        if (!board.isAuthor(member)) {
             if (!member.isAdmin()) {
                 throw new PlayHiveException(ErrorCode.POST_AUTHOR_MISMATCH);
             }

--- a/src/main/java/org/myteam/server/board/service/CategoryReadService.java
+++ b/src/main/java/org/myteam/server/board/service/CategoryReadService.java
@@ -1,7 +1,7 @@
 package org.myteam.server.board.service;
 
 import lombok.RequiredArgsConstructor;
-import org.myteam.server.board.entity.Category;
+import org.myteam.server.board.domain.Category;
 import org.myteam.server.board.repository.CategoryRepository;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;

--- a/src/main/java/org/myteam/server/board/service/CategoryService.java
+++ b/src/main/java/org/myteam/server/board/service/CategoryService.java
@@ -1,22 +1,22 @@
 package org.myteam.server.board.service;
 
+import static org.myteam.server.global.exception.ErrorCode.INVALID_PARAMETER;
+import static org.myteam.server.global.exception.ErrorCode.RESOURCE_NOT_FOUND;
+
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.board.controller.reponse.CategoryResponse;
+import org.myteam.server.board.domain.Category;
 import org.myteam.server.board.dto.CategorySaveRequest;
 import org.myteam.server.board.dto.CategoryUpdateRequest;
-import org.myteam.server.board.entity.Category;
 import org.myteam.server.board.repository.CategoryJpaRepository;
 import org.myteam.server.board.repository.CategoryRepository;
 import org.myteam.server.board.repository.querydsl.CategoryQuerydslRepository;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.myteam.server.global.exception.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -34,7 +34,8 @@ public class CategoryService {
         Category categoryEntity = new Category(categorySaveRequest);
 
         if (categorySaveRequest.getParentId() != null) {
-            Category parentCategory = categoryRepository.getById(categorySaveRequest.getParentId()); // 부모 카테고리 Entity 조회
+            Category parentCategory = categoryRepository.getById(
+                    categorySaveRequest.getParentId()); // 부모 카테고리 Entity 조회
             Integer depth = categorySaveRequest.getDepth();
             Integer parentDepth = parentCategory.getDepth();
 
@@ -182,11 +183,12 @@ public class CategoryService {
     /**
      * 최상단 카테고리가 아닌 그 외 카테고리 변경에 대한 유효성 검증
      *
-     * @param parent 부모 카테고리
+     * @param parent                부모 카테고리
      * @param categoryUpdateRequest 카테고리 변경 정보
      * @throws PlayHiveException
      */
-    public void validateSubForReOrderIndex(Category parent, CategoryUpdateRequest categoryUpdateRequest) throws PlayHiveException {
+    public void validateSubForReOrderIndex(Category parent, CategoryUpdateRequest categoryUpdateRequest)
+            throws PlayHiveException {
         // 그 외
         List<Category> siblings = parent.getChildren(); // 부모의 자식 리스트
         int siblingsCount = siblings.size(); // 형제 카테고리(자식)의 개수
@@ -212,6 +214,7 @@ public class CategoryService {
 
     /**
      * 카테고리 순번을 설정
+     *
      * @param parent 부모 카테고리
      */
     public int allocateNextOrderIndex(Category parent) {


### PR DESCRIPTION
## 기능 설명
- 게시글 crud 수정

## 작업 내용
- 회의를 통해 카테고리 ID를 쓰지 않고, boardType과 categoryType으로 받아 저장하는 방식으로 결정 되어 수정하였습니다.
- categoryType의 전적인증과, 플레이팁 enum은 boardType이 Esports인 경우에만 사용할 수 있습니다.
- enum 타입 다른 의견 있으시면 반영하겠습니다 :)

## 수정 사항
- 작성, 수정 시 category ID 대신 boardType, categoryType을 받도록 수정

## 추가 작업 예정
- S3 업로드한 파일을 삭제하는 API 작성 예정입니다.

## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
