### PR TITLE
feat: 게시글 추천,추천삭제 API 추가 & 게시글 조회 시 로그인 사용자 추천 여부 응답값 추가

### DIFF
--- a/src/main/java/org/myteam/server/board/controller/BoardController.java
+++ b/src/main/java/org/myteam/server/board/controller/BoardController.java
@@ -69,7 +69,6 @@ public class BoardController {
 
     /**
      * 게시글 상세 조회
-     * TODO :: 현재 로그인 한 사용자가 해당 게시글 추천을 눌렀는지 응답값 추가
      */
     @GetMapping("/{boardId}")
     public ResponseEntity<ResponseDto<BoardResponse>> getBoard(@PathVariable final Long boardId) {

--- a/src/main/java/org/myteam/server/board/controller/BoardController.java
+++ b/src/main/java/org/myteam/server/board/controller/BoardController.java
@@ -41,11 +41,10 @@ public class BoardController {
      */
     @PostMapping
     public ResponseEntity<ResponseDto<BoardResponse>> saveBoard(
-            @AuthenticationPrincipal final CustomUserDetails userDetails,
             @Valid @RequestBody final BoardSaveRequest boardSaveRequest,
             final HttpServletRequest request) {
         final String clientIP = ClientUtils.getRemoteIP(request);
-        final BoardResponse response = boardService.saveBoard(boardSaveRequest, userDetails, clientIP);
+        final BoardResponse response = boardService.saveBoard(boardSaveRequest, clientIP);
         return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 생성 성공", response));
     }
 
@@ -54,9 +53,8 @@ public class BoardController {
      */
     @PutMapping("/{boardId}")
     public ResponseEntity<ResponseDto<BoardResponse>> updateBoard(
-            @AuthenticationPrincipal final CustomUserDetails userDetails, @PathVariable final Long boardId,
-            @Valid @RequestBody final BoardSaveRequest boardSaveRequest) {
-        final BoardResponse response = boardService.updateBoard(boardSaveRequest, userDetails, boardId);
+            @PathVariable final Long boardId, @Valid @RequestBody final BoardSaveRequest boardSaveRequest) {
+        final BoardResponse response = boardService.updateBoard(boardSaveRequest, boardId);
         return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 수정 성공", response));
     }
 
@@ -64,14 +62,14 @@ public class BoardController {
      * 게시글 삭제
      */
     @DeleteMapping("/{boardId}")
-    public ResponseEntity<ResponseDto<Void>> deleteBoard(@PathVariable final Long boardId,
-                                                         @AuthenticationPrincipal final CustomUserDetails userDetails) {
-        boardService.deleteBoard(boardId, userDetails);
+    public ResponseEntity<ResponseDto<Void>> deleteBoard(@PathVariable final Long boardId) {
+        boardService.deleteBoard(boardId);
         return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 삭제 성공", null));
     }
 
     /**
      * 게시글 상세 조회
+     * TODO :: 현재 로그인 한 사용자가 해당 게시글 추천을 눌렀는지 응답값 추가
      */
     @GetMapping("/{boardId}")
     public ResponseEntity<ResponseDto<BoardResponse>> getBoard(@PathVariable final Long boardId) {

--- a/src/main/java/org/myteam/server/board/controller/BoardRecommendController.java
+++ b/src/main/java/org/myteam/server/board/controller/BoardRecommendController.java
@@ -1,0 +1,42 @@
+package org.myteam.server.board.controller;
+
+import static org.myteam.server.global.web.response.ResponseStatus.SUCCESS;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.myteam.server.board.service.BoardRecommendService;
+import org.myteam.server.global.web.response.ResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/board/recommend")
+@RequiredArgsConstructor
+public class BoardRecommendController {
+
+    private final BoardRecommendService boardRecommendService;
+
+    /**
+     * 게시글 추천
+     */
+    @PostMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<Void>> recommendBoard(@PathVariable Long boardId) {
+        boardRecommendService.recommendBoard(boardId);
+        return ResponseEntity.ok(
+                new ResponseDto<>(SUCCESS.name(), "게시글 추천 성공", null));
+    }
+
+    /**
+     * 게시글 추천 삭제
+     */
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<ResponseDto<Void>> deleteBoard(@PathVariable Long boardId) {
+        boardRecommendService.deleteRecommendBoard(boardId);
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 추천 삭제 성공", null));
+    }
+}

--- a/src/main/java/org/myteam/server/board/domain/Board.java
+++ b/src/main/java/org/myteam/server/board/domain/Board.java
@@ -13,19 +13,19 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.myteam.server.board.dto.request.BoardSaveRequest;
+import org.myteam.server.global.domain.BaseTime;
 import org.myteam.server.member.entity.Member;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_board")
-public class Board {
+public class Board extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -54,12 +54,6 @@ public class Board {
 
     private String thumbnail;
 
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
     @OneToOne(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private BoardCount boardCount;
 
@@ -75,8 +69,6 @@ public class Board {
         this.link = link;
         this.createdIp = createdIp;
         this.thumbnail = thumbnail;
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
         this.boardCount = boardCount;
     }
 
@@ -87,7 +79,6 @@ public class Board {
         this.content = request.getContent();
         this.link = request.getLink();
         this.thumbnail = request.getThumbnail();
-        this.updatedAt = LocalDateTime.now();
     }
 
     public boolean isAuthor(Member member) {

--- a/src/main/java/org/myteam/server/board/domain/Board.java
+++ b/src/main/java/org/myteam/server/board/domain/Board.java
@@ -1,6 +1,7 @@
 package org.myteam.server.board.domain;
 
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -34,9 +35,11 @@ public class Board {
     @JoinColumn(name = "public_id")
     private Member member;
 
+    @Column(name = "board_type")
     @Enumerated(EnumType.STRING)
     private BoardType boardType;
 
+    @Column(name = "category_type")
     @Enumerated(EnumType.STRING)
     private CategoryType categoryType;
 
@@ -46,12 +49,15 @@ public class Board {
 
     private String link;
 
+    @Column(name = "created_ip")
     private String createdIp;
 
     private String thumbnail;
 
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @OneToOne(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/org/myteam/server/board/domain/BoardCount.java
+++ b/src/main/java/org/myteam/server/board/domain/BoardCount.java
@@ -56,4 +56,12 @@ public class BoardCount {
                 .viewCount(COUNT_SETTING_NUMBER)
                 .build();
     }
+
+    public void addRecommendCount() {
+        this.recommendCount += 1;
+    }
+
+    public void minusRecommendCount() {
+        this.recommendCount -= 1;
+    }
 }

--- a/src/main/java/org/myteam/server/board/domain/BoardRecommend.java
+++ b/src/main/java/org/myteam/server/board/domain/BoardRecommend.java
@@ -1,6 +1,5 @@
 package org.myteam.server.board.domain;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -8,18 +7,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.myteam.server.global.domain.BaseTime;
 import org.myteam.server.member.entity.Member;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "p_board_recommend")
-public class BoardRecommend {
+public class BoardRecommend extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,18 +29,10 @@ public class BoardRecommend {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
     @Builder
     public BoardRecommend(Long id, Board board, Member member) {
         this.id = id;
         this.board = board;
         this.member = member;
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/org/myteam/server/board/domain/BoardRecommend.java
+++ b/src/main/java/org/myteam/server/board/domain/BoardRecommend.java
@@ -1,0 +1,47 @@
+package org.myteam.server.board.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.member.entity.Member;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_board_recommend")
+public class BoardRecommend {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public BoardRecommend(Long id, Board board, Member member) {
+        this.id = id;
+        this.board = board;
+        this.member = member;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/org/myteam/server/board/domain/BoardType.java
+++ b/src/main/java/org/myteam/server/board/domain/BoardType.java
@@ -4,7 +4,7 @@ public enum BoardType {
     /**
      * e-sports
      */
-    E_SPORTS,
+    ESPORTS,
     /**
      * 야구
      */
@@ -15,6 +15,6 @@ public enum BoardType {
     FOOTBALL;
 
     public boolean isEsports() {
-        return this.equals(E_SPORTS);
+        return this.equals(ESPORTS);
     }
 }

--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
@@ -73,11 +73,11 @@ public class BoardResponse {
     /**
      * 작성 일시
      */
-    private LocalDateTime createdAt;
+    private LocalDateTime createDate;
     /**
      * 수정 일시
      */
-    private LocalDateTime updatedAt;
+    private LocalDateTime lastModifiedDate;
 
     public BoardResponse(Board board, BoardCount boardCount, boolean isRecommended) {
         this.boardType = board.getBoardType();
@@ -94,7 +94,7 @@ public class BoardResponse {
         this.recommendCount = boardCount.getRecommendCount();
         this.commentCount = boardCount.getCommentCount();
         this.viewCount = boardCount.getViewCount();
-        this.createdAt = board.getCreatedAt();
-        this.updatedAt = board.getUpdatedAt();
+        this.createDate = board.getCreateDate();
+        this.lastModifiedDate = board.getLastModifiedDate();
     }
 }

--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
@@ -1,5 +1,6 @@
 package org.myteam.server.board.dto.reponse;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
@@ -55,6 +56,7 @@ public class BoardResponse {
     /**
      * 로그인한 사용자 게시글 추천 여부
      */
+    @JsonProperty("isRecommended")
     private boolean isRecommended;
     /**
      * 추천 수

--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
@@ -53,7 +53,11 @@ public class BoardResponse {
      */
     private String thumbnail;
     /**
-     * 좋아요 수
+     * 로그인한 사용자 게시글 추천 여부
+     */
+    private boolean isRecommended;
+    /**
+     * 추천 수
      */
     private Integer recommendCount;
     /**
@@ -73,7 +77,7 @@ public class BoardResponse {
      */
     private LocalDateTime updatedAt;
 
-    public BoardResponse(Board board, BoardCount boardCount) {
+    public BoardResponse(Board board, BoardCount boardCount, boolean isRecommended) {
         this.boardType = board.getBoardType();
         this.categoryType = board.getCategoryType();
         this.boardId = board.getId();
@@ -84,6 +88,7 @@ public class BoardResponse {
         this.content = board.getContent();
         this.link = board.getLink();
         this.thumbnail = board.getThumbnail();
+        this.isRecommended = isRecommended;
         this.recommendCount = boardCount.getRecommendCount();
         this.commentCount = boardCount.getCommentCount();
         this.viewCount = boardCount.getViewCount();

--- a/src/main/java/org/myteam/server/board/repository/BoardCountRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardCountRepository.java
@@ -1,10 +1,18 @@
 package org.myteam.server.board.repository;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.myteam.server.board.domain.BoardCount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardCountRepository extends JpaRepository<BoardCount, Long> {
+
     void deleteByBoardId(Long id);
+
+    // 비관적 락으로 동시성 문제 해결
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<BoardCount> findByBoardId(Long boardId);
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
@@ -48,8 +48,8 @@ public class BoardQueryRepository {
                         member.publicId,
                         member.nickname,
                         boardCount.commentCount,
-                        board.createdAt,
-                        board.updatedAt
+                        board.createDate,
+                        board.lastModifiedDate
                 ))
                 .from(board)
                 .join(boardCount).on(boardCount.boardId.eq(board.id))
@@ -98,7 +98,7 @@ public class BoardQueryRepository {
         // default 최신순
         BoardOrderType boardOrderType = Optional.ofNullable(orderType).orElse(BoardOrderType.CREATE);
         return switch (boardOrderType) {
-            case CREATE -> board.createdAt.desc();
+            case CREATE -> board.createDate.desc();
             case RECOMMEND -> boardCount.recommendCount.desc();
             case COMMENT -> boardCount.commentCount.desc();
         };
@@ -129,8 +129,8 @@ public class BoardQueryRepository {
                         member.publicId,
                         member.nickname,
                         boardCount.commentCount,
-                        board.createdAt,
-                        board.updatedAt
+                        board.createDate,
+                        board.lastModifiedDate
                 ))
                 .from(board)
                 .join(boardCount).on(boardCount.boardId.eq(board.id))

--- a/src/main/java/org/myteam/server/board/repository/BoardRecommendRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardRecommendRepository.java
@@ -1,0 +1,15 @@
+package org.myteam.server.board.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.myteam.server.board.domain.BoardRecommend;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRecommendRepository extends JpaRepository<BoardRecommend, Long> {
+    
+    Optional<BoardRecommend> findByBoardIdAndMemberPublicId(Long boardId, UUID memberId);
+
+    void deleteByBoardIdAndMemberPublicId(Long boardId, UUID publicId);
+}

--- a/src/main/java/org/myteam/server/board/service/BoardCountReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardCountReadService.java
@@ -1,0 +1,20 @@
+package org.myteam.server.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.board.domain.BoardCount;
+import org.myteam.server.board.repository.BoardCountRepository;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardCountReadService {
+
+    private final BoardCountRepository boardCountRepository;
+
+    public BoardCount findByBoardId(Long boardId) {
+        return boardCountRepository.findByBoardId(boardId)
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_RECOMMEND_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/myteam/server/board/service/BoardReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReadService.java
@@ -3,11 +3,9 @@ package org.myteam.server.board.service;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.myteam.server.board.domain.Board;
-import org.myteam.server.board.domain.BoardCount;
 import org.myteam.server.board.dto.reponse.BoardDto;
 import org.myteam.server.board.dto.reponse.BoardListResponse;
 import org.myteam.server.board.dto.request.BoardServiceRequest;
-import org.myteam.server.board.repository.BoardCountRepository;
 import org.myteam.server.board.repository.BoardQueryRepository;
 import org.myteam.server.board.repository.BoardRepository;
 import org.myteam.server.global.exception.ErrorCode;
@@ -23,16 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class BoardReadService {
 
     private final BoardRepository boardRepository;
-    private final BoardCountRepository boardCountRepository;
     private final BoardQueryRepository boardQueryRepository;
 
-    public Board boardFindById(long boardId) {
+    public Board findById(long boardId) {
         return boardRepository.findById(boardId)
-                .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_NOT_FOUND));
-    }
-
-    public BoardCount boardCountFindById(long boardId) {
-        return boardCountRepository.findById(boardId)
                 .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_NOT_FOUND));
     }
 

--- a/src/main/java/org/myteam/server/board/service/BoardRecommendReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardRecommendReadService.java
@@ -1,0 +1,33 @@
+package org.myteam.server.board.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.board.repository.BoardRecommendRepository;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardRecommendReadService {
+
+    private final BoardRecommendRepository boardRecommendRepository;
+
+    public void confirmExistBoardRecommend(Long boardId, UUID memberId) {
+        boardRecommendRepository.findByBoardIdAndMemberPublicId(boardId, memberId)
+                .ifPresent(member -> {
+                    throw new PlayHiveException(ErrorCode.ALREADY_MEMBER_RECOMMEND_BOARD);
+                });
+    }
+
+    public boolean isAlreadyRecommended(Long boardId, UUID publicId) {
+        if (!boardRecommendRepository.findByBoardIdAndMemberPublicId(boardId, publicId).isPresent()) {
+            throw new PlayHiveException(ErrorCode.NO_MEMBER_RECOMMEND_RECORD);
+        }
+        return true;
+    }
+
+    public boolean isRecommended(Long boardId, UUID publicId) {
+        return boardRecommendRepository.findByBoardIdAndMemberPublicId(boardId, publicId).isPresent();
+    }
+}

--- a/src/main/java/org/myteam/server/board/service/BoardRecommendService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardRecommendService.java
@@ -1,0 +1,83 @@
+package org.myteam.server.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.board.domain.Board;
+import org.myteam.server.board.domain.BoardRecommend;
+import org.myteam.server.board.repository.BoardRecommendRepository;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.service.SecurityReadService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BoardRecommendService {
+
+    private final SecurityReadService securityReadService;
+    private final BoardReadService boardReadService;
+    private final BoardCountReadService boardCountReadService;
+    private final BoardRecommendReadService boardRecommendReadService;
+
+    private final BoardRecommendRepository boardRecommendRepository;
+
+    @Transactional
+    public void recommendBoard(Long boardId) {
+        Board board = boardReadService.findById(boardId);
+        Member member = securityReadService.getMember();
+
+        verifyMemberAlreadyRecommend(board, member);
+
+        recommend(board, member);
+
+        addRecommendCount(board.getId());
+    }
+
+    @Transactional
+    public void deleteRecommendBoard(Long boardId) {
+
+        Board board = boardReadService.findById(boardId);
+        Member member = securityReadService.getMember();
+
+        isAlreadyRecommended(board, member);
+
+        boardRecommendRepository.deleteByBoardIdAndMemberPublicId(board.getId(), member.getPublicId());
+
+        minusRecommendCount(boardId);
+    }
+
+    /**
+     * 추천이 되어있는 상태인지 검사
+     */
+    private void isAlreadyRecommended(Board board, Member member) {
+        boardRecommendReadService.isAlreadyRecommended(board.getId(), member.getPublicId());
+    }
+
+    /**
+     * 이미 추천한 상태인지 검사
+     */
+    private void verifyMemberAlreadyRecommend(Board board, Member member) {
+        boardRecommendReadService.confirmExistBoardRecommend(board.getId(), member.getPublicId());
+    }
+
+    /**
+     * 게시글 추천 생성
+     */
+    private void recommend(Board board, Member member) {
+        BoardRecommend recommend = BoardRecommend.builder().board(board).member(member).build();
+        boardRecommendRepository.save(recommend);
+    }
+
+    /**
+     * recommendCount 증가
+     */
+    public void addRecommendCount(Long boardId) {
+        boardCountReadService.findByBoardId(boardId).addRecommendCount();
+    }
+
+    /**
+     * recommendCount 감소
+     */
+    public void minusRecommendCount(Long boardId) {
+        boardCountReadService.findByBoardId(boardId).minusRecommendCount();
+    }
+}

--- a/src/main/java/org/myteam/server/global/exception/ErrorCode.java
+++ b/src/main/java/org/myteam/server/global/exception/ErrorCode.java
@@ -24,7 +24,6 @@ public enum ErrorCode {
     MEMBER_NOT_EQUALS(HttpStatus.BAD_REQUEST, "Member Not Equals"),
     NO_MEMBER_RECOMMEND_RECORD(HttpStatus.BAD_REQUEST, "No Member Recommend Record"),
     ALREADY_MEMBER_RECOMMEND_NEWS(HttpStatus.BAD_REQUEST, "Member Already Recommend News"),
-    ALREADY_MEMBER_RECOMMEND_BOARD(HttpStatus.BAD_REQUEST, "Member Already Recommend Board"),
 
     // 401 Unauthorized,
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Unauthorized"),
@@ -65,7 +64,8 @@ public enum ErrorCode {
     // 409 Conflict,
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "User already exists"),
     BAN_ALREADY_EXISTS(HttpStatus.CONFLICT, "This user already exists"),
-    INQUIRY_ANSWER_ALREADY_EXISTS(HttpStatus.CONFLICT, "This inquiry already exists");
+    INQUIRY_ANSWER_ALREADY_EXISTS(HttpStatus.CONFLICT, "This inquiry already exists"),
+    ALREADY_MEMBER_RECOMMEND_BOARD(HttpStatus.CONFLICT, "Member Already Recommend Board");
 
     private final HttpStatus status;
     private final String msg;

--- a/src/main/java/org/myteam/server/global/exception/ErrorCode.java
+++ b/src/main/java/org/myteam/server/global/exception/ErrorCode.java
@@ -22,7 +22,9 @@ public enum ErrorCode {
     INVALID_TYPE(HttpStatus.BAD_REQUEST, "Invalid type provided"),
     INVALID_MIME_TYPE(HttpStatus.BAD_REQUEST, "Invalid mime type provided"),
     MEMBER_NOT_EQUALS(HttpStatus.BAD_REQUEST, "Member Not Equals"),
+    NO_MEMBER_RECOMMEND_RECORD(HttpStatus.BAD_REQUEST, "No Member Recommend Record"),
     ALREADY_MEMBER_RECOMMEND_NEWS(HttpStatus.BAD_REQUEST, "Member Already Recommend News"),
+    ALREADY_MEMBER_RECOMMEND_BOARD(HttpStatus.BAD_REQUEST, "Member Already Recommend Board"),
 
     // 401 Unauthorized,
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Unauthorized"),
@@ -34,7 +36,8 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid Token"),
     MISSING_AUTH_HEADER(HttpStatus.UNAUTHORIZED, "No Authorization header or not Bearer type"),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid Refresh Token"),
-    UNAUTHORIZED_EMAIL_ACCOUNT(HttpStatus.UNAUTHORIZED, "Email account verification failed due to an invalid refresh token."),
+    UNAUTHORIZED_EMAIL_ACCOUNT(HttpStatus.UNAUTHORIZED,
+            "Email account verification failed due to an invalid refresh token."),
 
     // 403 Forbidden
     ACCOUNT_DISABLED(HttpStatus.FORBIDDEN, "Account disabled"),
@@ -57,6 +60,7 @@ public enum ErrorCode {
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "Inquiry not found"),
     INQUIRY_ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "Inquiry answer not found"),
     NEWS_COUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "News Count not found"),
+    BOARD_RECOMMEND_NOT_FOUND(HttpStatus.NOT_FOUND, "Board Recommend not found"),
 
     // 409 Conflict,
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "User already exists"),


### PR DESCRIPTION
## 기능 설명
- 게시글 추천하면 boardRecommend를 생성하고, boardCount의 recommendCount를 1 증가 시킵니다.
- 게시글 추천 삭제하면 boardRecommend를 삭제하고, boardCount의 recommendCount를 1 감소 시킵니다.

## 작업 내용
- 게시글 추천 API 추가.
- 게시글 추천 삭제 API 추가
- 게시글 조회 시 로그인한 사용자가 해당 게시글을 추천 했는지 여부를 isRecommended에 담아 내려주도록 응답값 추가

## 수정 사항
-

## 추가 작업 예정
- 
 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
