### PR TITLE
fix: 뉴스 api security설정, Swagger 설명추가

### DIFF
--- a/src/main/java/org/myteam/server/global/page/request/PageInfoRequest.java
+++ b/src/main/java/org/myteam/server/global/page/request/PageInfoRequest.java
@@ -1,5 +1,6 @@
 package org.myteam.server.global.page.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,7 +10,9 @@ import lombok.Setter;
 @NoArgsConstructor
 public class PageInfoRequest {
 
+	@Schema(description = "페이지 번호")
 	private int page = 1;
+	@Schema(description = "각 페이지 컨텐츠 갯수")
 	private int size = 12;
 
 	public PageInfoRequest(int page, int size) {

--- a/src/main/java/org/myteam/server/news/news/controller/NewsController.java
+++ b/src/main/java/org/myteam/server/news/news/controller/NewsController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -28,6 +30,7 @@ public class NewsController {
 
 	private final NewsReadService newsReadService;
 
+	@Operation(summary = "뉴스 목록 조회 API", description = "뉴스의 목록을 조회합니다.")
 	@GetMapping
 	public ResponseEntity<ResponseDto<NewsListResponse>> findAll(@ModelAttribute @Valid NewsRequest request) {
 		return ResponseEntity.ok(new ResponseDto<>(
@@ -36,8 +39,13 @@ public class NewsController {
 			newsReadService.findAll(request.toServiceRequest())));
 	}
 
+	@Operation(summary = "뉴스 상세 조회 API", description = "뉴스의 상세를 조회합니다.")
 	@GetMapping("/{newsId}")
-	public ResponseEntity<ResponseDto<NewsResponse>> findOne(@PathVariable Long newsId) {
+	public ResponseEntity<ResponseDto<NewsResponse>> findOne(
+		@PathVariable
+		@Parameter(description = "뉴스 ID")
+		Long newsId
+	) {
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
 			"뉴스 상세 조회 성공",

--- a/src/main/java/org/myteam/server/news/news/dto/controller/request/NewsRequest.java
+++ b/src/main/java/org/myteam/server/news/news/dto/controller/request/NewsRequest.java
@@ -5,6 +5,7 @@ import org.myteam.server.news.news.domain.NewsCategory;
 import org.myteam.server.news.news.dto.service.request.NewsServiceRequest;
 import org.myteam.server.news.news.repository.OrderType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,10 +17,15 @@ import lombok.Setter;
 @NoArgsConstructor
 public class NewsRequest extends PageInfoRequest {
 
+	@Schema(description = "뉴스 카테고리", example = "BASEBALL, FOOTBALL, ESPORTS")
 	@NotNull(message = "뉴스 카테고리는 필수입니다.")
 	private NewsCategory category;
+
+	@Schema(description = "뉴스 정렬 타입", example = "DATE(날짜순), COMMENT(댓글순), VIEW(조회순)")
 	@NotNull(message = "뉴스 정렬 타입은 필수입니다.")
 	private OrderType orderType;
+
+	@Schema(description = "검색할 뉴스 내용", example = "검색할 뉴스 제목")
 	private String content;
 
 	@Builder

--- a/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
+++ b/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
@@ -4,16 +4,23 @@ import java.time.LocalDateTime;
 
 import org.myteam.server.news.news.domain.NewsCategory;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class NewsDto {
+
+	@Schema(description = "뉴스 ID")
 	private Long id;
+	@Schema(description = "뉴스 카테고리")
 	private NewsCategory category;
+	@Schema(description = "뉴스 제목")
 	private String title;
+	@Schema(description = "뉴스 썸네일 이미지")
 	private String thumbImg;
+	@Schema(description = "뉴스 계시 날짜")
 	private LocalDateTime postDate;
 
 	public NewsDto(Long id, NewsCategory category, String title, String thumbImg, LocalDateTime postDate) {

--- a/src/main/java/org/myteam/server/news/news/dto/service/response/NewsResponse.java
+++ b/src/main/java/org/myteam/server/news/news/dto/service/response/NewsResponse.java
@@ -7,6 +7,7 @@ import org.myteam.server.news.news.domain.NewsCategory;
 import org.myteam.server.news.news.dto.repository.NewsDto;
 import org.myteam.server.news.newsCount.domain.NewsCount;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,20 +15,22 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class NewsResponse {
+
+	@Schema(description = "뉴스 ID")
 	private Long id;
-
+	@Schema(description = "뉴스 카테고리")
 	private NewsCategory category;
-
+	@Schema(description = "뉴스 제목")
 	private String title;
-
+	@Schema(description = "뉴스 썸네일 이미지")
 	private String thumbImg;
-
+	@Schema(description = "뉴스 추천수")
 	private int recommendCount;
-
+	@Schema(description = "뉴스 댓글수")
 	private int commentCount;
-
+	@Schema(description = "뉴스 조회수")
 	private int viewCount;
-
+	@Schema(description = "뉴스 계시 날짜")
 	private LocalDateTime postDate;
 
 	@Builder

--- a/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
@@ -72,7 +72,7 @@ public class NewsQueryRepository {
 
 	private OrderSpecifier<?> isOrderByEqualToOrderType(OrderType orderType) {
 		return switch (orderType) {
-			case DATE -> news.createDate.desc();
+			case DATE -> news.postDate.desc();
 			case VIEW -> newsCount.viewCount.desc();
 			case COMMENT -> newsCount.commentCount.desc();
 		};

--- a/src/main/java/org/myteam/server/news/newsComment/controller/NewsCommentController.java
+++ b/src/main/java/org/myteam/server/news/newsComment/controller/NewsCommentController.java
@@ -22,6 +22,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,14 +36,17 @@ public class NewsCommentController {
 	private final NewsCommentService newsCommentService;
 	private final NewsCommentReadService newsCommentReadService;
 
+	@Operation(summary = "뉴스 댓글 저장 API", description = "뉴스 댓글을 저장합니다.")
 	@PostMapping
-	public ResponseEntity<ResponseDto<NewsCommentResponse>> save(@RequestBody @Valid NewsCommentSaveRequest newsSaveRequest, HttpServletRequest request) {
+	public ResponseEntity<ResponseDto<NewsCommentResponse>> save(
+		@RequestBody @Valid NewsCommentSaveRequest newsSaveRequest, HttpServletRequest request) {
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
 			"뉴스 댓글 저장 성공",
 			newsCommentService.save(newsSaveRequest.toServiceRequest(ClientUtils.getRemoteIP(request)))));
 	}
 
+	@Operation(summary = "뉴스 댓글 목록 조회 API", description = "뉴스 댓글을 조회합니다.")
 	@GetMapping
 	public ResponseEntity<ResponseDto<NewsCommentListResponse>> findByNewsId(
 		@ModelAttribute @Valid NewsCommentRequest newsCommentRequest) {
@@ -51,6 +56,7 @@ public class NewsCommentController {
 			newsCommentReadService.findByNewsId(newsCommentRequest.toServiceRequest())));
 	}
 
+	@Operation(summary = "뉴스 댓글 수정 API", description = "뉴스 댓글을 수정합니다.")
 	@PatchMapping
 	public ResponseEntity<ResponseDto<Long>> update(
 		@RequestBody @Valid NewsCommentUpdateRequest newsCommentUpdateRequest) {
@@ -60,8 +66,13 @@ public class NewsCommentController {
 			newsCommentService.update(newsCommentUpdateRequest.toServiceRequest())));
 	}
 
+	@Operation(summary = "뉴스 댓글 삭제 API", description = "뉴스 댓글을 삭제합니다.")
 	@DeleteMapping("/{newsCommentId}")
-	public ResponseEntity<ResponseDto<Long>> delete(@PathVariable Long newsCommentId) {
+	public ResponseEntity<ResponseDto<Long>> delete(
+		@PathVariable
+		@Parameter(description = "뉴스 댓글 ID")
+		Long newsCommentId
+	) {
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
 			"뉴스 댓글 삭제 성공",

--- a/src/main/java/org/myteam/server/news/newsComment/dto/controller/request/NewsCommentRequest.java
+++ b/src/main/java/org/myteam/server/news/newsComment/dto/controller/request/NewsCommentRequest.java
@@ -3,6 +3,7 @@ package org.myteam.server.news.newsComment.dto.controller.request;
 import org.myteam.server.global.page.request.PageInfoRequest;
 import org.myteam.server.news.newsComment.dto.service.request.NewsCommentServiceRequest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class NewsCommentRequest extends PageInfoRequest {
 
+	@Schema(description = "뉴스 ID")
 	@NotNull(message = "뉴스ID는 필수입니다.")
 	private Long newsId;
 

--- a/src/main/java/org/myteam/server/news/newsComment/dto/controller/request/NewsCommentSaveRequest.java
+++ b/src/main/java/org/myteam/server/news/newsComment/dto/controller/request/NewsCommentSaveRequest.java
@@ -2,6 +2,7 @@ package org.myteam.server.news.newsComment.dto.controller.request;
 
 import org.myteam.server.news.newsComment.dto.service.request.NewsCommentSaveServiceRequest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +12,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsCommentSaveRequest {
 
+	@Schema(description = "뉴스 ID")
 	@NotNull(message = "뉴스ID는 필수입니다.")
 	private Long newsId;
+	@Schema(description = "댓글")
 	@NotNull(message = "뉴스 댓글은 필수입니다.")
 	private String comment;
 

--- a/src/main/java/org/myteam/server/news/newsComment/dto/controller/request/NewsCommentUpdateRequest.java
+++ b/src/main/java/org/myteam/server/news/newsComment/dto/controller/request/NewsCommentUpdateRequest.java
@@ -2,6 +2,7 @@ package org.myteam.server.news.newsComment.dto.controller.request;
 
 import org.myteam.server.news.newsComment.dto.service.request.NewsCommentUpdateServiceRequest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +12,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsCommentUpdateRequest {
 
+	@Schema(description = "뉴스 댓글 ID")
 	@NotNull(message = "뉴스 댓글 ID는 필수입니다.")
 	private Long newsCommentId;
+	@Schema(description = "뉴스 댓글 내용")
 	@NotNull(message = "뉴스 댓글 내용은 필수입니다.")
 	private String comment;
 

--- a/src/main/java/org/myteam/server/news/newsComment/dto/repository/NewsCommentDto.java
+++ b/src/main/java/org/myteam/server/news/newsComment/dto/repository/NewsCommentDto.java
@@ -2,6 +2,7 @@ package org.myteam.server.news.newsComment.dto.repository;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,11 +10,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsCommentDto {
 
+	@Schema(description = "뉴스 댓글 ID")
 	private Long newsCommentId;
+	@Schema(description = "뉴스 ID")
 	private Long newsId;
+	@Schema(description = "뉴스 작성자")
 	private NewsCommentMemberDto memberDto;
+	@Schema(description = "뉴스 댓글")
 	private String comment;
+	@Schema(description = "뉴스 댓글 작성시 IP")
 	private String ip;
+	@Schema(description = "뉴스 댓글 날짜")
 	private LocalDateTime createTime;
 
 	public NewsCommentDto(Long newsCommentId, Long newsId, NewsCommentMemberDto memberDto, String comment, String ip, LocalDateTime createTime) {

--- a/src/main/java/org/myteam/server/news/newsComment/dto/repository/NewsCommentMemberDto.java
+++ b/src/main/java/org/myteam/server/news/newsComment/dto/repository/NewsCommentMemberDto.java
@@ -1,5 +1,6 @@
 package org.myteam.server.news.newsComment.dto.repository;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +9,10 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 public class NewsCommentMemberDto {
+
+	@Schema(description = "작성자 ID")
 	private UUID publicId;
+	@Schema(description = "작성자 닉네임")
 	private String nickName;
 
 	public NewsCommentMemberDto(UUID publicId, String nickName) {

--- a/src/main/java/org/myteam/server/news/newsComment/dto/service/response/NewsCommentResponse.java
+++ b/src/main/java/org/myteam/server/news/newsComment/dto/service/response/NewsCommentResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.news.newsComment.domain.NewsComment;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,10 +14,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsCommentResponse {
 
+	@Schema(description = "뉴스 댓글 ID")
 	private Long newsCommentId;
+	@Schema(description = "뉴스 ID")
 	private Long newsId;
+	@Schema(description = "뉴스 작성자")
 	private NewsCommentMemberResponse member;
+	@Schema(description = "뉴스 댓글 내용")
 	private String comment;
+	@Schema(description = "뉴스 댓글 작성 날짜")
 	private LocalDateTime createDate;
 
 	@Builder

--- a/src/main/java/org/myteam/server/news/newsCount/controller/NewsCountController.java
+++ b/src/main/java/org/myteam/server/news/newsCount/controller/NewsCountController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,16 +23,26 @@ public class NewsCountController {
 
 	private final NewsCountService newsCountService;
 
+	@Operation(summary = "뉴스 추천수 추가 API", description = "뉴스를 추천합니다.")
 	@PatchMapping("/recommend/{newsId}")
-	public ResponseEntity<ResponseDto<NewsRecommendResponse>> recommend(@PathVariable Long newsId) {
+	public ResponseEntity<ResponseDto<NewsRecommendResponse>> recommend(
+		@PathVariable
+		@Parameter(description = "뉴스 ID")
+		Long newsId
+	) {
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
 			"뉴스 추천 추가 성공",
 			newsCountService.recommendNews(newsId)));
 	}
 
+	@Operation(summary = "뉴스 추천수 삭제 API", description = "뉴스의 추천을 취소합니다.")
 	@DeleteMapping("/recommend/{newsId}")
-	public ResponseEntity<ResponseDto<NewsRecommendResponse>> cancelRecommend(@PathVariable Long newsId) {
+	public ResponseEntity<ResponseDto<NewsRecommendResponse>> cancelRecommend(
+		@PathVariable
+		@Parameter(description = "뉴스 ID")
+		Long newsId
+	) {
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
 			"뉴스 추천 삭제 성공",

--- a/src/main/java/org/myteam/server/news/newsCount/dto/service/response/NewsRecommendResponse.java
+++ b/src/main/java/org/myteam/server/news/newsCount/dto/service/response/NewsRecommendResponse.java
@@ -1,5 +1,6 @@
 package org.myteam.server.news.newsCount.dto.service.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsRecommendResponse {
 
+	@Schema(description = "뉴스 ID")
 	private Long newsId;
 
 	@Builder

--- a/src/main/java/org/myteam/server/news/newsReply/controller/NewsReplyController.java
+++ b/src/main/java/org/myteam/server/news/newsReply/controller/NewsReplyController.java
@@ -22,6 +22,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,7 @@ public class NewsReplyController {
 	private final NewsReplyService newsReplyService;
 	private final NewsReplyReadService newsReplyReadService;
 
+	@Operation(summary = "뉴스 대댓글 저장 API", description = "뉴스 댓글의 대댓글을 추가합니다.")
 	@PostMapping
 	public ResponseEntity<ResponseDto<NewsReplyResponse>> save(
 		@RequestBody @Valid NewsReplySaveRequest newsSaveRequest, HttpServletRequest request) {
@@ -43,8 +46,9 @@ public class NewsReplyController {
 			newsReplyService.save(newsSaveRequest.toServiceRequest(ClientUtils.getRemoteIP(request)))));
 	}
 
+	@Operation(summary = "뉴스 대댓글 목록 조회 API", description = "뉴스 댓글의 대댓글 목록을 조회합니다.")
 	@GetMapping
-	public ResponseEntity<ResponseDto<NewsReplyListResponse>> findByNewsId(
+	public ResponseEntity<ResponseDto<NewsReplyListResponse>> findByNewsCommentId(
 		@ModelAttribute @Valid NewsReplyRequest newsReplyRequest) {
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
@@ -52,6 +56,7 @@ public class NewsReplyController {
 			newsReplyReadService.findByNewsCommentId(newsReplyRequest.toServiceRequest())));
 	}
 
+	@Operation(summary = "뉴스 대댓글 수정 API", description = "뉴스 댓글의 대댓글을 수정합니다.")
 	@PatchMapping
 	public ResponseEntity<ResponseDto<Long>> update(
 		@RequestBody @Valid NewsReplyUpdateRequest newsReplyUpdateRequest) {
@@ -61,8 +66,13 @@ public class NewsReplyController {
 			newsReplyService.update(newsReplyUpdateRequest.toServiceRequest())));
 	}
 
+	@Operation(summary = "뉴스 대댓글 삭제 API", description = "뉴스 댓글의 대댓글을 삭제합니다.")
 	@DeleteMapping("/{newsReplyId}")
-	public ResponseEntity<ResponseDto<Long>> delete(@PathVariable Long newsReplyId) {
+	public ResponseEntity<ResponseDto<Long>> delete(
+		@PathVariable
+		@Parameter(description = "뉴스 대댓글 ID")
+		Long newsReplyId
+	) {
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
 			"뉴스 대댓글 삭제 성공",

--- a/src/main/java/org/myteam/server/news/newsReply/dto/controller/request/NewsReplyRequest.java
+++ b/src/main/java/org/myteam/server/news/newsReply/dto/controller/request/NewsReplyRequest.java
@@ -3,6 +3,7 @@ package org.myteam.server.news.newsReply.dto.controller.request;
 import org.myteam.server.global.page.request.PageInfoRequest;
 import org.myteam.server.news.newsReply.dto.service.request.NewsReplyServiceRequest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,8 @@ import lombok.Setter;
 @NoArgsConstructor
 public class NewsReplyRequest extends PageInfoRequest {
 
-	@NotNull(message = "뉴스 대댓글 ID는 필수입니다.")
+	@Schema(description = "뉴스 댓글 ID")
+	@NotNull(message = "뉴스 댓글 ID는 필수입니다.")
 	private Long newsCommentId;
 
 	@Builder

--- a/src/main/java/org/myteam/server/news/newsReply/dto/controller/request/NewsReplySaveRequest.java
+++ b/src/main/java/org/myteam/server/news/newsReply/dto/controller/request/NewsReplySaveRequest.java
@@ -2,6 +2,7 @@ package org.myteam.server.news.newsReply.dto.controller.request;
 
 import org.myteam.server.news.newsReply.dto.service.request.NewsReplySaveServiceRequest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +12,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsReplySaveRequest {
 
+	@Schema(description = "뉴스 댓글 ID")
 	@NotNull(message = "뉴스 댓글 ID는 필수입니다.")
 	private Long newsCommentId;
+	@Schema(description = "뉴스 대댓글 내용")
 	@NotNull(message = "뉴스 대댓글은 필수입니다.")
 	private String comment;
 

--- a/src/main/java/org/myteam/server/news/newsReply/dto/controller/request/NewsReplyUpdateRequest.java
+++ b/src/main/java/org/myteam/server/news/newsReply/dto/controller/request/NewsReplyUpdateRequest.java
@@ -2,6 +2,7 @@ package org.myteam.server.news.newsReply.dto.controller.request;
 
 import org.myteam.server.news.newsReply.dto.service.request.NewsReplyUpdateServiceRequest;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +12,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsReplyUpdateRequest {
 
+	@Schema(description = "뉴스 대댓글 ID")
 	@NotNull(message = "뉴스 대댓글 ID는 필수입니다.")
 	private Long newsReplyId;
+	@Schema(description = "뉴스 대댓글 내용 ID")
 	@NotNull(message = "뉴스 대댓글 내용은 필수입니다.")
 	private String comment;
 

--- a/src/main/java/org/myteam/server/news/newsReply/dto/repository/NewsReplyDto.java
+++ b/src/main/java/org/myteam/server/news/newsReply/dto/repository/NewsReplyDto.java
@@ -2,6 +2,7 @@ package org.myteam.server.news.newsReply.dto.repository;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,11 +10,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsReplyDto {
 
+	@Schema(description = "뉴스 대댓글 ID")
 	private Long newsReplyId;
+	@Schema(description = "뉴스 댓글 ID")
 	private Long newsCommentId;
+	@Schema(description = "뉴스 작성자")
 	private NewsReplyMemberDto member;
+	@Schema(description = "뉴스 대댓글 내용")
 	private String comment;
+	@Schema(description = "뉴스 대댓글 작성시 IP")
 	private String ip;
+	@Schema(description = "뉴스 대댓글 작성날짜")
 	private LocalDateTime createTime;
 
 	public NewsReplyDto(Long newsReplyId, Long newsCommentId, NewsReplyMemberDto member, String comment,

--- a/src/main/java/org/myteam/server/news/newsReply/dto/repository/NewsReplyMemberDto.java
+++ b/src/main/java/org/myteam/server/news/newsReply/dto/repository/NewsReplyMemberDto.java
@@ -1,5 +1,6 @@
 package org.myteam.server.news.newsReply.dto.repository;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +9,10 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 public class NewsReplyMemberDto {
+
+	@Schema(description = "작성자 ID")
 	private UUID publicId;
+	@Schema(description = "작성자 닉네임")
 	private String nickName;
 
 	public NewsReplyMemberDto(UUID publicId, String nickName) {

--- a/src/main/java/org/myteam/server/news/newsReply/dto/service/response/NewsReplyMemberResponse.java
+++ b/src/main/java/org/myteam/server/news/newsReply/dto/service/response/NewsReplyMemberResponse.java
@@ -1,5 +1,6 @@
 package org.myteam.server.news.newsReply.dto.service.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,12 +11,14 @@ import java.util.UUID;
 @NoArgsConstructor
 public class NewsReplyMemberResponse {
 
-	private UUID memberPublicId;
+	@Schema(description = "작성자 ID")
+	private UUID publicId;
+	@Schema(description = "작성자 닉네임")
 	private String nickName;
 
 	@Builder
-	public NewsReplyMemberResponse(UUID memberPublicId, String nickName) {
-		this.memberPublicId = memberPublicId;
+	public NewsReplyMemberResponse(UUID publicId, String nickName) {
+		this.publicId = publicId;
 		this.nickName = nickName;
 	}
 }

--- a/src/main/java/org/myteam/server/news/newsReply/dto/service/response/NewsReplyResponse.java
+++ b/src/main/java/org/myteam/server/news/newsReply/dto/service/response/NewsReplyResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.news.newsReply.domain.NewsReply;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,10 +14,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsReplyResponse {
 
+	@Schema(description = "뉴스 대댓글 ID")
 	private Long newsReplyId;
+	@Schema(description = "뉴스 댓글 ID")
 	private Long newsCommentId;
+	@Schema(description = "뉴스 작성자")
 	private NewsReplyMemberResponse member;
+	@Schema(description = "뉴스 대댓글 내용")
 	private String comment;
+	@Schema(description = "뉴스 대댓글 작성날짜")
 	private LocalDateTime createDate;
 
 	@Builder
@@ -35,7 +41,7 @@ public class NewsReplyResponse {
 			.newsCommentId(newsReply.getNewsComment().getId())
 			.member(
 				NewsReplyMemberResponse.builder()
-					.memberPublicId(member.getPublicId())
+					.publicId(member.getPublicId())
 					.nickName(member.getNickname())
 					.build()
 			)

--- a/src/test/java/org/myteam/server/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/IntegrationTestSupport.java
@@ -2,6 +2,7 @@ package org.myteam.server;
 
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
@@ -104,6 +105,7 @@ public abstract class IntegrationTestSupport {
 			.title("기사타이틀" + index)
 			.category(category)
 			.thumbImg("www.test.com")
+			.postDate(LocalDateTime.now())
 			.build());
 
 		NewsCount newsCount = NewsCount.builder()

--- a/src/test/java/org/myteam/server/news/newsReply/controller/NewsReplyControllerTest.java
+++ b/src/test/java/org/myteam/server/news/newsReply/controller/NewsReplyControllerTest.java
@@ -132,7 +132,7 @@ class NewsReplyControllerTest extends ControllerTestSupport {
 			.andDo(print())
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
-			.andExpect(jsonPath("$.message").value("뉴스 대댓글 ID는 필수입니다."));
+			.andExpect(jsonPath("$.message").value("뉴스 댓글 ID는 필수입니다."));
 	}
 
 	@DisplayName("뉴스 대댓글을 수정한다.")


### PR DESCRIPTION
## 기능 설명
- 뉴스 API는 로그인을 안해도 사용 가능해야하므로 Security 제외
- Swagger API 설명
## 작업 내용
- SecurityConfig /api/news 추가
- Swagger API 설명 추가
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인