### PR TITLE
epic: 실시간 경기 댓글

### DIFF
--- a/src/main/java/org/myteam/server/global/exception/ErrorCode.java
+++ b/src/main/java/org/myteam/server/global/exception/ErrorCode.java
@@ -78,6 +78,12 @@ public enum ErrorCode {
     MATCH_PREDICTION_NOT_FOUNT(HttpStatus.NOT_FOUND, "Match Prediction not found"),
 
 
+    MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "Match not found"),
+    MATCH_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Match Comment not found"),
+    MATCH_REPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "Match Reply not found"),
+    MATCH_COUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "Match Count not found"),
+
+
     // 409 Conflict,
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "User already exists"),
     BAN_ALREADY_EXISTS(HttpStatus.CONFLICT, "This user already exists"),

--- a/src/main/java/org/myteam/server/match/matchComment/controller/MatchCommentController.java
+++ b/src/main/java/org/myteam/server/match/matchComment/controller/MatchCommentController.java
@@ -1,0 +1,81 @@
+package org.myteam.server.match.matchComment.controller;
+
+import static org.myteam.server.global.web.response.ResponseStatus.*;
+
+import org.myteam.server.global.web.response.ResponseDto;
+import org.myteam.server.match.matchComment.dto.controller.request.MatchCommentRequest;
+import org.myteam.server.match.matchComment.dto.controller.request.MatchCommentSaveRequest;
+import org.myteam.server.match.matchComment.dto.controller.request.MatchCommentUpdateRequest;
+import org.myteam.server.match.matchComment.dto.service.response.MatchCommentListResponse;
+import org.myteam.server.match.matchComment.dto.service.response.MatchCommentResponse;
+import org.myteam.server.match.matchComment.service.MatchCommentReadService;
+import org.myteam.server.match.matchComment.service.MatchCommentService;
+import org.myteam.server.util.ClientUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/match/comment")
+public class MatchCommentController {
+
+	private final MatchCommentService matchCommentService;
+	private final MatchCommentReadService matchCommentReadService;
+
+	@Operation(summary = "경기 댓글 저장 API", description = "경기 댓글을 저장합니다.")
+	@PostMapping
+	public ResponseEntity<ResponseDto<MatchCommentResponse>> save(
+		@RequestBody @Valid MatchCommentSaveRequest matchCommentSaveRequest, HttpServletRequest request) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"경기 댓글 저장 성공",
+			matchCommentService.save(matchCommentSaveRequest.toServiceRequest(ClientUtils.getRemoteIP(request)))));
+	}
+
+	@Operation(summary = "경기 댓글 목록 조회 API", description = "경기 댓글을 조회합니다.")
+	@GetMapping
+	public ResponseEntity<ResponseDto<MatchCommentListResponse>> findByNewsId(
+		@ModelAttribute @Valid MatchCommentRequest matchCommentRequest) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"경기 댓글 조회 성공",
+			matchCommentReadService.findByMatchId(matchCommentRequest.toServiceRequest())));
+	}
+
+	@Operation(summary = "경기 댓글 수정 API", description = "경기 댓글을 수정합니다.")
+	@PatchMapping
+	public ResponseEntity<ResponseDto<Long>> update(
+		@RequestBody @Valid MatchCommentUpdateRequest matchCommentUpdateRequest) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"경기 댓글 수정 성공",
+			matchCommentService.update(matchCommentUpdateRequest.toServiceRequest())));
+	}
+
+	@Operation(summary = "경기 댓글 삭제 API", description = "경기 댓글을 삭제합니다.")
+	@DeleteMapping("/{matchCommentId}")
+	public ResponseEntity<ResponseDto<Long>> delete(
+		@PathVariable
+		@Parameter(description = "경기 댓글 ID")
+		Long matchCommentId
+	) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"경기 댓글 삭제 성공",
+			matchCommentService.delete(matchCommentId)));
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/domain/MatchComment.java
+++ b/src/main/java/org/myteam/server/match/matchComment/domain/MatchComment.java
@@ -1,0 +1,70 @@
+package org.myteam.server.match.matchComment.domain;
+
+import org.myteam.server.global.domain.Base;
+import org.myteam.server.match.match.domain.Match;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.news.domain.News;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_match_comment")
+public class MatchComment extends Base {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Match match;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member member;
+
+	private String comment;
+
+	private String recommendCount;
+
+	private String ip;
+
+	@Builder
+	public MatchComment(Long id, Match match, Member member, String comment, String recommendCount, String ip) {
+		this.id = id;
+		this.match = match;
+		this.member = member;
+		this.comment = comment;
+		this.recommendCount = recommendCount;
+		this.ip = ip;
+	}
+
+	public void confirmMember(Member member) {
+		this.member.confirmMemberEquals(member);
+	}
+
+	public void updateComment(String comment) {
+		this.comment = comment;
+	}
+
+	public void addRecommendCount() {
+		this.recommendCount += 1;
+	}
+
+	public static MatchComment createEntity(Match match, Member member, String comment, String ip) {
+		return MatchComment.builder()
+			.match(match)
+			.member(member)
+			.comment(comment)
+			.ip(ip)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/controller/request/MatchCommentRequest.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/controller/request/MatchCommentRequest.java
@@ -1,0 +1,35 @@
+package org.myteam.server.match.matchComment.dto.controller.request;
+
+import org.myteam.server.global.page.request.PageInfoRequest;
+import org.myteam.server.match.matchComment.dto.service.request.MatchCommentServiceRequest;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MatchCommentRequest extends PageInfoRequest {
+
+	@Schema(description = "경기 ID")
+	@NotNull(message = "경기 ID는 필수입니다.")
+	private Long matchId;
+
+	@Builder
+	public MatchCommentRequest(Long matchId, int page, int size) {
+		super(page, size);
+		this.matchId = matchId;
+	}
+
+	public MatchCommentServiceRequest toServiceRequest() {
+		return MatchCommentServiceRequest.builder()
+			.matchId(matchId)
+			.size(getSize())
+			.page(getPage())
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/controller/request/MatchCommentSaveRequest.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/controller/request/MatchCommentSaveRequest.java
@@ -1,0 +1,35 @@
+package org.myteam.server.match.matchComment.dto.controller.request;
+
+import org.myteam.server.match.matchComment.dto.service.request.MatchCommentSaveServiceRequest;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentSaveRequest {
+
+	@Schema(description = "경기 ID")
+	@NotNull(message = "경기ID는 필수입니다.")
+	private Long matchId;
+	@Schema(description = "댓글")
+	@NotNull(message = "경기 댓글은 필수입니다.")
+	private String comment;
+
+	@Builder
+	public MatchCommentSaveRequest(Long matchId, String comment) {
+		this.matchId = matchId;
+		this.comment = comment;
+	}
+
+	public MatchCommentSaveServiceRequest toServiceRequest(String ip) {
+		return MatchCommentSaveServiceRequest.builder()
+			.matchId(matchId)
+			.comment(comment)
+			.ip(ip)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/controller/request/MatchCommentUpdateRequest.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/controller/request/MatchCommentUpdateRequest.java
@@ -1,0 +1,34 @@
+package org.myteam.server.match.matchComment.dto.controller.request;
+
+import org.myteam.server.match.matchComment.dto.service.request.MatchCommentUpdateServiceRequest;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentUpdateRequest {
+
+	@Schema(description = "경기 댓글 ID")
+	@NotNull(message = "경기 댓글 ID는 필수입니다.")
+	private Long matchCommentId;
+	@Schema(description = "뉴스 댓글 내용")
+	@NotNull(message = "경기 댓글 내용은 필수입니다.")
+	private String comment;
+
+	@Builder
+	public MatchCommentUpdateRequest(Long matchCommentId, String comment) {
+		this.matchCommentId = matchCommentId;
+		this.comment = comment;
+	}
+
+	public MatchCommentUpdateServiceRequest toServiceRequest() {
+		return MatchCommentUpdateServiceRequest.builder()
+			.matchCommentId(matchCommentId)
+			.comment(comment)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/repository/MatchCommentDto.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/repository/MatchCommentDto.java
@@ -1,0 +1,34 @@
+package org.myteam.server.match.matchComment.dto.repository;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentDto {
+
+	@Schema(description = "경기 댓글 ID")
+	private Long matchCommentId;
+	@Schema(description = "경기 ID")
+	private Long matchId;
+	@Schema(description = "경기 댓글 작성자")
+	private MatchCommentMemberDto memberDto;
+	@Schema(description = "경기 댓글")
+	private String comment;
+	@Schema(description = "경기 댓글 작성시 IP")
+	private String ip;
+	@Schema(description = "경기 댓글 날짜")
+	private LocalDateTime createTime;
+
+	public MatchCommentDto(Long matchCommentId, Long matchId, MatchCommentMemberDto memberDto, String comment, String ip, LocalDateTime createTime) {
+		this.matchCommentId = matchCommentId;
+		this.matchId = matchId;
+		this.memberDto = memberDto;
+		this.comment = comment;
+		this.ip = ip;
+		this.createTime = createTime;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/repository/MatchCommentMemberDto.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/repository/MatchCommentMemberDto.java
@@ -1,0 +1,22 @@
+package org.myteam.server.match.matchComment.dto.repository;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentMemberDto {
+
+	@Schema(description = "작성자 ID")
+	private UUID publicId;
+	@Schema(description = "작성자 닉네임")
+	private String nickName;
+
+	public MatchCommentMemberDto(UUID publicId, String nickName) {
+		this.publicId = publicId;
+		this.nickName = nickName;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/service/request/MatchCommentSaveServiceRequest.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/service/request/MatchCommentSaveServiceRequest.java
@@ -1,0 +1,20 @@
+package org.myteam.server.match.matchComment.dto.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentSaveServiceRequest {
+	private Long matchId;
+	private String comment;
+	private String ip;
+
+	@Builder
+	public MatchCommentSaveServiceRequest(Long matchId, String comment, String ip) {
+		this.matchId = matchId;
+		this.comment = comment;
+		this.ip = ip;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/service/request/MatchCommentServiceRequest.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/service/request/MatchCommentServiceRequest.java
@@ -1,0 +1,20 @@
+package org.myteam.server.match.matchComment.dto.service.request;
+
+import org.myteam.server.global.page.request.PageInfoServiceRequest;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentServiceRequest extends PageInfoServiceRequest {
+
+	private Long matchId;
+
+	@Builder
+	public MatchCommentServiceRequest(Long matchId, int size, int page) {
+		super(page, size);
+		this.matchId = matchId;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/service/request/MatchCommentUpdateServiceRequest.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/service/request/MatchCommentUpdateServiceRequest.java
@@ -1,0 +1,19 @@
+package org.myteam.server.match.matchComment.dto.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentUpdateServiceRequest {
+
+	private Long matchCommentId;
+	private String comment;
+
+	@Builder
+	public MatchCommentUpdateServiceRequest(Long matchCommentId, String comment) {
+		this.matchCommentId = matchCommentId;
+		this.comment = comment;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/service/response/MatchCommentListResponse.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/service/response/MatchCommentListResponse.java
@@ -1,0 +1,26 @@
+package org.myteam.server.match.matchComment.dto.service.response;
+
+import org.myteam.server.global.page.response.PageCustomResponse;
+import org.myteam.server.match.matchComment.dto.repository.MatchCommentDto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentListResponse {
+
+	private PageCustomResponse<MatchCommentDto> list;
+
+	@Builder
+	public MatchCommentListResponse(PageCustomResponse<MatchCommentDto> list) {
+		this.list = list;
+	}
+
+	public static MatchCommentListResponse createResponse(PageCustomResponse<MatchCommentDto> list) {
+		return MatchCommentListResponse.builder()
+			.list(list)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/service/response/MatchCommentMemberResponse.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/service/response/MatchCommentMemberResponse.java
@@ -1,0 +1,21 @@
+package org.myteam.server.match.matchComment.dto.service.response;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentMemberResponse {
+
+	private UUID memberPublicId;
+	private String nickName;
+
+	@Builder
+	public MatchCommentMemberResponse(UUID memberPublicId, String nickName) {
+		this.memberPublicId = memberPublicId;
+		this.nickName = nickName;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/dto/service/response/MatchCommentResponse.java
+++ b/src/main/java/org/myteam/server/match/matchComment/dto/service/response/MatchCommentResponse.java
@@ -1,0 +1,52 @@
+package org.myteam.server.match.matchComment.dto.service.response;
+
+import java.time.LocalDateTime;
+
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.member.entity.Member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchCommentResponse {
+
+	@Schema(description = "경기 댓글 ID")
+	private Long matchCommentId;
+	@Schema(description = "경기 ID")
+	private Long matchId;
+	@Schema(description = "경기 댓글 작성자")
+	private MatchCommentMemberResponse member;
+	@Schema(description = "경기 댓글 내용")
+	private String comment;
+	@Schema(description = "경기 댓글 작성 날짜")
+	private LocalDateTime createDate;
+
+	@Builder
+	public MatchCommentResponse(Long matchCommentId, Long matchId, MatchCommentMemberResponse member, String comment,
+		LocalDateTime createDate) {
+		this.matchCommentId = matchCommentId;
+		this.matchId = matchId;
+		this.member = member;
+		this.comment = comment;
+		this.createDate = createDate;
+	}
+
+	public static MatchCommentResponse createResponse(MatchComment matchComment, Member member) {
+		return MatchCommentResponse.builder()
+			.matchCommentId(matchComment.getId())
+			.matchId(matchComment.getMatch().getId())
+			.member(
+				MatchCommentMemberResponse.builder()
+					.memberPublicId(member.getPublicId())
+					.nickName(member.getNickname())
+					.build()
+			)
+			.comment(matchComment.getComment())
+			.createDate(matchComment.getCreateDate())
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/repository/MatchCommentLockRepository.java
+++ b/src/main/java/org/myteam/server/match/matchComment/repository/MatchCommentLockRepository.java
@@ -1,0 +1,17 @@
+package org.myteam.server.match.matchComment.repository;
+
+import java.util.Optional;
+
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.news.newsCount.domain.NewsCount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+
+@Repository
+public interface MatchCommentLockRepository extends JpaRepository<MatchComment, Long> {
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	Optional<MatchComment> findById(Long matchCommentId);
+}

--- a/src/main/java/org/myteam/server/match/matchComment/repository/MatchCommentQueryRepository.java
+++ b/src/main/java/org/myteam/server/match/matchComment/repository/MatchCommentQueryRepository.java
@@ -1,0 +1,71 @@
+package org.myteam.server.match.matchComment.repository;
+
+import static java.util.Optional.*;
+import static org.myteam.server.match.matchComment.domain.QMatchComment.*;
+import static org.myteam.server.news.newsComment.domain.QNewsComment.*;
+
+import java.util.List;
+
+import org.myteam.server.match.matchComment.domain.QMatchComment;
+import org.myteam.server.match.matchComment.dto.repository.MatchCommentDto;
+import org.myteam.server.match.matchComment.dto.repository.MatchCommentMemberDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchCommentQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public Page<MatchCommentDto> getNewsCommentList(Long matchId, Pageable pageable) {
+		List<MatchCommentDto> content = queryFactory
+			.select(Projections.constructor(MatchCommentDto.class,
+				matchComment.id,
+				matchComment.match.id,
+				Projections.constructor(MatchCommentMemberDto.class,
+					matchComment.member.publicId,
+					matchComment.member.nickname
+				),
+				matchComment.comment,
+				matchComment.ip,
+				matchComment.createDate
+			))
+			.from(matchComment)
+			.where(
+				isMatchEqualTo(matchId)
+			)
+			.orderBy(matchComment.createDate.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		long total = getTotalNewsCount(matchId);
+
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	private long getTotalNewsCount(Long matchId) {
+		return ofNullable(
+			queryFactory
+				.select(matchComment.count())
+				.from(matchComment)
+				.where(
+					isMatchEqualTo(matchId)
+				)
+				.fetchOne()
+		).orElse(0L);
+	}
+
+	private BooleanExpression isMatchEqualTo(Long matchId) {
+		return matchComment.match.id.eq(matchId);
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchComment/repository/MatchCommentRepository.java
+++ b/src/main/java/org/myteam/server/match/matchComment/repository/MatchCommentRepository.java
@@ -1,0 +1,9 @@
+package org.myteam.server.match.matchComment.repository;
+
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MatchCommentRepository extends JpaRepository<MatchComment, Long> {
+}

--- a/src/main/java/org/myteam/server/match/matchComment/repository/OrderType.java
+++ b/src/main/java/org/myteam/server/match/matchComment/repository/OrderType.java
@@ -1,0 +1,7 @@
+package org.myteam.server.match.matchComment.repository;
+
+public enum OrderType {
+	LIKE,
+	COMMENT,
+	VIEW
+}

--- a/src/main/java/org/myteam/server/match/matchComment/service/MatchCommentReadService.java
+++ b/src/main/java/org/myteam/server/match/matchComment/service/MatchCommentReadService.java
@@ -1,0 +1,48 @@
+package org.myteam.server.match.matchComment.service;
+
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.global.page.response.PageCustomResponse;
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.match.matchComment.dto.repository.MatchCommentDto;
+import org.myteam.server.match.matchComment.dto.service.request.MatchCommentServiceRequest;
+import org.myteam.server.match.matchComment.dto.service.response.MatchCommentListResponse;
+import org.myteam.server.match.matchComment.repository.MatchCommentLockRepository;
+import org.myteam.server.match.matchComment.repository.MatchCommentQueryRepository;
+import org.myteam.server.match.matchComment.repository.MatchCommentRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchCommentReadService {
+
+	private final MatchCommentRepository matchCommentRepository;
+	private final MatchCommentQueryRepository matchCommentQueryRepository;
+	private final MatchCommentLockRepository matchCommentLockRepository;
+
+	public MatchCommentListResponse findByMatchId(MatchCommentServiceRequest matchCommentServiceRequest) {
+
+		Page<MatchCommentDto> list = matchCommentQueryRepository.getNewsCommentList(
+			matchCommentServiceRequest.getMatchId(),
+			matchCommentServiceRequest.toPageable()
+		);
+
+		return MatchCommentListResponse.createResponse(PageCustomResponse.of(list));
+	}
+
+	public MatchComment findById(Long newsCommentId) {
+		return matchCommentRepository.findById(newsCommentId)
+			.orElseThrow(() -> new PlayHiveException(ErrorCode.MATCH_COMMENT_NOT_FOUND));
+	}
+
+	public MatchComment findByIdLock(Long newsCommentId) {
+		return matchCommentLockRepository.findById(newsCommentId)
+			.orElseThrow(() -> new PlayHiveException(ErrorCode.MATCH_COMMENT_NOT_FOUND));
+	}
+
+}

--- a/src/main/java/org/myteam/server/match/matchComment/service/MatchCommentService.java
+++ b/src/main/java/org/myteam/server/match/matchComment/service/MatchCommentService.java
@@ -1,0 +1,71 @@
+package org.myteam.server.match.matchComment.service;
+
+import org.myteam.server.match.match.domain.Match;
+import org.myteam.server.match.match.service.MatchReadService;
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.match.matchComment.dto.service.request.MatchCommentSaveServiceRequest;
+import org.myteam.server.match.matchComment.dto.service.request.MatchCommentUpdateServiceRequest;
+import org.myteam.server.match.matchComment.dto.service.response.MatchCommentResponse;
+import org.myteam.server.match.matchComment.repository.MatchCommentRepository;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.service.SecurityReadService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MatchCommentService {
+
+	private final MatchCommentRepository matchCommentRepository;
+	private final MatchCommentReadService matchCommentReadService;
+	private final MatchReadService matchReadService;
+	private final SecurityReadService securityReadService;
+	// private final MatchCountService newsCountService;
+
+	public MatchCommentResponse save(MatchCommentSaveServiceRequest matchCommentSaveServiceRequest) {
+		Match match = matchReadService.findById(matchCommentSaveServiceRequest.getMatchId());
+		Member member = securityReadService.getMember();
+
+		MatchComment matchComment = matchCommentRepository.save(
+			MatchComment.createEntity(match, member, matchCommentSaveServiceRequest.getComment(),
+				matchCommentSaveServiceRequest.getIp()));
+
+		// newsCountService.addCommendCount(matchComment.getId());
+
+		return MatchCommentResponse.createResponse(matchComment, member);
+	}
+
+	public Long update(MatchCommentUpdateServiceRequest matchCommentUpdateServiceRequest) {
+		Member member = securityReadService.getMember();
+		MatchComment matchComment = matchCommentReadService.findById(matchCommentUpdateServiceRequest.getMatchCommentId());
+
+		matchComment.confirmMember(member);
+		matchComment.updateComment(matchCommentUpdateServiceRequest.getComment());
+
+		return matchComment.getId();
+	}
+
+	public Long delete(Long matchCommentId) {
+		Member member = securityReadService.getMember();
+		MatchComment matchComment = matchCommentReadService.findById(matchCommentId);
+
+		matchComment.confirmMember(member);
+
+		matchCommentRepository.deleteById(matchCommentId);
+
+		// match.minusCommendCount(newsComment.getNews().getId());
+
+		return matchComment.getId();
+	}
+
+	public Long recommendComment(Long matchCommentId) {
+		Member member = securityReadService.getMember();
+		MatchComment matchComment = matchCommentReadService.findByIdLock(matchCommentId);
+
+		matchComment.addRecommendCount();
+		return matchComment.getId();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/controller/MatchReplyController.java
+++ b/src/main/java/org/myteam/server/match/matchReply/controller/MatchReplyController.java
@@ -1,0 +1,81 @@
+package org.myteam.server.match.matchReply.controller;
+
+import static org.myteam.server.global.web.response.ResponseStatus.*;
+
+import org.myteam.server.global.web.response.ResponseDto;
+import org.myteam.server.match.matchReply.dto.controller.request.MatchReplyRequest;
+import org.myteam.server.match.matchReply.dto.controller.request.MatchReplySaveRequest;
+import org.myteam.server.match.matchReply.dto.controller.request.MatchReplyUpdateRequest;
+import org.myteam.server.match.matchReply.dto.service.response.MatchReplyListResponse;
+import org.myteam.server.match.matchReply.dto.service.response.MatchReplyResponse;
+import org.myteam.server.match.matchReply.service.MatchReplyReadService;
+import org.myteam.server.match.matchReply.service.MatchReplyService;
+import org.myteam.server.util.ClientUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/match/reply")
+public class MatchReplyController {
+
+	private final MatchReplyService matchReplyService;
+	private final MatchReplyReadService matchReplyReadService;
+
+	@Operation(summary = "경기 대댓글 저장 API", description = "경기 댓글의 대댓글을 추가합니다.")
+	@PostMapping
+	public ResponseEntity<ResponseDto<MatchReplyResponse>> save(
+		@RequestBody @Valid MatchReplySaveRequest matchReplySaveRequest, HttpServletRequest request) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"경기 대댓글 저장 성공",
+			matchReplyService.save(matchReplySaveRequest.toServiceRequest(ClientUtils.getRemoteIP(request)))));
+	}
+
+	@Operation(summary = "경기 대댓글 목록 조회 API", description = "경기 댓글의 대댓글 목록을 조회합니다.")
+	@GetMapping
+	public ResponseEntity<ResponseDto<MatchReplyListResponse>> findByNewsCommentId(
+		@ModelAttribute @Valid MatchReplyRequest matchReplyRequest) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"경기 대댓글 조회 성공",
+			matchReplyReadService.findByMatchCommentId(matchReplyRequest.toServiceRequest())));
+	}
+
+	@Operation(summary = "경기 대댓글 수정 API", description = "경기 댓글의 대댓글을 수정합니다.")
+	@PatchMapping
+	public ResponseEntity<ResponseDto<Long>> update(
+		@RequestBody @Valid MatchReplyUpdateRequest matchReplyUpdateRequest) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"경기 대댓글 수정 성공",
+			matchReplyService.update(matchReplyUpdateRequest.toServiceRequest())));
+	}
+
+	@Operation(summary = "경기 대댓글 삭제 API", description = "경기 댓글의 대댓글을 삭제합니다.")
+	@DeleteMapping("/{matchReplyId}")
+	public ResponseEntity<ResponseDto<Long>> delete(
+		@PathVariable
+		@Parameter(description = "경기 대댓글 ID")
+		Long matchReplyId
+	) {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"경기 대댓글 삭제 성공",
+			matchReplyService.delete(matchReplyId)));
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/domain/MatchReply.java
+++ b/src/main/java/org/myteam/server/match/matchReply/domain/MatchReply.java
@@ -1,0 +1,62 @@
+package org.myteam.server.match.matchReply.domain;
+
+import org.myteam.server.global.domain.Base;
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.member.entity.Member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_match_reply")
+public class MatchReply extends Base {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private MatchComment matchComment;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member member;
+
+	private String comment;
+
+	private String ip;
+
+	@Builder
+	public MatchReply(Long id, MatchComment matchComment, Member member, String comment, String ip) {
+		this.id = id;
+		this.matchComment = matchComment;
+		this.member = member;
+		this.comment = comment;
+		this.ip = ip;
+	}
+
+	public void confirmMember(Member member) {
+		this.member.confirmMemberEquals(member);
+	}
+
+	public void updateComment(String comment) {
+		this.comment = comment;
+	}
+
+	public static MatchReply createEntity(MatchComment matchComment, Member member, String comment, String ip) {
+		return MatchReply.builder()
+			.matchComment(matchComment)
+			.member(member)
+			.comment(comment)
+			.ip(ip)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/controller/request/MatchReplyRequest.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/controller/request/MatchReplyRequest.java
@@ -1,0 +1,35 @@
+package org.myteam.server.match.matchReply.dto.controller.request;
+
+import org.myteam.server.global.page.request.PageInfoRequest;
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplyServiceRequest;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MatchReplyRequest extends PageInfoRequest {
+
+	@Schema(description = "경기 댓글 ID")
+	@NotNull(message = "경기 댓글 ID는 필수입니다.")
+	private Long matchCommentId;
+
+	@Builder
+	public MatchReplyRequest(Long matchCommentId, int page, int size) {
+		super(page, size);
+		this.matchCommentId = matchCommentId;
+	}
+
+	public MatchReplyServiceRequest toServiceRequest() {
+		return MatchReplyServiceRequest.builder()
+			.matchCommentId(matchCommentId)
+			.size(getSize())
+			.page(getPage())
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/controller/request/MatchReplySaveRequest.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/controller/request/MatchReplySaveRequest.java
@@ -1,0 +1,35 @@
+package org.myteam.server.match.matchReply.dto.controller.request;
+
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplySaveServiceRequest;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplySaveRequest {
+
+	@Schema(description = "경기 댓글 ID")
+	@NotNull(message = "경기 댓글 ID는 필수입니다.")
+	private Long matchCommentId;
+	@Schema(description = "경기 대댓글 내용")
+	@NotNull(message = "경기 대댓글은 필수입니다.")
+	private String comment;
+
+	@Builder
+	public MatchReplySaveRequest(Long matchCommentId, String comment) {
+		this.matchCommentId = matchCommentId;
+		this.comment = comment;
+	}
+
+	public MatchReplySaveServiceRequest toServiceRequest(String ip) {
+		return MatchReplySaveServiceRequest.builder()
+			.matchCommentId(matchCommentId)
+			.comment(comment)
+			.ip(ip)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/controller/request/MatchReplyUpdateRequest.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/controller/request/MatchReplyUpdateRequest.java
@@ -1,0 +1,34 @@
+package org.myteam.server.match.matchReply.dto.controller.request;
+
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplyUpdateServiceRequest;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplyUpdateRequest {
+
+	@Schema(description = "경기 대댓글 ID")
+	@NotNull(message = "경기 대댓글 ID는 필수입니다.")
+	private Long matchReplyId;
+	@Schema(description = "경기 대댓글 내용 ID")
+	@NotNull(message = "경기 대댓글 내용은 필수입니다.")
+	private String comment;
+
+	@Builder
+	public MatchReplyUpdateRequest(Long matchReplyId, String comment) {
+		this.matchReplyId = matchReplyId;
+		this.comment = comment;
+	}
+
+	public MatchReplyUpdateServiceRequest toServiceRequest() {
+		return MatchReplyUpdateServiceRequest.builder()
+			.matchReplyId(matchReplyId)
+			.comment(comment)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/repository/MatchReplyDto.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/repository/MatchReplyDto.java
@@ -1,0 +1,35 @@
+package org.myteam.server.match.matchReply.dto.repository;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplyDto {
+
+	@Schema(description = "경기 대댓글 ID")
+	private Long matchReplyId;
+	@Schema(description = "경기 댓글 ID")
+	private Long matchCommentId;
+	@Schema(description = "경기 작성자")
+	private MatchReplyMemberDto member;
+	@Schema(description = "경기 대댓글 내용")
+	private String comment;
+	@Schema(description = "경기 대댓글 작성시 IP")
+	private String ip;
+	@Schema(description = "경기 대댓글 작성날짜")
+	private LocalDateTime createTime;
+
+	public MatchReplyDto(Long matchReplyId, Long matchCommentId, MatchReplyMemberDto member, String comment,
+		String ip, LocalDateTime createTime) {
+		this.matchReplyId = matchReplyId;
+		this.matchCommentId = matchCommentId;
+		this.member = member;
+		this.comment = comment;
+		this.ip = ip;
+		this.createTime = createTime;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/repository/MatchReplyMemberDto.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/repository/MatchReplyMemberDto.java
@@ -1,0 +1,22 @@
+package org.myteam.server.match.matchReply.dto.repository;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplyMemberDto {
+
+	@Schema(description = "작성자 ID")
+	private UUID publicId;
+	@Schema(description = "작성자 닉네임")
+	private String nickName;
+
+	public MatchReplyMemberDto(UUID publicId, String nickName) {
+		this.publicId = publicId;
+		this.nickName = nickName;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/service/request/MatchReplySaveServiceRequest.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/service/request/MatchReplySaveServiceRequest.java
@@ -1,0 +1,20 @@
+package org.myteam.server.match.matchReply.dto.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplySaveServiceRequest {
+	private Long matchCommentId;
+	private String comment;
+	private String ip;
+
+	@Builder
+	public MatchReplySaveServiceRequest(Long matchCommentId, String comment, String ip) {
+		this.matchCommentId = matchCommentId;
+		this.comment = comment;
+		this.ip = ip;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/service/request/MatchReplyServiceRequest.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/service/request/MatchReplyServiceRequest.java
@@ -1,0 +1,20 @@
+package org.myteam.server.match.matchReply.dto.service.request;
+
+import org.myteam.server.global.page.request.PageInfoServiceRequest;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplyServiceRequest extends PageInfoServiceRequest {
+
+	private Long matchCommentId;
+
+	@Builder
+	public MatchReplyServiceRequest(Long matchCommentId, int size, int page) {
+		super(page, size);
+		this.matchCommentId = matchCommentId;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/service/request/MatchReplyUpdateServiceRequest.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/service/request/MatchReplyUpdateServiceRequest.java
@@ -1,0 +1,19 @@
+package org.myteam.server.match.matchReply.dto.service.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplyUpdateServiceRequest {
+
+	private Long matchReplyId;
+	private String comment;
+
+	@Builder
+	public MatchReplyUpdateServiceRequest(Long matchReplyId, String comment) {
+		this.matchReplyId = matchReplyId;
+		this.comment = comment;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/service/response/MatchReplyListResponse.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/service/response/MatchReplyListResponse.java
@@ -1,0 +1,26 @@
+package org.myteam.server.match.matchReply.dto.service.response;
+
+import org.myteam.server.global.page.response.PageCustomResponse;
+import org.myteam.server.match.matchReply.dto.repository.MatchReplyDto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplyListResponse {
+
+	private PageCustomResponse<MatchReplyDto> list;
+
+	@Builder
+	public MatchReplyListResponse(PageCustomResponse<MatchReplyDto> list) {
+		this.list = list;
+	}
+
+	public static MatchReplyListResponse createResponse(PageCustomResponse<MatchReplyDto> list) {
+		return MatchReplyListResponse.builder()
+			.list(list)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/service/response/MatchReplyMemberResponse.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/service/response/MatchReplyMemberResponse.java
@@ -1,0 +1,24 @@
+package org.myteam.server.match.matchReply.dto.service.response;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplyMemberResponse {
+
+	@Schema(description = "작성자 ID")
+	private UUID publicId;
+	@Schema(description = "작성자 닉네임")
+	private String nickName;
+
+	@Builder
+	public MatchReplyMemberResponse(UUID publicId, String nickName) {
+		this.publicId = publicId;
+		this.nickName = nickName;
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/dto/service/response/MatchReplyResponse.java
+++ b/src/main/java/org/myteam/server/match/matchReply/dto/service/response/MatchReplyResponse.java
@@ -1,0 +1,52 @@
+package org.myteam.server.match.matchReply.dto.service.response;
+
+import java.time.LocalDateTime;
+
+import org.myteam.server.match.matchReply.domain.MatchReply;
+import org.myteam.server.member.entity.Member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchReplyResponse {
+
+	@Schema(description = "경기 대댓글 ID")
+	private Long matchReplyId;
+	@Schema(description = "경기 댓글 ID")
+	private Long matchCommentId;
+	@Schema(description = "경기 작성자")
+	private MatchReplyMemberResponse member;
+	@Schema(description = "경기 대댓글 내용")
+	private String comment;
+	@Schema(description = "경기 대댓글 작성날짜")
+	private LocalDateTime createDate;
+
+	@Builder
+	public MatchReplyResponse(Long matchReplyId, Long matchCommentId, MatchReplyMemberResponse member, String comment,
+		LocalDateTime createDate) {
+		this.matchReplyId = matchReplyId;
+		this.matchCommentId = matchCommentId;
+		this.member = member;
+		this.comment = comment;
+		this.createDate = createDate;
+	}
+
+	public static MatchReplyResponse createResponse(MatchReply matchReply, Member member) {
+		return MatchReplyResponse.builder()
+			.matchReplyId(matchReply.getId())
+			.matchCommentId(matchReply.getMatchComment().getId())
+			.member(
+				MatchReplyMemberResponse.builder()
+					.publicId(member.getPublicId())
+					.nickName(member.getNickname())
+					.build()
+			)
+			.comment(matchReply.getComment())
+			.createDate(matchReply.getCreateDate())
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/repository/MatchReplyQueryRepository.java
+++ b/src/main/java/org/myteam/server/match/matchReply/repository/MatchReplyQueryRepository.java
@@ -1,0 +1,69 @@
+package org.myteam.server.match.matchReply.repository;
+
+import static java.util.Optional.*;
+import static org.myteam.server.match.matchReply.domain.QMatchReply.*;
+
+import java.util.List;
+
+import org.myteam.server.match.matchReply.dto.repository.MatchReplyDto;
+import org.myteam.server.match.matchReply.dto.repository.MatchReplyMemberDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MatchReplyQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	public Page<MatchReplyDto> getMatchReplyList(Long matchCommentId, Pageable pageable) {
+		List<MatchReplyDto> content = queryFactory
+			.select(Projections.constructor(MatchReplyDto.class,
+				matchReply.id,
+				matchReply.matchComment.id,
+				Projections.constructor(MatchReplyMemberDto.class,
+					matchReply.member.publicId,
+					matchReply.member.nickname
+				),
+				matchReply.comment,
+				matchReply.ip,
+				matchReply.createDate
+			))
+			.from(matchReply)
+			.where(
+				isMatchCommentEqualTo(matchCommentId)
+			)
+			.orderBy(matchReply.createDate.asc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		long total = getTotalMatchReplyCount(matchCommentId);
+
+		return new PageImpl<>(content, pageable, total);
+	}
+
+	private long getTotalMatchReplyCount(Long matchCommentId) {
+		return ofNullable(
+			queryFactory
+				.select(matchReply.count())
+				.from(matchReply)
+				.where(
+					isMatchCommentEqualTo(matchCommentId)
+				)
+				.fetchOne()
+		).orElse(0L);
+	}
+
+	private BooleanExpression isMatchCommentEqualTo(Long matchCommentId) {
+		return matchReply.matchComment.id.eq(matchCommentId);
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchReply/repository/MatchReplyRepository.java
+++ b/src/main/java/org/myteam/server/match/matchReply/repository/MatchReplyRepository.java
@@ -1,0 +1,9 @@
+package org.myteam.server.match.matchReply.repository;
+
+import org.myteam.server.match.matchReply.domain.MatchReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MatchReplyRepository extends JpaRepository<MatchReply, Long> {
+}

--- a/src/main/java/org/myteam/server/match/matchReply/service/MatchReplyReadService.java
+++ b/src/main/java/org/myteam/server/match/matchReply/service/MatchReplyReadService.java
@@ -1,0 +1,40 @@
+package org.myteam.server.match.matchReply.service;
+
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.global.page.response.PageCustomResponse;
+import org.myteam.server.match.matchReply.domain.MatchReply;
+import org.myteam.server.match.matchReply.dto.repository.MatchReplyDto;
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplyServiceRequest;
+import org.myteam.server.match.matchReply.dto.service.response.MatchReplyListResponse;
+import org.myteam.server.match.matchReply.repository.MatchReplyQueryRepository;
+import org.myteam.server.match.matchReply.repository.MatchReplyRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchReplyReadService {
+
+	private final MatchReplyRepository matchReplyRepository;
+	private final MatchReplyQueryRepository matchReplyQueryRepository;
+
+	public MatchReplyListResponse findByMatchCommentId(MatchReplyServiceRequest matchReplyServiceRequest) {
+		Page<MatchReplyDto> list = matchReplyQueryRepository.getMatchReplyList(
+			matchReplyServiceRequest.getMatchCommentId(),
+			matchReplyServiceRequest.toPageable()
+		);
+
+		return MatchReplyListResponse.createResponse(PageCustomResponse.of(list));
+	}
+
+	public MatchReply findById(Long matchReplyId) {
+		return matchReplyRepository.findById(matchReplyId)
+			.orElseThrow(() -> new PlayHiveException(ErrorCode.MATCH_REPLY_NOT_FOUND));
+	}
+
+}

--- a/src/main/java/org/myteam/server/match/matchReply/service/MatchReplyService.java
+++ b/src/main/java/org/myteam/server/match/matchReply/service/MatchReplyService.java
@@ -1,0 +1,57 @@
+package org.myteam.server.match.matchReply.service;
+
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.match.matchComment.service.MatchCommentReadService;
+import org.myteam.server.match.matchReply.domain.MatchReply;
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplySaveServiceRequest;
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplyUpdateServiceRequest;
+import org.myteam.server.match.matchReply.dto.service.response.MatchReplyResponse;
+import org.myteam.server.match.matchReply.repository.MatchReplyRepository;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.service.SecurityReadService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MatchReplyService {
+
+	private final MatchReplyRepository matchReplyRepository;
+	private final MatchReplyReadService matchReplyReadService;
+	private final MatchCommentReadService matchCommentReadService;
+	private final SecurityReadService securityReadService;
+
+	public MatchReplyResponse save(MatchReplySaveServiceRequest matchReplySaveServiceRequest) {
+		MatchComment matchComment = matchCommentReadService.findById(matchReplySaveServiceRequest.getMatchCommentId());
+		Member member = securityReadService.getMember();
+
+		return MatchReplyResponse.createResponse(
+			matchReplyRepository.save(
+				MatchReply.createEntity(matchComment, member, matchReplySaveServiceRequest.getComment(),
+					matchReplySaveServiceRequest.getIp())), member
+		);
+	}
+
+	public Long update(MatchReplyUpdateServiceRequest matchReplyUpdateServiceRequest) {
+		Member member = securityReadService.getMember();
+		MatchReply matchReply = matchReplyReadService.findById(matchReplyUpdateServiceRequest.getMatchReplyId());
+
+		matchReply.confirmMember(member);
+		matchReply.updateComment(matchReplyUpdateServiceRequest.getComment());
+
+		return matchReply.getId();
+	}
+
+	public Long delete(Long matchReplyId) {
+		Member member = securityReadService.getMember();
+		MatchReply matchReply = matchReplyReadService.findById(matchReplyId);
+
+		matchReply.confirmMember(member);
+
+		matchReplyRepository.deleteById(matchReplyId);
+		return matchReply.getId();
+	}
+}

--- a/src/test/java/org/myteam/server/ControllerTestSupport.java
+++ b/src/test/java/org/myteam/server/ControllerTestSupport.java
@@ -2,9 +2,15 @@ package org.myteam.server;
 
 import org.myteam.server.match.match.controller.MatchController;
 import org.myteam.server.match.match.service.MatchReadService;
+import org.myteam.server.match.matchComment.controller.MatchCommentController;
+import org.myteam.server.match.matchComment.service.MatchCommentReadService;
+import org.myteam.server.match.matchComment.service.MatchCommentService;
 import org.myteam.server.match.matchPrediction.controller.MatchPredictionController;
 import org.myteam.server.match.matchPrediction.service.MatchPredictionReadService;
 import org.myteam.server.match.matchPrediction.service.MatchPredictionService;
+import org.myteam.server.match.matchReply.controller.MatchReplyController;
+import org.myteam.server.match.matchReply.service.MatchReplyReadService;
+import org.myteam.server.match.matchReply.service.MatchReplyService;
 import org.myteam.server.member.repository.MemberJpaRepository;
 import org.myteam.server.member.service.MemberService;
 import org.myteam.server.news.news.controller.NewsController;
@@ -30,7 +36,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 	NewsCommentController.class,
 	NewsReplyController.class,
 	MatchController.class,
-	MatchPredictionController.class
+	MatchPredictionController.class,
+	MatchCommentController.class,
+	MatchReplyController.class
 })
 @MockBean(JpaMetamodelMappingContext.class)
 public abstract class ControllerTestSupport {
@@ -59,6 +67,14 @@ public abstract class ControllerTestSupport {
 	protected MatchPredictionReadService matchPredictionReadService;
 	@MockBean
 	protected MatchPredictionService matchPredictionService;
+	@MockBean
+	protected MatchCommentReadService matchCommentReadService;
+	@MockBean
+	protected MatchCommentService matchCommentService;
+	@MockBean
+	protected MatchReplyReadService matchReplyReadService;
+	@MockBean
+	protected MatchReplyService matchReplyService;
 
 }
 

--- a/src/test/java/org/myteam/server/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/IntegrationTestSupport.java
@@ -16,8 +16,12 @@ import org.myteam.server.inquiry.service.InquiryService;
 import org.myteam.server.match.match.domain.Match;
 import org.myteam.server.match.match.domain.MatchCategory;
 import org.myteam.server.match.match.repository.MatchRepository;
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.match.matchComment.repository.MatchCommentRepository;
 import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
 import org.myteam.server.match.matchPrediction.repository.MatchPredictionRepository;
+import org.myteam.server.match.matchReply.domain.MatchReply;
+import org.myteam.server.match.matchReply.repository.MatchReplyRepository;
 import org.myteam.server.match.team.domain.Team;
 import org.myteam.server.match.team.domain.TeamCategory;
 import org.myteam.server.match.team.repository.TeamRepository;
@@ -51,7 +55,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
-import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @ActiveProfiles("test")
@@ -87,6 +90,10 @@ public abstract class IntegrationTestSupport {
 	protected InquiryAnswerRepository inquiryAnswerRepository;
 	@Autowired
 	protected MatchPredictionRepository matchPredictionRepository;
+	@Autowired
+	protected MatchCommentRepository matchCommentRepository;
+	@Autowired
+	protected MatchReplyRepository matchReplyRepository;
 
 	/**
 	 * ================== Service ========================
@@ -119,12 +126,13 @@ public abstract class IntegrationTestSupport {
 	protected S3Controller s3Controller;
 	@MockBean
 	protected S3Service s3Service;
-	protected S3Client s3Client;
 	@MockBean
 	protected SlackService slackService;
 
 	@AfterEach
 	void tearDown() {
+		matchReplyRepository.deleteAllInBatch();
+		matchCommentRepository.deleteAllInBatch();
 		matchPredictionRepository.deleteAllInBatch();
 		matchRepository.deleteAllInBatch();
 		teamRepository.deleteAllInBatch();
@@ -180,7 +188,7 @@ public abstract class IntegrationTestSupport {
 		return savedNews;
 	}
 
-	protected NewsComment craeteNewsComment(News news, Member member, String comment) {
+	protected NewsComment createNewsComment(News news, Member member, String comment) {
 		return newsCommentRepository.save(
 			NewsComment.builder()
 				.news(news)
@@ -235,5 +243,27 @@ public abstract class IntegrationTestSupport {
 			.home(home)
 			.away(away)
 			.build());
+	}
+
+	protected MatchComment createMatchComment(Match match, Member member, String comment) {
+		return matchCommentRepository.save(
+			MatchComment.builder()
+				.match(match)
+				.member(member)
+				.comment(comment)
+				.ip("1.1.1.1")
+				.build()
+		);
+	}
+
+	protected MatchReply createMatchReply(MatchComment matchComment, Member member, String comment) {
+		return matchReplyRepository.save(
+			MatchReply.builder()
+				.matchComment(matchComment)
+				.member(member)
+				.comment(comment)
+				.ip("1.1.1.1")
+				.build()
+		);
 	}
 }

--- a/src/test/java/org/myteam/server/match/matchComment/controller/MatchCommentControllerTest.java
+++ b/src/test/java/org/myteam/server/match/matchComment/controller/MatchCommentControllerTest.java
@@ -1,0 +1,223 @@
+package org.myteam.server.match.matchComment.controller;
+
+import static org.myteam.server.global.web.response.ResponseStatus.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.ControllerTestSupport;
+import org.myteam.server.match.matchComment.dto.controller.request.MatchCommentRequest;
+import org.myteam.server.match.matchComment.dto.controller.request.MatchCommentSaveRequest;
+import org.myteam.server.match.matchComment.dto.controller.request.MatchCommentUpdateRequest;
+import org.springframework.security.test.context.support.WithMockUser;
+
+class MatchCommentControllerTest extends ControllerTestSupport {
+
+	@DisplayName("경기 댓글을 저장한다.")
+	@Test
+	@WithMockUser
+	void saveTest() throws Exception {
+		// given
+		MatchCommentSaveRequest matchCommentSaveRequest = MatchCommentSaveRequest.builder()
+			.matchId(1L)
+			.comment("댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/match/comment")
+					.content(objectMapper.writeValueAsString(matchCommentSaveRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("경기 댓글 저장 성공"));
+	}
+
+	@DisplayName("경기 댓글을 저장시 경기ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void saveWithoutMatchIdTest() throws Exception {
+		// given
+		MatchCommentSaveRequest matchCommentSaveRequest = MatchCommentSaveRequest.builder()
+			.comment("댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/match/comment")
+					.content(objectMapper.writeValueAsString(matchCommentSaveRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기ID는 필수입니다."));
+	}
+
+	@DisplayName("경기 댓글을 저장시 댓글 필수이다.")
+	@Test
+	@WithMockUser
+	void saveWithoutCommentTest() throws Exception {
+		// given
+		MatchCommentSaveRequest matchCommentSaveRequest = MatchCommentSaveRequest.builder()
+			.matchId(1L)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/match/comment")
+					.content(objectMapper.writeValueAsString(matchCommentSaveRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기 댓글은 필수입니다."));
+	}
+
+	@DisplayName("경기 댓글 목록을 조회한다.")
+	@Test
+	@WithMockUser
+	void findAllTest() throws Exception {
+		// given
+		MatchCommentRequest matchCommentRequest = MatchCommentRequest.builder()
+			.page(1)
+			.size(10)
+			.matchId(1L)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				get("/api/match/comment")
+					.param("page", String.valueOf(matchCommentRequest.getPage()))
+					.param("size", String.valueOf(matchCommentRequest.getSize()))
+					.param("matchId", String.valueOf(matchCommentRequest.getMatchId()))
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("경기 댓글 조회 성공"));
+	}
+
+	@DisplayName("경기 목록을 조회시 경기ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void findAllWithoutOrderTypeTest() throws Exception {
+		// given
+		MatchCommentRequest matchCommentRequest = MatchCommentRequest.builder()
+			.page(1)
+			.size(10)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				get("/api/match/comment")
+					.param("page", String.valueOf(matchCommentRequest.getPage()))
+					.param("size", String.valueOf(matchCommentRequest.getSize()))
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기 ID는 필수입니다."));
+	}
+
+	@DisplayName("경기 댓글을 수정한다.")
+	@Test
+	@WithMockUser
+	void updateTest() throws Exception {
+		// given
+		MatchCommentUpdateRequest matchCommentUpdateRequest = MatchCommentUpdateRequest.builder()
+			.matchCommentId(1L)
+			.comment("경기 댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/match/comment")
+					.content(objectMapper.writeValueAsString(matchCommentUpdateRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("경기 댓글 수정 성공"));
+	}
+
+	@DisplayName("경기 댓글을 수정시 경기 댓글ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void updateWithoutCommentIdTest() throws Exception {
+		// given
+		MatchCommentUpdateRequest matchCommentUpdateRequest = MatchCommentUpdateRequest.builder()
+			.comment("뉴스 댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/match/comment")
+					.content(objectMapper.writeValueAsString(matchCommentUpdateRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기 댓글 ID는 필수입니다."));
+	}
+
+	@DisplayName("경기 댓글을 수정시 댓글 내용은 필수이다.")
+	@Test
+	@WithMockUser
+	void updateWithoutCommentTest() throws Exception {
+		// given
+		MatchCommentUpdateRequest matchCommentUpdateRequest = MatchCommentUpdateRequest.builder()
+			.matchCommentId(1L)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/match/comment")
+					.content(objectMapper.writeValueAsString(matchCommentUpdateRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기 댓글 내용은 필수입니다."));
+	}
+
+	@DisplayName("경기 댓글을 삭제한다.")
+	@Test
+	@WithMockUser
+	void deleteTest() throws Exception {
+		// given
+		// when // then
+		mockMvc.perform(
+				delete("/api/match/comment/{matchCommentId}", 1L)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("경기 댓글 삭제 성공"));
+	}
+}

--- a/src/test/java/org/myteam/server/match/matchComment/service/MatchCommentReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/matchComment/service/MatchCommentReadServiceTest.java
@@ -1,0 +1,109 @@
+package org.myteam.server.match.matchComment.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.global.page.response.PageableCustomResponse;
+import org.myteam.server.match.match.domain.Match;
+import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.match.matchComment.dto.repository.MatchCommentDto;
+import org.myteam.server.match.matchComment.dto.service.request.MatchCommentServiceRequest;
+import org.myteam.server.match.matchComment.dto.service.response.MatchCommentListResponse;
+import org.myteam.server.match.team.domain.Team;
+import org.myteam.server.match.team.domain.TeamCategory;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.news.domain.News;
+import org.myteam.server.news.news.domain.NewsCategory;
+import org.myteam.server.news.newsComment.domain.NewsComment;
+import org.myteam.server.news.newsComment.dto.repository.NewsCommentDto;
+import org.myteam.server.news.newsComment.dto.service.request.NewsCommentServiceRequest;
+import org.myteam.server.news.newsComment.dto.service.response.NewsCommentListResponse;
+import org.myteam.server.news.newsComment.service.NewsCommentReadService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class MatchCommentReadServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private MatchCommentReadService matchCommentReadService;
+
+	@DisplayName("경기 댓글 ID로 경기댓글을 조회한다.")
+	@Test
+	void findByIdTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchComment matchComment = createMatchComment(match, member, "경기 댓글 테스트");
+
+		MatchComment findMatchComment = matchCommentReadService.findById(matchComment.getId());
+
+		assertThat(findMatchComment)
+			.extracting("id", "match.id", "member.publicId", "comment")
+			.contains(matchComment.getId(), match.getId(), member.getPublicId(), "경기 댓글 테스트");
+	}
+
+	@DisplayName("경기 댓글 ID로 조회시 조회하지 않으면 예외가 발생한다.")
+	@Test
+	void findByIdNotExistThrowExceptionTest() {
+		assertThatThrownBy(() -> matchCommentReadService.findById(1L))
+			.isInstanceOf(PlayHiveException.class)
+			.hasMessage(ErrorCode.MATCH_COMMENT_NOT_FOUND.getMsg());
+	}
+
+	@DisplayName("경기ID로 댓글리스트를 조회한다.")
+	@Test
+	void findByMatchIdTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchComment matchComment1 = createMatchComment(match, member, "경기 댓글 테스트1");
+		MatchComment matchComment2 = createMatchComment(match, member, "경기 댓글 테스트2");
+
+		MatchCommentServiceRequest matchCommentServiceRequest = MatchCommentServiceRequest.builder()
+			.matchId(match.getId())
+			.page(1)
+			.size(10)
+			.build();
+
+		MatchCommentListResponse matchCommentListResponse = matchCommentReadService.findByMatchId(
+			matchCommentServiceRequest);
+
+		List<MatchCommentDto> matchCommentList = matchCommentListResponse.getList().getContent();
+		PageableCustomResponse pageInfo = matchCommentListResponse.getList().getPageInfo();
+
+		assertAll(
+			() -> assertThat(pageInfo)
+				.extracting("currentPage", "totalPage", "totalElement")
+				.containsExactlyInAnyOrder(
+					1, 1, 2L
+				),
+			() -> assertThat(matchCommentList)
+				.extracting("matchCommentId", "matchId", "memberDto.publicId", "memberDto.nickName", "comment")
+				.contains(
+					Tuple.tuple(matchComment1.getId(), matchComment1.getMatch().getId(), matchComment1.getMember().getPublicId(),
+						"test",
+						"경기 댓글 테스트1"),
+					Tuple.tuple(matchComment2.getId(), matchComment2.getMatch().getId(), matchComment2.getMember().getPublicId(),
+						"test",
+						"경기 댓글 테스트2")
+				)
+		);
+	}
+}

--- a/src/test/java/org/myteam/server/match/matchComment/service/MatchCommentServiceTest.java
+++ b/src/test/java/org/myteam/server/match/matchComment/service/MatchCommentServiceTest.java
@@ -1,0 +1,110 @@
+package org.myteam.server.match.matchComment.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.match.match.domain.Match;
+import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.match.matchComment.dto.service.request.MatchCommentSaveServiceRequest;
+import org.myteam.server.match.matchComment.dto.service.request.MatchCommentUpdateServiceRequest;
+import org.myteam.server.match.matchComment.dto.service.response.MatchCommentResponse;
+import org.myteam.server.match.team.domain.Team;
+import org.myteam.server.match.team.domain.TeamCategory;
+import org.myteam.server.member.entity.Member;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+public class MatchCommentServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private MatchCommentService matchCommentService;
+
+	@DisplayName("경기댓글을 저장한다.")
+	@Test
+	@Transactional
+	void saveTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchCommentSaveServiceRequest matchCommentSaveServiceRequest = MatchCommentSaveServiceRequest.builder()
+			.matchId(match.getId())
+			.comment("댓글 테스트")
+			.ip("1.1.1.1")
+			.build();
+
+		MatchCommentResponse matchCommentResponse = matchCommentService.save(matchCommentSaveServiceRequest);
+
+		assertThat(matchCommentRepository.findById(matchCommentResponse.getMatchCommentId()).get())
+			.extracting("id", "match.id", "member.publicId", "comment", "ip")
+			.contains(matchCommentResponse.getMatchCommentId(), match.getId(), member.getPublicId(), "댓글 테스트", "1.1.1.1");
+
+		// assertAll(
+		// 	() -> assertThat(matchCommentRepository.findById(matchCommentResponse.getMatchCommentId()).get())
+		// 		.extracting("id", "match.id", "member.publicId", "comment", "ip")
+		// 		.contains(matchCommentResponse.getMatchCommentId(), match.getId(), member.getPublicId(), "댓글 테스트", "1.1.1.1");
+		// 	() -> assertThat(newsCountRepository.findByNewsId(match.getId()).get().getCommentCount()).isEqualTo(11)
+		// );
+	}
+
+	@DisplayName("경기댓글을 수정한다.")
+	@Test
+	void updateTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchComment matchComment = createMatchComment(match, member, "경기 댓글 테스트");
+
+		MatchCommentUpdateServiceRequest matchCommentUpdateServiceRequest = MatchCommentUpdateServiceRequest.builder()
+			.matchCommentId(matchComment.getId())
+			.comment("경기 댓글 수정 테스트")
+			.build();
+
+		Long updatedCommentId = matchCommentService.update(matchCommentUpdateServiceRequest);
+
+		assertThat(matchCommentRepository.findById(updatedCommentId).get())
+			.extracting("id", "match.id", "member.publicId", "comment", "ip")
+			.contains(matchComment.getId(), match.getId(), member.getPublicId(), "경기 댓글 수정 테스트", "1.1.1.1");
+	}
+
+	@DisplayName("경기댓글을 삭제한다.")
+	@Test
+	@Transactional
+	void deleteTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchComment matchComment = createMatchComment(match, member, "경기 댓글 테스트");
+
+		Long deletedCommentId = matchCommentService.delete(matchComment.getId());
+
+		assertThatThrownBy(() -> matchCommentService.delete(deletedCommentId))
+			.isInstanceOf(PlayHiveException.class)
+			.hasMessage(ErrorCode.MATCH_COMMENT_NOT_FOUND.getMsg());
+
+		// assertAll(
+		// 	() -> assertThatThrownBy(() -> newsCommentService.delete(deletedCommentId))
+		// 		.isInstanceOf(PlayHiveException.class)
+		// 		.hasMessage(ErrorCode.NEWS_COMMENT_NOT_FOUND.getMsg()),
+		// 	() -> assertThat(newsCountRepository.findByNewsId(news.getId()).get().getCommentCount()).isEqualTo(9)
+		// );
+	}
+}

--- a/src/test/java/org/myteam/server/match/matchReply/controller/MatchReplyControllerTest.java
+++ b/src/test/java/org/myteam/server/match/matchReply/controller/MatchReplyControllerTest.java
@@ -1,0 +1,223 @@
+package org.myteam.server.match.matchReply.controller;
+
+import static org.myteam.server.global.web.response.ResponseStatus.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.ControllerTestSupport;
+import org.myteam.server.match.matchReply.dto.controller.request.MatchReplyRequest;
+import org.myteam.server.match.matchReply.dto.controller.request.MatchReplySaveRequest;
+import org.myteam.server.match.matchReply.dto.controller.request.MatchReplyUpdateRequest;
+import org.springframework.security.test.context.support.WithMockUser;
+
+class MatchReplyControllerTest extends ControllerTestSupport {
+
+	@DisplayName("경기 대댓글을 저장한다.")
+	@Test
+	@WithMockUser
+	void saveTest() throws Exception {
+		// given
+		MatchReplySaveRequest matchReplySaveRequest = MatchReplySaveRequest.builder()
+			.matchCommentId(1L)
+			.comment("대댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/match/reply")
+					.content(objectMapper.writeValueAsString(matchReplySaveRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("경기 대댓글 저장 성공"));
+	}
+
+	@DisplayName("경기 대댓글을 저장시 경기ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void saveWithoutNewsIdTest() throws Exception {
+		// given
+		MatchReplySaveRequest matchReplySaveRequest = MatchReplySaveRequest.builder()
+			.comment("대댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/match/reply")
+					.content(objectMapper.writeValueAsString(matchReplySaveRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기 댓글 ID는 필수입니다."));
+	}
+
+	@DisplayName("경기 대댓글을 저장시 경기ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void saveWithoutCommentTest() throws Exception {
+		// given
+		MatchReplySaveRequest matchReplySaveRequest = MatchReplySaveRequest.builder()
+			.matchCommentId(1L)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				post("/api/match/reply")
+					.content(objectMapper.writeValueAsString(matchReplySaveRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기 대댓글은 필수입니다."));
+	}
+
+	@DisplayName("경기 대댓글 목록을 조회한다.")
+	@Test
+	@WithMockUser
+	void findAllTest() throws Exception {
+		// given
+		MatchReplyRequest matchReplyRequest = MatchReplyRequest.builder()
+			.page(1)
+			.size(10)
+			.matchCommentId(1L)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				get("/api/match/reply")
+					.param("page", String.valueOf(matchReplyRequest.getPage()))
+					.param("size", String.valueOf(matchReplyRequest.getSize()))
+					.param("matchCommentId", String.valueOf(matchReplyRequest.getMatchCommentId()))
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("경기 대댓글 조회 성공"));
+	}
+
+	@DisplayName("대댓글 조회시 경기 대댓글 ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void findAllWithoutOrderTypeTest() throws Exception {
+		// given
+		MatchReplyRequest matchReplyRequest = MatchReplyRequest.builder()
+			.page(1)
+			.size(10)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				get("/api/match/reply")
+					.param("page", String.valueOf(matchReplyRequest.getPage()))
+					.param("size", String.valueOf(matchReplyRequest.getSize()))
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기 댓글 ID는 필수입니다."));
+	}
+
+	@DisplayName("경기 대댓글을 수정한다.")
+	@Test
+	@WithMockUser
+	void updateTest() throws Exception {
+		// given
+		MatchReplyUpdateRequest matchReplyUpdateRequest = MatchReplyUpdateRequest.builder()
+			.matchReplyId(1L)
+			.comment("경기 대댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/match/reply")
+					.content(objectMapper.writeValueAsString(matchReplyUpdateRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("경기 대댓글 수정 성공"));
+	}
+
+	@DisplayName("경기 대댓글을 수정시 경기대댓글ID는 필수이다.")
+	@Test
+	@WithMockUser
+	void updateWithoutCommentIdTest() throws Exception {
+		// given
+		MatchReplyUpdateRequest matchReplyUpdateRequest = MatchReplyUpdateRequest.builder()
+			.comment("경기 대댓글 테스트")
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/match/reply")
+					.content(objectMapper.writeValueAsString(matchReplyUpdateRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기 대댓글 ID는 필수입니다."));
+	}
+
+	@DisplayName("경기 대댓글을 수정시 대댓글 내용은 필수이다.")
+	@Test
+	@WithMockUser
+	void updateWithoutCommentTest() throws Exception {
+		// given
+		MatchReplyUpdateRequest matchReplyUpdateRequest = MatchReplyUpdateRequest.builder()
+			.matchReplyId(1L)
+			.build();
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/match/reply")
+					.content(objectMapper.writeValueAsString(matchReplyUpdateRequest))
+					.contentType(APPLICATION_JSON)
+					.accept(APPLICATION_JSON)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value("경기 대댓글 내용은 필수입니다."));
+	}
+
+	@DisplayName("경기 대댓글을 삭제한다.")
+	@Test
+	@WithMockUser
+	void deleteTest() throws Exception {
+		// given
+		// when // then
+		mockMvc.perform(
+				delete("/api/match/reply/{matchReplyId}", 1L)
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("경기 대댓글 삭제 성공"));
+	}
+}

--- a/src/test/java/org/myteam/server/match/matchReply/service/MatchReplyReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/matchReply/service/MatchReplyReadServiceTest.java
@@ -1,0 +1,108 @@
+package org.myteam.server.match.matchReply.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.global.page.response.PageableCustomResponse;
+import org.myteam.server.match.match.domain.Match;
+import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.match.matchReply.domain.MatchReply;
+import org.myteam.server.match.matchReply.dto.repository.MatchReplyDto;
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplyServiceRequest;
+import org.myteam.server.match.matchReply.dto.service.response.MatchReplyListResponse;
+import org.myteam.server.match.team.domain.Team;
+import org.myteam.server.match.team.domain.TeamCategory;
+import org.myteam.server.member.entity.Member;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class MatchReplyReadServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private MatchReplyReadService matchReplyReadService;
+
+	@DisplayName("경기 대댓글 ID로 경기 대댓글을 조회한다.")
+	@Test
+	void findByIdTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchComment matchComment = createMatchComment(match, member, "경기 댓글 테스트");
+
+		MatchReply matchReply = createMatchReply(matchComment, member, "경기 대댓글 테스트");
+
+		MatchReply findMatchReply = matchReplyReadService.findById(matchReply.getId());
+
+		assertThat(findMatchReply)
+			.extracting("id", "matchComment.id", "member.publicId", "comment")
+			.contains(matchReply.getId(), matchComment.getId(), member.getPublicId(), "경기 대댓글 테스트");
+	}
+
+	@DisplayName("경기 댓글 ID로 조회시 존재하지 않으면 예외가 발생한다.")
+	@Test
+	void findByIdNotExistThrowExceptionTest() {
+		assertThatThrownBy(() -> matchReplyReadService.findById(1L))
+			.isInstanceOf(PlayHiveException.class)
+			.hasMessage(ErrorCode.MATCH_REPLY_NOT_FOUND.getMsg());
+	}
+
+	@DisplayName("댓글ID로 대댓글리스트를 조회한다.")
+	@Test
+	void findByMatchIdTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchComment matchComment = createMatchComment(match, member, "경기 댓글 테스트");
+
+		MatchReply matchReply1 = createMatchReply(matchComment, member, "경기 대댓글 테스트1");
+		MatchReply matchReply2 = createMatchReply(matchComment, member, "경기 대댓글 테스트2");
+		MatchReply matchReply3 = createMatchReply(matchComment, member, "경기 대댓글 테스트3");
+
+		MatchReplyServiceRequest matchReplyServiceRequest = MatchReplyServiceRequest.builder()
+			.matchCommentId(matchComment.getId())
+			.page(1)
+			.size(2)
+			.build();
+
+		MatchReplyListResponse matchReplyListResponse = matchReplyReadService.findByMatchCommentId(
+			matchReplyServiceRequest);
+
+		List<MatchReplyDto> matchReplyList = matchReplyListResponse.getList().getContent();
+		PageableCustomResponse pageInfo = matchReplyListResponse.getList().getPageInfo();
+
+		assertAll(
+			() -> assertThat(pageInfo)
+				.extracting("currentPage", "totalPage", "totalElement")
+				.containsExactlyInAnyOrder(
+					1, 2, 3L
+				),
+			() -> assertThat(matchReplyList)
+				.extracting("matchReplyId", "matchCommentId", "member.publicId", "member.nickName", "comment")
+				.contains(
+					Tuple.tuple(matchReply1.getId(), matchReply1.getMatchComment().getId(), matchReply1.getMember().getPublicId(),
+						"test",
+						"경기 대댓글 테스트1"),
+					Tuple.tuple(matchReply2.getId(), matchReply2.getMatchComment().getId(), matchReply2.getMember().getPublicId(),
+						"test",
+						"경기 대댓글 테스트2")
+				)
+		);
+	}
+}

--- a/src/test/java/org/myteam/server/match/matchReply/service/NewsReplyServiceTest.java
+++ b/src/test/java/org/myteam/server/match/matchReply/service/NewsReplyServiceTest.java
@@ -1,0 +1,111 @@
+package org.myteam.server.match.matchReply.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.match.match.domain.Match;
+import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.matchComment.domain.MatchComment;
+import org.myteam.server.match.matchReply.domain.MatchReply;
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplySaveServiceRequest;
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplyServiceRequest;
+import org.myteam.server.match.matchReply.dto.service.request.MatchReplyUpdateServiceRequest;
+import org.myteam.server.match.matchReply.dto.service.response.MatchReplyResponse;
+import org.myteam.server.match.team.domain.Team;
+import org.myteam.server.match.team.domain.TeamCategory;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.news.domain.News;
+import org.myteam.server.news.news.domain.NewsCategory;
+import org.myteam.server.news.newsComment.domain.NewsComment;
+import org.myteam.server.news.newsReply.domain.NewsReply;
+import org.myteam.server.news.newsReply.dto.service.request.NewsReplySaveServiceRequest;
+import org.myteam.server.news.newsReply.dto.service.request.NewsReplyUpdateServiceRequest;
+import org.myteam.server.news.newsReply.dto.service.response.NewsReplyResponse;
+import org.myteam.server.news.newsReply.service.NewsReplyService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class NewsReplyServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private MatchReplyService matchReplyService;
+
+	@DisplayName("경기 대댓글을 저장한다.")
+	@Test
+	void saveTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchComment matchComment = createMatchComment(match, member, "경기 댓글 테스트");
+
+		MatchReplySaveServiceRequest matchReplySaveServiceRequest = MatchReplySaveServiceRequest.builder()
+			.matchCommentId(matchComment.getId())
+			.comment("대댓글 테스트")
+			.ip("1.1.1.1")
+			.build();
+
+		MatchReplyResponse matchReplyResponse = matchReplyService.save(matchReplySaveServiceRequest);
+
+		assertThat(matchReplyRepository.findById(matchReplyResponse.getMatchReplyId()).get())
+			.extracting("id", "matchComment.id", "member.publicId", "comment", "ip")
+			.contains(matchReplyResponse.getMatchReplyId(), matchComment.getId(), member.getPublicId(), "대댓글 테스트",
+				"1.1.1.1");
+	}
+
+	@DisplayName("경기 대댓글을 수정한다.")
+	@Test
+	void updateTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchComment matchComment = createMatchComment(match, member, "경기 댓글 테스트");
+
+		MatchReply matchReply = createMatchReply(matchComment, member, "경기 대댓글 테스트");
+
+		MatchReplyUpdateServiceRequest matchReplyUpdateServiceRequest = MatchReplyUpdateServiceRequest.builder()
+			.matchReplyId(matchReply.getId())
+			.comment("경기 대댓글 수정 테스트")
+			.build();
+
+		Long updatedReplyId = matchReplyService.update(matchReplyUpdateServiceRequest);
+
+		assertThat(matchReplyRepository.findById(updatedReplyId).get())
+			.extracting("id", "matchComment.id", "member.publicId", "comment", "ip")
+			.contains(matchReply.getId(), matchComment.getId(), member.getPublicId(), "경기 대댓글 수정 테스트", "1.1.1.1");
+	}
+
+	@DisplayName("경기 대댓글을 삭제한다.")
+	@Test
+	void deleteTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+
+		Member member = createMember(1);
+
+		MatchComment matchComment = createMatchComment(match, member, "경기 댓글 테스트");
+
+		MatchReply matchReply = createMatchReply(matchComment, member, "경기 대댓글 테스트");
+
+		Long deletedReplyId = matchReplyService.delete(matchReply.getId());
+
+		assertThatThrownBy(() -> matchReplyService.delete(deletedReplyId))
+			.isInstanceOf(PlayHiveException.class)
+			.hasMessage(ErrorCode.MATCH_REPLY_NOT_FOUND.getMsg());
+	}
+
+}

--- a/src/test/java/org/myteam/server/news/newsComment/service/NewsCommentReadServiceTest.java
+++ b/src/test/java/org/myteam/server/news/newsComment/service/NewsCommentReadServiceTest.java
@@ -32,7 +32,7 @@ public class NewsCommentReadServiceTest extends IntegrationTestSupport {
 		News news = createNews(1, NewsCategory.BASEBALL, 10);
 		Member member = createMember(1);
 
-		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트");
+		NewsComment newsComment = createNewsComment(news, member, "뉴스 댓글 테스트");
 
 		NewsComment findNewsComment = newsCommentReadService.findById(newsComment.getId());
 
@@ -56,8 +56,8 @@ public class NewsCommentReadServiceTest extends IntegrationTestSupport {
 		Member member1 = createMember(1);
 		Member member2 = createMember(1);
 
-		NewsComment newsComment1 = craeteNewsComment(news, member1, "뉴스 댓글 테스트1");
-		NewsComment newsComment2 = craeteNewsComment(news, member2, "뉴스 댓글 테스트2");
+		NewsComment newsComment1 = createNewsComment(news, member1, "뉴스 댓글 테스트1");
+		NewsComment newsComment2 = createNewsComment(news, member2, "뉴스 댓글 테스트2");
 
 		NewsCommentServiceRequest newsCommentServiceRequest = NewsCommentServiceRequest.builder()
 			.newsId(news.getId())

--- a/src/test/java/org/myteam/server/news/newsComment/service/NewsCommentServiceTest.java
+++ b/src/test/java/org/myteam/server/news/newsComment/service/NewsCommentServiceTest.java
@@ -52,7 +52,7 @@ public class NewsCommentServiceTest extends IntegrationTestSupport {
 		News news = createNews(1, NewsCategory.BASEBALL, 10);
 		Member member = createMember(1);
 
-		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트");
+		NewsComment newsComment = createNewsComment(news, member, "뉴스 댓글 테스트");
 
 		NewsCommentUpdateServiceRequest newsCommentUpdateServiceRequest = NewsCommentUpdateServiceRequest.builder()
 			.newsCommentId(newsComment.getId())
@@ -73,7 +73,7 @@ public class NewsCommentServiceTest extends IntegrationTestSupport {
 		News news = createNews(1, NewsCategory.BASEBALL, 10);
 		Member member = createMember(1);
 
-		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트");
+		NewsComment newsComment = createNewsComment(news, member, "뉴스 댓글 테스트");
 		Long deletedCommentId = newsCommentService.delete(newsComment.getId());
 
 		assertAll(

--- a/src/test/java/org/myteam/server/news/newsReply/service/NewsReplyReadServiceTest.java
+++ b/src/test/java/org/myteam/server/news/newsReply/service/NewsReplyReadServiceTest.java
@@ -33,7 +33,7 @@ public class NewsReplyReadServiceTest extends IntegrationTestSupport {
 		News news = createNews(1, NewsCategory.BASEBALL, 10);
 		Member member = createMember(1);
 
-		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트");
+		NewsComment newsComment = createNewsComment(news, member, "뉴스 댓글 테스트");
 
 		NewsReply newsReply = createNewsReply(newsComment, member, "뉴스 대댓글 테스트");
 
@@ -59,7 +59,7 @@ public class NewsReplyReadServiceTest extends IntegrationTestSupport {
 		Member member1 = createMember(1);
 		Member member2 = createMember(1);
 
-		NewsComment newsComment1 = craeteNewsComment(news, member1, "뉴스 댓글 테스트1");
+		NewsComment newsComment1 = createNewsComment(news, member1, "뉴스 댓글 테스트1");
 
 		NewsReply newsReply1 = createNewsReply(newsComment1, member1, "뉴스 대댓글 테스트1");
 		NewsReply newsReply2 = createNewsReply(newsComment1, member2, "뉴스 대댓글 테스트2");

--- a/src/test/java/org/myteam/server/news/newsReply/service/NewsReplyServiceTest.java
+++ b/src/test/java/org/myteam/server/news/newsReply/service/NewsReplyServiceTest.java
@@ -27,7 +27,7 @@ public class NewsReplyServiceTest extends IntegrationTestSupport {
 	void saveTest() {
 		News news = createNews(1, NewsCategory.BASEBALL, 10);
 		Member member = createMember(1);
-		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트1");
+		NewsComment newsComment = createNewsComment(news, member, "뉴스 댓글 테스트1");
 
 		NewsReplySaveServiceRequest newsReplySaveServiceRequest = NewsReplySaveServiceRequest.builder()
 			.newsCommentId(newsComment.getId())
@@ -48,7 +48,7 @@ public class NewsReplyServiceTest extends IntegrationTestSupport {
 	void updateTest() {
 		News news = createNews(1, NewsCategory.BASEBALL, 10);
 		Member member = createMember(1);
-		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트");
+		NewsComment newsComment = createNewsComment(news, member, "뉴스 댓글 테스트");
 		NewsReply newsReply = createNewsReply(newsComment, member, "뉴스 대댓글 테스트");
 
 		NewsReplyUpdateServiceRequest newsReplyUpdateServiceRequest = NewsReplyUpdateServiceRequest.builder()
@@ -69,7 +69,7 @@ public class NewsReplyServiceTest extends IntegrationTestSupport {
 		News news = createNews(1, NewsCategory.BASEBALL, 10);
 		Member member = createMember(1);
 
-		NewsComment newsComment = craeteNewsComment(news, member, "뉴스 댓글 테스트");
+		NewsComment newsComment = createNewsComment(news, member, "뉴스 댓글 테스트");
 		NewsReply newsReply = createNewsReply(newsComment, member, "뉴스 대댓글 테스트");
 		Long deletedReplyId = newsReplyService.delete(newsReply.getId());
 


### PR DESCRIPTION
## 기능 설명
- 실시간 경기 예측에 사용되는 댓글 API
## 작업 내용
- MatchCommentController
- MatchCommentService
- MatchReplyController
- MatchReplyService
## 수정 사항
- 
## 추가 작업 예정
- 흠.. 로그인한 사용자가 이 댓글을 추천을 했는지 안했는지 여부를 클라이언트에게 알려줘야하는데 개발이 안되어있어서 뉴스API와 공통으로 쓸수있는 기능을 개발해야 할 것 같습니다.
- 그리고 경기는 뉴스와 다르게 댓글에만 추천을 누를수 있어 따로 개발을 해야할 것 같습니다.
- 일단 큰 틀만 개발해서 PR올립니다.
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
