### PR TITLE
feat: 게시글, 댓글, 대댓글 삭제시 하위 데이터들도 삭제되도록 수정

### DIFF
--- a/src/main/java/org/myteam/server/board/repository/BoardCommentRecommendRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardCommentRecommendRepository.java
@@ -11,4 +11,6 @@ public interface BoardCommentRecommendRepository extends JpaRepository<BoardComm
     Optional<BoardCommentRecommend> findByBoardCommentIdAndMemberPublicId(Long boardCommentId, UUID publicId);
 
     void deleteByBoardCommentIdAndMemberPublicId(Long boardCommentId, UUID publicId);
+
+    void deleteByBoardCommentId(Long boardCommentId);
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardCommentRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardCommentRepository.java
@@ -1,9 +1,11 @@
 package org.myteam.server.board.repository;
 
+import java.util.List;
 import org.myteam.server.board.domain.BoardComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
+    List<BoardComment> findAllByBoardId(Long boardId);
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardRecommendRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardRecommendRepository.java
@@ -8,8 +8,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardRecommendRepository extends JpaRepository<BoardRecommend, Long> {
-    
+
     Optional<BoardRecommend> findByBoardIdAndMemberPublicId(Long boardId, UUID memberId);
 
     void deleteByBoardIdAndMemberPublicId(Long boardId, UUID publicId);
+
+    void deleteAllByBoardId(Long boardId);
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardReplyRecommendRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardReplyRecommendRepository.java
@@ -12,4 +12,6 @@ public interface BoardReplyRecommendRepository extends JpaRepository<BoardReplyR
     Optional<BoardReplyRecommend> findByBoardReplyIdAndMemberPublicId(Long boardReplyId, UUID publicId);
 
     void deleteByBoardReplyIdAndMemberPublicId(Long boardReplyId, UUID publicId);
+
+    void deleteAllByBoardReplyId(Long boardReplyId);
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardReplyRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardReplyRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BoardReplyRepository extends JpaRepository<BoardReply, Long> {
     List<BoardReply> findByBoardCommentId(Long boardCommentId);
+
+    List<BoardReply> findAllByBoardCommentId(Long boardCommentId);
 }

--- a/src/main/java/org/myteam/server/board/service/BoardCommentReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardCommentReadService.java
@@ -61,4 +61,8 @@ public class BoardCommentReadService {
 
         return response;
     }
+
+    public List<BoardComment> findAllByBoardId(Long boardId) {
+        return boardCommentRepository.findAllByBoardId(boardId);
+    }
 }

--- a/src/main/java/org/myteam/server/board/service/BoardReplyReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReplyReadService.java
@@ -24,4 +24,8 @@ public class BoardReplyReadService {
     public List<BoardReply> findByBoardCommentId(Long boardCommentId) {
         return boardReplyRepository.findByBoardCommentId(boardCommentId);
     }
+
+    public List<BoardReply> findAllByBoardCommentId(Long boardCommentId) {
+        return boardReplyRepository.findAllByBoardCommentId(boardCommentId);
+    }
 }

--- a/src/main/java/org/myteam/server/board/service/BoardReplyService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReplyService.java
@@ -5,6 +5,7 @@ import org.myteam.server.board.domain.BoardComment;
 import org.myteam.server.board.domain.BoardReply;
 import org.myteam.server.board.dto.reponse.BoardReplyResponse;
 import org.myteam.server.board.dto.request.BoardReplySaveRequest;
+import org.myteam.server.board.repository.BoardReplyRecommendRepository;
 import org.myteam.server.board.repository.BoardReplyRepository;
 import org.myteam.server.chat.domain.BadWordFilter;
 import org.myteam.server.global.util.upload.MediaUtils;
@@ -28,6 +29,7 @@ public class BoardReplyService {
     private final S3Service s3Service;
 
     private final BoardReplyRepository boardReplyRepository;
+    private final BoardReplyRecommendRepository boardReplyRecommendRepository;
     private final BadWordFilter badWordFilter;
 
     /**
@@ -88,9 +90,13 @@ public class BoardReplyService {
 
         boardReply.verifyBoardReplyAuthor(boardReply, loginUser);
 
+        // 대댓글 추천 삭제
+        boardReplyRecommendRepository.deleteAllByBoardReplyId(boardReply.getId());
+        // 대댓글 이미지 삭제
         s3Service.deleteFile(MediaUtils.getImagePath(boardReply.getImageUrl()));
+        // 대댓글 삭제
         boardReplyRepository.delete(boardReply);
-
+        // 게시글 댓글 카운트 감소
         boardCountService.minusCommentCount(boardReply.getBoardComment().getBoard().getId());
     }
 


### PR DESCRIPTION
## 기능 설명
- 
## 작업 내용
- 게시글 삭제 시 댓글,대댓글,추천 관련 데이터까지 삭제 되도록 로직 추가
- 게시글 댓글 삭제 시 대댓글, 추천 관련 데이터까지 삭제 되도록 로직 추가
- 게시글 대댓글 삭제 시 추천 관련 데이터까지 삭제 되도록 로직 추가

## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
