### PR TITLE
feat: 게시글 목록 조회 시 댓글 검색 추가

### DIFF
--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardCommentSearchDto.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardCommentSearchDto.java
@@ -1,0 +1,19 @@
+package org.myteam.server.board.dto.reponse;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BoardCommentSearchDto {
+    /**
+     * 댓글 검색 시 결과
+     */
+    private Long boardCommentId;
+    /**
+     * 댓글 검색 시 결과
+     */
+    private String comment;
+}

--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardDto.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.myteam.server.board.domain.BoardType;
 import org.myteam.server.board.domain.CategoryType;
 
@@ -58,6 +59,11 @@ public class BoardDto {
      * 수정 일시
      */
     private LocalDateTime updatedAt;
+    /**
+     * 댓글 검색 시 결과
+     */
+    @Setter
+    private BoardCommentSearchDto boardCommentSearchDto;
 
     public BoardDto(BoardType boardType, CategoryType categoryType, Long id, String title,
                     String createdIp, String thumbnail, UUID publicId, String nickname, Integer commentCount,

--- a/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
@@ -98,7 +98,7 @@ public class BoardQueryRepository {
 
 
     private BooleanExpression isSearchTypeLikeTo(BoardSearchType searchType, String search) {
-        if (search == null || search.isEmpty()) {
+        if (searchType == null || search == null || search.isEmpty()) {
             return null;
         }
 

--- a/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
@@ -74,8 +74,8 @@ public class BoardQueryRepository {
 
                 BoardCommentSearchDto commentSearch = getSearchBoardComment(boardDto.getId(), search);
 
-                if (commentSearch != null) { // Null 체크 추가
-                    boardDto.setBoardCommentSearchDto(commentSearch); // BoardDto에 해당 필드를 추가해야 함
+                if (commentSearch != null) {
+                    boardDto.setBoardCommentSearchDto(commentSearch);
                 }
             });
         }

--- a/src/main/java/org/myteam/server/board/service/BoardCommentService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardCommentService.java
@@ -99,8 +99,10 @@ public class BoardCommentService {
         int minusCount = deleteBoardReply(boardComment.getId());
         // 댓글 추천 삭제
         boardCommentRecommendRepository.deleteByBoardCommentId(boardComment.getId());
-        // S3 이미지 삭제
-        s3Service.deleteFile(MediaUtils.getImagePath(boardComment.getImageUrl()));
+        if (boardComment.getImageUrl() != null) {
+            // S3 이미지 삭제
+            s3Service.deleteFile(MediaUtils.getImagePath(boardComment.getImageUrl()));
+        }
         // 댓글 삭제
         boardCommentRepository.deleteById(boardCommentId);
 
@@ -116,8 +118,10 @@ public class BoardCommentService {
         for (BoardReply boardReply : boardReplyList) {
             // 대댓글 추천 삭제
             boardReplyRecommendRepository.deleteAllByBoardReplyId(boardReply.getId());
-            // 대댓글 이미지 삭제
-            s3Service.deleteFile(MediaUtils.getImagePath(boardReply.getImageUrl()));
+            if (boardReply.getImageUrl() != null) {
+                // 대댓글 이미지 삭제
+                s3Service.deleteFile(MediaUtils.getImagePath(boardReply.getImageUrl()));
+            }
             // 대댓글 삭제
             boardReplyRepository.delete(boardReply);
         }

--- a/src/main/java/org/myteam/server/board/service/BoardReplyService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReplyService.java
@@ -92,8 +92,10 @@ public class BoardReplyService {
 
         // 대댓글 추천 삭제
         boardReplyRecommendRepository.deleteAllByBoardReplyId(boardReply.getId());
-        // 대댓글 이미지 삭제
-        s3Service.deleteFile(MediaUtils.getImagePath(boardReply.getImageUrl()));
+        if (boardReply.getImageUrl() != null) {
+            // 대댓글 이미지 삭제
+            s3Service.deleteFile(MediaUtils.getImagePath(boardReply.getImageUrl()));
+        }
         // 대댓글 삭제
         boardReplyRepository.delete(boardReply);
         // 게시글 댓글 카운트 감소

--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -155,8 +155,10 @@ public class BoardService {
                 deleteBoardReply(boardComment.getId());
                 // 댓글 추천 삭제
                 boardCommentRecommendRepository.deleteByBoardCommentId(boardComment.getId());
-                // S3 이미지 삭제
-                s3Service.deleteFile(MediaUtils.getImagePath(boardComment.getImageUrl()));
+                if (boardComment.getImageUrl() != null) {
+                    // S3 이미지 삭제
+                    s3Service.deleteFile(MediaUtils.getImagePath(boardComment.getImageUrl()));
+                }
                 // 댓글 삭제
                 boardCommentRepository.deleteById(boardComment.getId());
             });
@@ -172,8 +174,10 @@ public class BoardService {
             boardReplyList.forEach(boardReply -> {
                 // 대댓글 추천 삭제
                 boardReplyRecommendRepository.deleteAllByBoardReplyId(boardReply.getId());
-                // 대댓글 이미지 삭제
-                s3Service.deleteFile(MediaUtils.getImagePath(boardReply.getImageUrl()));
+                if (boardReply.getImageUrl() != null) {
+                    // 대댓글 이미지 삭제
+                    s3Service.deleteFile(MediaUtils.getImagePath(boardReply.getImageUrl()));
+                }
                 // 대댓글 삭제
                 boardReplyRepository.delete(boardReply);
             });


### PR DESCRIPTION
## 기능 설명
- searchType이 COMMENT일 경우 search로 입력된 검색어로 댓글 검색 작업하였습니다.
댓글 데이터(댓글 ID -> 클릭시 댓글 상세 조회를 위한 ID, 댓글 내용) 응답값 추가하였습니다.


## 작업 내용
- 댓글 검색 필터 추가하였습니다.
- s3관련 이미지 삭제 시 이미지가 존재할경우에만 s3에 접근하여 삭제 하도록 if문 추가하였습니다.

## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
