### PR TITLE
feat: 게시판 댓글 목록 조회 수정

### DIFF
--- a/src/main/java/org/myteam/server/board/controller/BoardCommentController.java
+++ b/src/main/java/org/myteam/server/board/controller/BoardCommentController.java
@@ -5,7 +5,6 @@ import static org.myteam.server.global.web.response.ResponseStatus.SUCCESS;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.myteam.server.board.domain.BoardOrderType;
 import org.myteam.server.board.dto.reponse.BoardCommentListResponse;
 import org.myteam.server.board.dto.reponse.BoardCommentResponse;
 import org.myteam.server.board.dto.request.BoardCommentSaveRequest;
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -82,10 +80,9 @@ public class BoardCommentController {
      */
     @GetMapping("/{boardId}/comment")
     public ResponseEntity<ResponseDto<BoardCommentListResponse>> getBoardComments(@PathVariable Long boardId,
-                                                                                  @RequestParam BoardOrderType orderType,
                                                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(
                 new ResponseDto<>(SUCCESS.name(), "게시판 댓글 목록 조회 성공",
-                        boardCommentReadService.findByBoardId(boardId, orderType, userDetails)));
+                        boardCommentReadService.findByBoardId(boardId, userDetails)));
     }
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardCommentQueryRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardCommentQueryRepository.java
@@ -4,16 +4,15 @@ import static org.myteam.server.board.domain.QBoardComment.boardComment;
 import static org.myteam.server.board.domain.QBoardReply.boardReply;
 
 import com.querydsl.core.types.ExpressionUtils;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.myteam.server.board.domain.BoardOrderType;
 import org.myteam.server.board.dto.reponse.BoardCommentResponse;
 import org.myteam.server.board.dto.reponse.BoardReplyResponse;
 import org.myteam.server.board.service.BoardCommentRecommendReadService;
@@ -32,9 +31,58 @@ public class BoardCommentQueryRepository {
     private final BoardCommentRecommendReadService boardCommentRecommendReadService;
     private final BoardReplyRecommendReadService boardReplyRecommendReadService;
 
-    public List<BoardCommentResponse> getBoardCommentList(Long boardId, BoardOrderType orderType,
-                                                          CustomUserDetails userDetails) {
-        List<BoardCommentResponse> list = queryFactory
+    public List<BoardCommentResponse> getBoardCommentList(Long boardId, CustomUserDetails userDetails) {
+
+        // 추천수가 높은 상위 3개 댓글 조회
+        List<BoardCommentResponse> topComments = getBestCommentList(boardId);
+
+        // 상위 3개를 제외한 나머지 댓글 조회 (최신순 정렬)
+        List<BoardCommentResponse> otherComments = queryFactory
+                .select(Projections.constructor(BoardCommentResponse.class,
+                        boardComment.id,
+                        boardComment.board.id,
+                        boardComment.createdIp,
+                        boardComment.member.publicId,
+                        boardComment.member.nickname,
+                        boardComment.imageUrl,
+                        boardComment.comment,
+                        boardComment.recommendCount,
+                        boardComment.createDate,
+                        boardComment.lastModifiedDate,
+                        ExpressionUtils.as(Expressions.constant(false), "isRecommended")
+                ))
+                .from(boardComment)
+                .where(isBoardEqualTo(boardId)
+                        .and(boardComment.id.notIn(topComments.stream()
+                                .map(BoardCommentResponse::getBoardCommentId)
+                                .collect(Collectors.toList())))) // 상위 3개 제외
+                .orderBy(boardComment.createDate.desc(), boardComment.comment.asc()) // 최신순 정렬, 같다면 댓글 가나다순
+                .fetch();
+
+        // 최종 리스트: 추천 Top 3 + 최신순 나머지 댓글
+        List<BoardCommentResponse> finalList = new ArrayList<>();
+        finalList.addAll(topComments);
+        finalList.addAll(otherComments);
+
+        finalList.forEach(comment -> {
+            boolean isRecommended = false;
+
+            if (userDetails != null) {
+                UUID loginUser = memberRepository.findByPublicId(userDetails.getPublicId()).get().getPublicId();
+                isRecommended = boardCommentRecommendReadService.isRecommended(comment.getBoardCommentId(), loginUser);
+            }
+            comment.setRecommended(isRecommended);
+            comment.setBoardReplyList(getRepliesForComments(comment.getBoardCommentId(), userDetails));
+        });
+
+        return finalList;
+    }
+
+    /**
+     * 베스트 댓글 목록 조회
+     */
+    private List<BoardCommentResponse> getBestCommentList(Long boardId) {
+        return queryFactory
                 .select(Projections.constructor(BoardCommentResponse.class,
                         boardComment.id,
                         boardComment.board.id,
@@ -50,23 +98,14 @@ public class BoardCommentQueryRepository {
                 ))
                 .from(boardComment)
                 .where(isBoardEqualTo(boardId))
-                .orderBy(isOrderByEqualToOrderType(orderType))
+                .orderBy(boardComment.recommendCount.desc(), boardComment.createDate.desc()) // 추천순 + 최신순
+                .limit(3)
                 .fetch();
-
-        list.forEach(comment -> {
-            boolean isRecommended = false;
-
-            if (userDetails != null) {
-                UUID loginUser = memberRepository.findByPublicId(userDetails.getPublicId()).get().getPublicId();
-                isRecommended = boardCommentRecommendReadService.isRecommended(comment.getBoardCommentId(), loginUser);
-            }
-            comment.setRecommended(isRecommended);
-            comment.setBoardReplyList(getRepliesForComments(comment.getBoardCommentId(), userDetails));
-        });
-
-        return list;
     }
 
+    /**
+     * 대댓글 목록 조회
+     */
     public List<BoardReplyResponse> getRepliesForComments(Long boardCommentId, CustomUserDetails userDetails) {
         List<BoardReplyResponse> replies = queryFactory
                 .select(Projections.fields(BoardReplyResponse.class,
@@ -104,16 +143,6 @@ public class BoardCommentQueryRepository {
 
     private BooleanExpression isBoardCommentEqualTo(Long boardCommentId) {
         return boardReply.boardComment.id.eq(boardCommentId);
-    }
-
-    private OrderSpecifier<?> isOrderByEqualToOrderType(BoardOrderType orderType) {
-        // default 추천순
-        BoardOrderType order = Optional.ofNullable(orderType).orElse(BoardOrderType.RECOMMEND);
-        return switch (order) {
-            case CREATE -> boardComment.createDate.desc();
-            case RECOMMEND -> boardComment.recommendCount.desc();
-            case COMMENT -> null;
-        };
     }
 
     private BooleanExpression isBoardEqualTo(Long boardId) {

--- a/src/main/java/org/myteam/server/board/service/BoardCommentReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardCommentReadService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.myteam.server.board.domain.BoardComment;
-import org.myteam.server.board.domain.BoardOrderType;
 import org.myteam.server.board.dto.reponse.BoardCommentListResponse;
 import org.myteam.server.board.dto.reponse.BoardCommentResponse;
 import org.myteam.server.board.repository.BoardCommentQueryRepository;
@@ -32,12 +31,10 @@ public class BoardCommentReadService {
                 .orElseThrow(() -> new PlayHiveException(ErrorCode.BOARD_COMMENT_NOT_FOUND));
     }
 
-    public BoardCommentListResponse findByBoardId(Long boardId, BoardOrderType orderType,
-                                                  CustomUserDetails userDetails) {
+    public BoardCommentListResponse findByBoardId(Long boardId, CustomUserDetails userDetails) {
 
         List<BoardCommentResponse> list = boardCommentQueryRepository.getBoardCommentList(
                 boardId,
-                orderType,
                 userDetails
         );
 


### PR DESCRIPTION
## 기능 설명
- 

## 작업 내용
- 게시글 댓글 목록 검색시 BEST 3개 상단고정 (추천순, 같다면 최신순), 나머지 BEST 3개 제외한 댓글 목록 (최신순, 같다면 댓글 가나다순)
- 게시글 댓글 목록 검색은 orderType을 따로 받을 필요가 없어보여 제거하였습니다.
 
## 수정 사항
- 

## 추가 작업 예정
- 

## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
