### PR TITLE
feat: 비밀번호 찾기 로직 수정

### DIFF
--- a/src/main/java/org/myteam/server/common/certification/controller/CertificationController.java
+++ b/src/main/java/org/myteam/server/common/certification/controller/CertificationController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.common.certification.dto.CertificationCertifyRequest;
 import org.myteam.server.common.certification.dto.CertificationEmailRequest;
 import org.myteam.server.common.certification.service.CertificationService;
+import org.myteam.server.common.mail.domain.EmailType;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.web.response.ResponseDto;
 import org.springframework.http.HttpStatus;
@@ -30,7 +31,7 @@ public class CertificationController {
     @PostMapping("/send")
     public ResponseEntity<?> sendCertificationEmail(@Valid @RequestBody CertificationEmailRequest certificationEmailRequest, BindingResult bindingResult) {
         log.info("send-certification email: {}", certificationEmailRequest.getEmail());
-        certificationService.send(certificationEmailRequest.getEmail());
+        certificationService.send(certificationEmailRequest.getEmail(), EmailType.CERTIFICATION);
         return new ResponseEntity<>(new ResponseDto<>(SUCCESS.name(), "인증 코드 이메일 전송 성공", null), HttpStatus.OK);
     }
 

--- a/src/main/java/org/myteam/server/common/certification/util/CertifyMailStrategy.java
+++ b/src/main/java/org/myteam/server/common/certification/util/CertifyMailStrategy.java
@@ -1,14 +1,8 @@
 package org.myteam.server.common.certification.util;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.common.certification.domain.CertificationCode;
-import org.myteam.server.common.mail.MailSender;
-import org.myteam.server.global.exception.PlayHiveException;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailException;
+import org.myteam.server.common.mail.service.AbstractMailSender;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -19,39 +13,27 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.myteam.server.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
-import static org.myteam.server.global.exception.ErrorCode.UNAUTHORIZED_EMAIL_ACCOUNT;
-
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
-public class CertifyMailSender implements MailSender {
-
-    @Value("${SENDER_EMAIL}")
-    private String senderEmail;
-    private final JavaMailSender javaMailSender;
+public class CertifyMailStrategy extends AbstractMailSender {
     private static final int EXPIRATION_MINUTES = 5; // 유효 시간 (5분)
     private final Map<String, CertificationCode> codeStorage = new ConcurrentHashMap<>();
 
-    // 메일을 보낸다
+    public CertifyMailStrategy(JavaMailSender javaMailSender) {
+        super(javaMailSender);
+    }
+
     @Override
-    public void send(String email) {
-        log.info("Sending email to {}", email);
+    protected String getSubject() {
+        return "이메일 인증 코드";
+    }
 
-        try {
-            // 인증 코드 생성
-            CertificationCode certificationCode = createNumber();
-            codeStorage.put(email, certificationCode); // 이메일별로 인증 코드 저장
-
-            // 이메일 생성 및 발송
-            MimeMessage message = createMail(email, certificationCode.getCode());
-            javaMailSender.send(message);
-            log.info("certificationCode ExpirationTime : {}", certificationCode.getExpirationTime());
-        } catch (MailException e) {
-            log.error("이메일 전송 중 에러가 발생하였습니다." + e.getMessage());
-            throw new PlayHiveException(UNAUTHORIZED_EMAIL_ACCOUNT, e.getMessage());
-        }
+    @Override
+    protected String getBody(String email) {
+        CertificationCode certificationCode = createNumber();
+        codeStorage.put(email, certificationCode);
+        return buildEmailContent(certificationCode.getCode(), certificationCode.getExpirationTime());
     }
 
     // 인증번호를 생성한다.
@@ -61,28 +43,9 @@ public class CertifyMailSender implements MailSender {
         return new CertificationCode(String.valueOf(code), expirationTime);
     }
 
-    // 메일 내용을 생성한다.
-    private MimeMessage createMail(String email, String code) {
-        MimeMessage message = javaMailSender.createMimeMessage();
-
-        try {
-            message.setFrom(senderEmail);
-            message.setRecipients(MimeMessage.RecipientType.TO, email);
-            message.setSubject("이메일 인증");
-
-            // 이메일 본문
-            String body = buildEmailContent(code, codeStorage.get(email).getExpirationTime());
-            message.setText(body, "UTF-8", "html");
-        } catch (MessagingException e) {
-            log.error("이메일 생성 중 에러가 발생하였습니다. 에러 메시지 : {}", e.getMessage());
-            throw new PlayHiveException(INTERNAL_SERVER_ERROR, e.getMessage());
-        }
-
-        return message;
-    }
-
     // 인증번호가 유효한지 검사한다.
-    public boolean isCodeValid(String email, String inputCode) {
+    @Override
+    public boolean verify(String email, String inputCode) {
         CertificationCode storedCode = codeStorage.get(email);
 
         if (storedCode == null || LocalDateTime.now().isAfter(storedCode.getExpirationTime())) {

--- a/src/main/java/org/myteam/server/common/certification/util/TemporaryPasswordMailStrategy.java
+++ b/src/main/java/org/myteam/server/common/certification/util/TemporaryPasswordMailStrategy.java
@@ -1,0 +1,70 @@
+package org.myteam.server.common.certification.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.myteam.server.common.mail.service.AbstractMailSender;
+import org.myteam.server.member.repository.MemberJpaRepository;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Slf4j
+@Component
+public class TemporaryPasswordMailStrategy extends AbstractMailSender {
+
+    private final MemberJpaRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public TemporaryPasswordMailStrategy(JavaMailSender javaMailSender,
+                                         MemberJpaRepository memberRepository,
+                                         PasswordEncoder passwordEncoder) {
+        super(javaMailSender);
+        this.memberRepository = memberRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    protected String getSubject() {
+        return "임시 비밀번호 안내";
+    }
+
+    @Override
+    protected String getBody(String email) {
+        String tempPassword = generateRandomPassword(email);
+        return buildTemporaryPasswordEmailContent(tempPassword);
+    }
+
+    private String generateRandomPassword(String email) {
+        int length = 10;
+        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789@#$%^&*";
+        SecureRandom random = new SecureRandom();
+        StringBuilder password = new StringBuilder();
+
+        for (int i = 0; i < length; i++) {
+            password.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        String tempPassword = password.toString();
+        log.info("랜덤 비밀번호 생성: {}", tempPassword);
+
+        memberRepository.findByEmail(email).ifPresent(member -> {
+            String encodedPassword = passwordEncoder.encode(tempPassword);
+            member.updatePassword(encodedPassword);
+            memberRepository.save(member); // DB 저장
+            log.info("사용자 {}의 비밀번호가 임시 비밀번호로 변경됨", email);
+        });
+
+        return tempPassword;
+    }
+
+    public String buildTemporaryPasswordEmailContent(String tempPassword) {
+        // 이메일 본문 생성
+        String body = "<h3>임시 비밀번호 안내</h3>";
+        body += "<p>귀하의 임시 비밀번호는 다음과 같습니다.</p>";
+        body += "<h2 style=\"color: red;\">" + tempPassword + "</h2>";
+        body += "<p>로그인 후 반드시 비밀번호를 변경해주세요.</p>";
+        body += "<p style=\"color: #555555; font-size: 12px; text-align: left; margin-top: 20px;\">";
+        body += "</p>";
+        return body;
+    }
+}

--- a/src/main/java/org/myteam/server/common/mail/MailSender.java
+++ b/src/main/java/org/myteam/server/common/mail/MailSender.java
@@ -1,5 +1,0 @@
-package org.myteam.server.common.mail;
-
-public interface MailSender {
-    void send (String message);
-}

--- a/src/main/java/org/myteam/server/common/mail/config/MailConfig.java
+++ b/src/main/java/org/myteam/server/common/mail/config/MailConfig.java
@@ -1,0 +1,22 @@
+package org.myteam.server.common.mail.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class MailConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost("smtp.naver.com");
+        mailSender.setPort(587);
+        mailSender.setUsername("teamplayhive@naver.com");
+        mailSender.setPassword("Play!57304");
+
+        return mailSender;
+    }
+}

--- a/src/main/java/org/myteam/server/common/mail/domain/EmailType.java
+++ b/src/main/java/org/myteam/server/common/mail/domain/EmailType.java
@@ -1,0 +1,6 @@
+package org.myteam.server.common.mail.domain;
+
+public enum EmailType {
+    CERTIFICATION, // 인증 코드 메일
+    TEMPORARY_PASSWORD // 임시 비밀번호 메일
+}

--- a/src/main/java/org/myteam/server/common/mail/service/AbstractMailSender.java
+++ b/src/main/java/org/myteam/server/common/mail/service/AbstractMailSender.java
@@ -1,0 +1,64 @@
+package org.myteam.server.common.mail.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public abstract class AbstractMailSender implements MailStrategy {
+
+    @Value("${SENDER_EMAIL}")
+    protected String senderEmail;
+    protected final JavaMailSender javaMailSender;
+
+    // 📌 구체적인 본문과 제목은 구현 클래스에서 정의
+    protected abstract String getSubject();
+    protected abstract String getBody(String email);
+
+    // 메일을 보낸다
+    @Override
+    public void send(String email) {
+        log.info("Sending email to {}", email);
+
+        try {
+            // 📌 각 구현체에서 제공하는 데이터 생성 메서드
+            String subject = getSubject();
+            String body = getBody(email);
+
+            // 📌 공통 이메일 생성
+            MimeMessage message = createMail(email, subject, body);
+            javaMailSender.send(message);
+
+            log.info("이메일 전송 완료 - email: {}", email);
+        } catch (MailException e) {
+            log.error("이메일 전송 중 에러 발생: {}", e.getMessage());
+            throw new PlayHiveException(ErrorCode.UNAUTHORIZED_EMAIL_ACCOUNT);
+        }
+    }
+
+    // 공통 이메일 생성 메서드
+    private MimeMessage createMail(String email, String subject, String body) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(senderEmail);
+            helper.setTo(email);
+            helper.setSubject(subject);
+            helper.setText(body, true);
+        } catch (MessagingException e) {
+            log.error("이메일 생성 중 에러 발생: {}", e.getMessage());
+            throw new PlayHiveException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+        return message;
+    }
+}

--- a/src/main/java/org/myteam/server/common/mail/service/MailStrategy.java
+++ b/src/main/java/org/myteam/server/common/mail/service/MailStrategy.java
@@ -1,0 +1,12 @@
+package org.myteam.server.common.mail.service;
+
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+
+public interface MailStrategy {
+    void send (String email);
+
+    default boolean verify(String email, String code) {
+        throw new PlayHiveException(ErrorCode.NOT_SUPPORT_TYPE);
+    }
+}

--- a/src/main/java/org/myteam/server/common/mail/util/MailStrategyFactory.java
+++ b/src/main/java/org/myteam/server/common/mail/util/MailStrategyFactory.java
@@ -1,0 +1,38 @@
+package org.myteam.server.common.mail.util;
+
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.common.certification.util.CertifyMailStrategy;
+import org.myteam.server.common.certification.util.TemporaryPasswordMailStrategy;
+import org.myteam.server.common.mail.domain.EmailType;
+import org.myteam.server.common.mail.service.MailStrategy;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class MailStrategyFactory {
+
+    private final Map<EmailType, MailStrategy> mailStrategyMap = new HashMap<>();
+
+    @Autowired
+    public void init(Map<String, MailStrategy> strategies) {
+        strategies.forEach((key, strategy) -> {
+            if (strategy instanceof CertifyMailStrategy) {
+                mailStrategyMap.put(EmailType.CERTIFICATION, strategy);
+            } else if (strategy instanceof TemporaryPasswordMailStrategy) {
+                mailStrategyMap.put(EmailType.TEMPORARY_PASSWORD, strategy);
+            }
+        });
+    }
+
+    public MailStrategy getStrategy(EmailType type) {
+        return Optional.ofNullable(mailStrategyMap.get(type))
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.NOT_SUPPORT_TYPE));
+    }
+}

--- a/src/main/java/org/myteam/server/global/exception/ErrorCode.java
+++ b/src/main/java/org/myteam/server/global/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "File I/O operation failed"),
     ENCRYPTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An error occurred during encryption."),
     DECRYPTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "An error occurred during decryption."),
+    NOT_SUPPORT_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "This email type is not supported"),
 
     // 503 Service Unavailable
     KAFKA_TOPIC_DELETE_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "Failed to delete the Kafka topic."),

--- a/src/main/java/org/myteam/server/member/controller/MyInfoController.java
+++ b/src/main/java/org/myteam/server/member/controller/MyInfoController.java
@@ -90,18 +90,12 @@ public class MyInfoController {
 
     @PostMapping("/find-password")
     public ResponseEntity<?> resetPassword(@RequestParam String email, HttpSession session) {
-        String certifiedEmail = (String) session.getAttribute("certifiedEmail");
-
-        if (certifiedEmail == null || !certifiedEmail.equals(email)) {
-            throw new PlayHiveException(ErrorCode.UNAUTHORIZED_EMAIL_ACCOUNT);
-        }
-
-        String password = memberReadService.findPassword(email);
+        memberService.generateTemporaryPassword(email, session);
 
         return ResponseEntity.ok(new ResponseDto<>(
                 SUCCESS.name(),
-                "비밀번호 찾기 성공",
-                password
+                "랜덤 비밀번호 생성 성공",
+                null
         ));
     }
 }

--- a/src/main/java/org/myteam/server/member/entity/Member.java
+++ b/src/main/java/org/myteam/server/member/entity/Member.java
@@ -43,9 +43,6 @@ public class Member extends Base {
     @Column(nullable = false, length = 60) // 패스워드 인코딩(BCrypt)
     private String password; // 비밀번호
 
-    @Column(nullable = false)
-    private String encodedPassword;
-
     @Column(length = 11)
     private String tel;
 
@@ -75,10 +72,9 @@ public class Member extends Base {
     private int birthDay;
 
     @Builder
-    public Member(String email, String password, String encodedPassword, String tel, String nickname, MemberRole role, MemberType type, UUID publicId, MemberStatus status) {
+    public Member(String email, String password, String tel, String nickname, MemberRole role, MemberType type, UUID publicId, MemberStatus status) {
         this.email = email;
         this.password = password;
-        this.encodedPassword = encodedPassword;
         this.tel = tel;
         this.nickname = nickname;
         this.role = role;
@@ -88,34 +84,30 @@ public class Member extends Base {
     }
 
     @Builder
-    public Member(MemberSaveRequest memberSaveRequest, PasswordEncoder passwordEncoder, String encodedPassword) {
+    public Member(MemberSaveRequest memberSaveRequest, PasswordEncoder passwordEncoder) {
         this.email = memberSaveRequest.getEmail();
         this.password = passwordEncoder.encode(memberSaveRequest.getPassword());
         this.tel = memberSaveRequest.getTel();
         this.nickname = memberSaveRequest.getNickname();
-        this.encodedPassword = encodedPassword;
     }
 
     // 전체 업데이트 메서드
-    public void update(MemberUpdateRequest memberUpdateRequest, String encodedPassword, PasswordEncoder passwordEncoder) {
+    public void update(MemberUpdateRequest memberUpdateRequest, PasswordEncoder passwordEncoder) {
         // this.email = memberUpdateRequest.getEmail();
         this.password = passwordEncoder.encode(memberUpdateRequest.getPassword()); // 비밀번호 변경 시 암호화 필요
         this.tel = memberUpdateRequest.getTel();
         this.nickname = memberUpdateRequest.getNickname();
-        this.encodedPassword = encodedPassword;
     }
 
     // 전체 업데이트 메서드
-    public void update(String password, String encodedPassword, String tel, String nickname) {
+    public void update(String password, String tel, String nickname) {
         this.password = password;
-        this.encodedPassword = encodedPassword;
         this.tel = tel;
         this.nickname = nickname;
     }
 
-    public void updatePassword(String password, String encodedPassword) {
+    public void updatePassword(String password) {
         this.password = password;
-        this.encodedPassword = encodedPassword; // 비밀번호 변경 시 암호화 필요
     }
 
     public void updateEmail(String email) {

--- a/src/main/java/org/myteam/server/member/service/MemberReadService.java
+++ b/src/main/java/org/myteam/server/member/service/MemberReadService.java
@@ -21,8 +21,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.myteam.server.global.exception.ErrorCode.NO_PERMISSION;
-import static org.myteam.server.global.exception.ErrorCode.RESOURCE_NOT_FOUND;
+import static org.myteam.server.global.exception.ErrorCode.*;
 import static org.myteam.server.global.security.jwt.JwtProvider.TOKEN_PREFIX;
 
 @Service
@@ -33,10 +32,8 @@ public class MemberReadService {
     private final MemberRepository memberRepository;
     private final MemberJpaRepository memberJpaRepository;
     private final SecurityReadService securityReadService;
-    private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
 
-    private final AESCryptoUtil crypto;
 
     public Member findById(UUID publicId) {
         Member member = memberRepository.findByPublicId(publicId)
@@ -47,6 +44,11 @@ public class MemberReadService {
         }
 
         return member;
+    }
+
+    public Member findByEmail(String email) {
+        return memberJpaRepository.findByEmail(email)
+                .orElseThrow(() -> new PlayHiveException(USER_NOT_FOUND));
     }
 
     public ProfileResponse getProfile() {
@@ -124,16 +126,5 @@ public class MemberReadService {
         List<Member> memberList = memberJpaRepository.findByTel(phoneNumber);
 
         return FindIdResponse.createResponse(memberList);
-    }
-
-    public String findPassword(String email) {
-        Member member = memberJpaRepository.findByEmail(email)
-                .orElseThrow(() -> new PlayHiveException(ErrorCode.PHONE_NUMBER_NOT_FOUND));
-
-        String encodedPassword = member.getEncodedPassword();
-
-        String originPassword = crypto.findOriginPwd(encodedPassword);
-
-        return originPassword;
     }
 }

--- a/src/main/java/org/myteam/server/mypage/service/MyPageService.java
+++ b/src/main/java/org/myteam/server/mypage/service/MyPageService.java
@@ -36,9 +36,8 @@ public class MyPageService {
         }
 
         String password = passwordEncoder.encode(request.getPassword());
-        String encodedPwd = cryptoUtil.createEncodedPwd(request.getPassword());
 
-        member.update(password, encodedPwd, request.getTel(), request.getNickname());
+        member.update(password, request.getTel(), request.getNickname());
 
         if (request.getBirthDate() != null) {
             memberValidator.validateBirthDate(request.getBirthDate());

--- a/src/main/java/org/myteam/server/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/myteam/server/oauth2/service/CustomOAuth2UserService.java
@@ -105,13 +105,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private OAuth2User createNewMember(OAuth2Response oAuth2Response, String providerId) {
         log.debug("Creating new member for providerId: {}", providerId);
         String password = PasswordUtil.generateRandomPassword();
-        String encodedPassword = aesCryptoUtil.createEncodedPwd(password);
 
         UUID publicId = UUID.randomUUID();
         Member newMember = Member.builder()
                 .email(oAuth2Response.getEmail())
                 .password(password)
-                .encodedPassword(encodedPassword)
                 .role(USER)
                 .tel(oAuth2Response.getTel())
                 .nickname(oAuth2Response.getNickname())


### PR DESCRIPTION
## 기능 설명
- 기획 변경에 따른 비밀번호 찾기 로직입니다.
## 작업 내용
- 추상 팩토리 패턴을 통해 이메일 보내는 로직을 확장성 높게 변경하였습니다.
- 이메일 인증 시도 -> 인증 성공 -> 비밀번호 찾기 -> 이메일로 랜덤 비번 보내주기 로직입니다.
## 수정 사항
- 이전 AES로 암호화하던 비밀번호는 이제 필요가 없어져 필드 제거하였습니다.
## 추가 작업 예정
- 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
