### PR TITLE
feat: 경기일정에 장소 응답값 추가, 일주일치 가져오도록 조건 수정

### DIFF
--- a/src/main/java/org/myteam/server/match/match/domain/Match.java
+++ b/src/main/java/org/myteam/server/match/match/domain/Match.java
@@ -32,16 +32,19 @@ public class Match extends Base {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Team awayTeam;
 
+	private String place;
+
 	@Enumerated(EnumType.STRING)
 	private MatchCategory category;
 
 	private LocalDateTime startTime;
 
 	@Builder
-	public Match(Long id, Team homeTeam, Team awayTeam, MatchCategory category, LocalDateTime startTime) {
+	public Match(Long id, Team homeTeam, Team awayTeam, String place, MatchCategory category, LocalDateTime startTime) {
 		this.id = id;
 		this.homeTeam = homeTeam;
 		this.awayTeam = awayTeam;
+		this.place = place;
 		this.category = category;
 		this.startTime = startTime;
 	}

--- a/src/main/java/org/myteam/server/match/match/dto/service/response/MatchResponse.java
+++ b/src/main/java/org/myteam/server/match/match/dto/service/response/MatchResponse.java
@@ -15,14 +15,17 @@ public class MatchResponse {
 	private Long id;
 	private TeamResponse homeTeam;
 	private TeamResponse awayTeam;
+	@Schema(description = "경기장소")
+	private String place;
 	@Schema(description = "경기 유형 ID")
 	private String category;
 
 	@Builder
-	public MatchResponse(Long id, TeamResponse homeTeam, TeamResponse awayTeam, String category) {
+	public MatchResponse(Long id, TeamResponse homeTeam, TeamResponse awayTeam, String place, String category) {
 		this.id = id;
 		this.homeTeam = homeTeam;
 		this.awayTeam = awayTeam;
+		this.place = place;
 		this.category = category;
 	}
 
@@ -31,6 +34,7 @@ public class MatchResponse {
 			.id(match.getId())
 			.homeTeam(TeamResponse.createResponse(match.getHomeTeam()))
 			.awayTeam(TeamResponse.createResponse(match.getAwayTeam()))
+			.place(match.getPlace())
 			.category(match.getCategory().name())
 			.build();
 	}

--- a/src/main/java/org/myteam/server/match/match/repository/MatchQueryRepository.java
+++ b/src/main/java/org/myteam/server/match/match/repository/MatchQueryRepository.java
@@ -29,7 +29,7 @@ public class MatchQueryRepository {
 			)
 			.fetch();
 	}
-	//
+
 	private BooleanExpression isBetweenDate(LocalDateTime startOfDay, LocalDateTime endTime) {
 		return match.startTime.between(startOfDay, endTime);
 	}

--- a/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
+++ b/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
@@ -33,7 +33,7 @@ public class MatchReadService {
 	public MatchScheduleListResponse findSchedulesBetweenDate(MatchCategory matchCategory) {
 		LocalDate today = LocalDate.now();
 		LocalDateTime startOfDay = today.atStartOfDay();
-		LocalDateTime endTime = today.plusDays(1).atTime(LocalTime.of(6, 0));
+		LocalDateTime endTime = today.plusWeeks(1).atTime(LocalTime.of(6, 0));
 
 		return MatchScheduleListResponse.createResponse(
 			matchQueryRepository.findSchedulesBetweenDate(startOfDay, endTime, matchCategory)


### PR DESCRIPTION
## 기능 설명
- 경기일정에 경기장소까지 응답하도록 추가했습니다.
- 일주일치 경기를 가져오도록 조건을 수정했습니다
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
