### PR TITLE
chore: 내가 쓴 게시글 목록 조회 RequestDto 새로 생성 후 변경

### DIFF
--- a/src/main/java/org/myteam/server/board/controller/BoardController.java
+++ b/src/main/java/org/myteam/server/board/controller/BoardController.java
@@ -125,21 +125,4 @@ public class BoardController {
         return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 목록 조회",
                 boardReadService.getBoardList(request.toServiceRequest())));
     }
-
-    /**
-     * 내가 쓴 게시글 목록 조회 (테스트용)
-     */
-    @Operation(summary = "내가 쓴 게시글 목록 조회 (테스트용)", description = "내가 쓴 게시글 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "내가 쓴 게시글 목록 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/my")
-    public ResponseEntity<ResponseDto<BoardListResponse>> getMyBoardList(
-            @ModelAttribute @Valid BoardSearchRequest request,
-            @AuthenticationPrincipal final CustomUserDetails userDetails) {
-
-        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "내가 쓴 게시글 목록 조회",
-                boardReadService.getMyBoardList(request.toServiceRequest(), userDetails.getPublicId())));
-    }
 }

--- a/src/main/java/org/myteam/server/board/service/BoardReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReadService.java
@@ -12,6 +12,7 @@ import org.myteam.server.board.repository.BoardRepository;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.page.response.PageCustomResponse;
+import org.myteam.server.mypage.dto.request.MyBoardServiceRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,21 +43,21 @@ public class BoardReadService {
         return BoardListResponse.createResponse(PageCustomResponse.of(boardPagingList));
     }
 
-    public BoardListResponse getMyBoardList(BoardServiceRequest boardServiceRequest, UUID publicId) {
+    public BoardListResponse getMyBoardList(MyBoardServiceRequest myBoardServiceRequest, UUID publicId) {
         log.info("내 게시글 조회: {} orderType: {}  searchType: {}, search: {}, page: {}, size: {}",
                 publicId,
-                boardServiceRequest.getOrderType(),
-                boardServiceRequest.getSearchType(),
-                boardServiceRequest.getSearch(),
-                boardServiceRequest.getPage(),
-                boardServiceRequest.getSize()
+                myBoardServiceRequest.getOrderType(),
+                myBoardServiceRequest.getSearchType(),
+                myBoardServiceRequest.getSearch(),
+                myBoardServiceRequest.getPage(),
+                myBoardServiceRequest.getSize()
         );
 
         Page<BoardDto> myBoardList = boardQueryRepository.getMyBoardList(
-                boardServiceRequest.getOrderType(),
-                boardServiceRequest.getSearchType(),
-                boardServiceRequest.getSearch(),
-                boardServiceRequest.toPageable(),
+                myBoardServiceRequest.getOrderType(),
+                myBoardServiceRequest.getSearchType(),
+                myBoardServiceRequest.getSearch(),
+                myBoardServiceRequest.toPageable(),
                 publicId
         );
         return BoardListResponse.createResponse(PageCustomResponse.of(myBoardList));

--- a/src/main/java/org/myteam/server/mypage/controller/MyPageController.java
+++ b/src/main/java/org/myteam/server/mypage/controller/MyPageController.java
@@ -12,22 +12,28 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.board.dto.reponse.BoardListResponse;
-import org.myteam.server.board.dto.request.BoardSearchRequest;
 import org.myteam.server.global.exception.ErrorResponse;
 import org.myteam.server.global.web.response.ResponseDto;
 import org.myteam.server.inquiry.dto.request.InquirySearchRequest;
 import org.myteam.server.inquiry.dto.response.InquiriesListResponse;
 import org.myteam.server.inquiry.dto.response.InquiryDetailsResponse;
-import org.myteam.server.inquiry.dto.response.InquiryResponse;
 import org.myteam.server.inquiry.service.InquiryReadService;
 import org.myteam.server.inquiry.service.InquiryService;
+import org.myteam.server.mypage.dto.request.MyBoardSearchRequest;
 import org.myteam.server.mypage.dto.request.MyPageRequest.MyPageUpdateRequest;
 import org.myteam.server.mypage.dto.response.MyPageResponse.MemberModifyResponse;
 import org.myteam.server.mypage.dto.response.MyPageResponse.MemberStatsResponse;
 import org.myteam.server.mypage.service.MyPageReadService;
 import org.myteam.server.mypage.service.MyPageService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -43,6 +49,7 @@ public class MyPageController {
 
     /**
      * 마이페이지 회원 정보 보여주기
+     *
      * @return
      */
     @Operation(summary = "마이페이지 회원 정보 조회", description = "로그인한 사용자의 정보를 조회합니다.")
@@ -64,6 +71,7 @@ public class MyPageController {
 
     /**
      * 마이페이지 회원 정보 수정 목록 보여주기
+     *
      * @return
      */
     @Operation(summary = "회원 정보 수정 페이지 조회", description = "회원 정보 수정 시 필요한 정보를 조회합니다.")
@@ -85,6 +93,7 @@ public class MyPageController {
 
     /**
      * 마이페이지 회원 정보 수정
+     *
      * @param myPageUpdateRequest
      * @return
      */
@@ -108,7 +117,8 @@ public class MyPageController {
 
     /**
      * 내가 쓴 게시글
-     * @param boardSearchRequest
+     *
+     * @param myBoardSearchRequest
      * @return
      */
     @Operation(summary = "내가 작성한 게시글 조회", description = "사용자가 작성한 게시글 목록을 조회합니다.")
@@ -119,8 +129,8 @@ public class MyPageController {
     })
     @GetMapping("/board")
     public ResponseEntity<ResponseDto<BoardListResponse>> getMyBoard(
-            @Valid @ModelAttribute BoardSearchRequest boardSearchRequest) {
-        BoardListResponse memberPosts = myPageReadService.getMemberPosts(boardSearchRequest.toServiceRequest());
+            @Valid @ModelAttribute MyBoardSearchRequest myBoardSearchRequest) {
+        BoardListResponse memberPosts = myPageReadService.getMemberPosts(myBoardSearchRequest.toServiceRequest());
 
         return ResponseEntity.ok(new ResponseDto<>(
                 SUCCESS.name(),
@@ -136,6 +146,7 @@ public class MyPageController {
 
     /**
      * 문의 내역 목록 조회
+     *
      * @param request
      * @return
      */

--- a/src/main/java/org/myteam/server/mypage/dto/request/MyBoardSearchRequest.java
+++ b/src/main/java/org/myteam/server/mypage/dto/request/MyBoardSearchRequest.java
@@ -1,0 +1,44 @@
+package org.myteam.server.mypage.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.myteam.server.board.domain.BoardOrderType;
+import org.myteam.server.board.domain.BoardSearchType;
+import org.myteam.server.global.page.request.PageInfoRequest;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MyBoardSearchRequest extends PageInfoRequest {
+    /**
+     * 정렬 타입
+     */
+    private BoardOrderType orderType;
+    /**
+     * 검색어 타입 (제목, 내용, 제목+내용,
+     */
+    private BoardSearchType searchType;
+    /**
+     * 검색어
+     */
+    private String search;
+
+    @Builder
+    public MyBoardSearchRequest(BoardOrderType orderType, BoardSearchType searchType, String search) {
+        this.orderType = orderType;
+        this.searchType = searchType;
+        this.search = search;
+    }
+
+    public MyBoardServiceRequest toServiceRequest() {
+        return MyBoardServiceRequest.builder()
+                .orderType(orderType)
+                .searchType(searchType)
+                .search(search)
+                .size(getSize())
+                .page(getPage())
+                .build();
+    }
+}

--- a/src/main/java/org/myteam/server/mypage/dto/request/MyBoardServiceRequest.java
+++ b/src/main/java/org/myteam/server/mypage/dto/request/MyBoardServiceRequest.java
@@ -1,0 +1,25 @@
+package org.myteam.server.mypage.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.board.domain.BoardOrderType;
+import org.myteam.server.board.domain.BoardSearchType;
+import org.myteam.server.global.page.request.PageInfoServiceRequest;
+
+@Getter
+@NoArgsConstructor
+public class MyBoardServiceRequest extends PageInfoServiceRequest {
+    private BoardOrderType orderType;
+    private BoardSearchType searchType;
+    private String search;
+
+    @Builder
+    public MyBoardServiceRequest(BoardOrderType orderType, BoardSearchType searchType, String search, int size,
+                                 int page) {
+        super(page, size);
+        this.orderType = orderType;
+        this.searchType = searchType;
+        this.search = search;
+    }
+}

--- a/src/main/java/org/myteam/server/mypage/service/MyPageReadService.java
+++ b/src/main/java/org/myteam/server/mypage/service/MyPageReadService.java
@@ -4,11 +4,11 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.board.dto.reponse.BoardListResponse;
-import org.myteam.server.board.dto.request.BoardServiceRequest;
 import org.myteam.server.board.service.BoardReadService;
 import org.myteam.server.inquiry.service.InquiryReadService;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.SecurityReadService;
+import org.myteam.server.mypage.dto.request.MyBoardServiceRequest;
 import org.myteam.server.mypage.dto.response.MyPageResponse.MemberModifyResponse;
 import org.myteam.server.mypage.dto.response.MyPageResponse.MemberStatsResponse;
 import org.springframework.stereotype.Service;
@@ -46,8 +46,8 @@ public class MyPageReadService {
         return MemberModifyResponse.createResponse(member);
     }
 
-    public BoardListResponse getMemberPosts(BoardServiceRequest boardServiceRequest) {
+    public BoardListResponse getMemberPosts(MyBoardServiceRequest myBoardServiceRequest) {
         Member member = securityReadService.getMember();
-        return boardReadService.getMyBoardList(boardServiceRequest, member.getPublicId());
+        return boardReadService.getMyBoardList(myBoardServiceRequest, member.getPublicId());
     }
 }


### PR DESCRIPTION
## 기능 설명
- 
## 작업 내용
- 영웅님께서 요청 주신 boardSearchRequest Dto와 내가쓴게시글 조회 dto 분리하였습니다

## 수정 사항
- MyPageController와 같은 API라서 BoardController에서 테스트용으로 쓰던 내가 쓴 게시글 목록 조회 제거하였습니다.

## 추가 작업 예정
- 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
