### PR TITLE
feat: 경기일정 날짜 조건 추가

### DIFF
--- a/src/main/java/org/myteam/server/match/match/domain/Match.java
+++ b/src/main/java/org/myteam/server/match/match/domain/Match.java
@@ -32,16 +32,19 @@ public class Match extends Base {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Team awayTeam;
 
+	private String place;
+
 	@Enumerated(EnumType.STRING)
 	private MatchCategory category;
 
 	private LocalDateTime startTime;
 
 	@Builder
-	public Match(Long id, Team homeTeam, Team awayTeam, MatchCategory category, LocalDateTime startTime) {
+	public Match(Long id, Team homeTeam, Team awayTeam, String place, MatchCategory category, LocalDateTime startTime) {
 		this.id = id;
 		this.homeTeam = homeTeam;
 		this.awayTeam = awayTeam;
+		this.place = place;
 		this.category = category;
 		this.startTime = startTime;
 	}

--- a/src/main/java/org/myteam/server/match/match/dto/service/response/MatchResponse.java
+++ b/src/main/java/org/myteam/server/match/match/dto/service/response/MatchResponse.java
@@ -15,14 +15,17 @@ public class MatchResponse {
 	private Long id;
 	private TeamResponse homeTeam;
 	private TeamResponse awayTeam;
+	@Schema(description = "경기장소")
+	private String place;
 	@Schema(description = "경기 유형 ID")
 	private String category;
 
 	@Builder
-	public MatchResponse(Long id, TeamResponse homeTeam, TeamResponse awayTeam, String category) {
+	public MatchResponse(Long id, TeamResponse homeTeam, TeamResponse awayTeam, String place, String category) {
 		this.id = id;
 		this.homeTeam = homeTeam;
 		this.awayTeam = awayTeam;
+		this.place = place;
 		this.category = category;
 	}
 
@@ -31,6 +34,7 @@ public class MatchResponse {
 			.id(match.getId())
 			.homeTeam(TeamResponse.createResponse(match.getHomeTeam()))
 			.awayTeam(TeamResponse.createResponse(match.getAwayTeam()))
+			.place(match.getPlace())
 			.category(match.getCategory().name())
 			.build();
 	}

--- a/src/main/java/org/myteam/server/match/match/repository/MatchQueryRepository.java
+++ b/src/main/java/org/myteam/server/match/match/repository/MatchQueryRepository.java
@@ -29,7 +29,7 @@ public class MatchQueryRepository {
 			)
 			.fetch();
 	}
-	//
+
 	private BooleanExpression isBetweenDate(LocalDateTime startOfDay, LocalDateTime endTime) {
 		return match.startTime.between(startOfDay, endTime);
 	}

--- a/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
+++ b/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
@@ -33,7 +33,7 @@ public class MatchReadService {
 	public MatchScheduleListResponse findSchedulesBetweenDate(MatchCategory matchCategory) {
 		LocalDate today = LocalDate.now();
 		LocalDateTime startOfDay = today.atStartOfDay();
-		LocalDateTime endTime = today.plusDays(1).atTime(LocalTime.of(6, 0));
+		LocalDateTime endTime = today.plusWeeks(1).atTime(LocalTime.of(6, 0));
 
 		return MatchScheduleListResponse.createResponse(
 			matchQueryRepository.findSchedulesBetweenDate(startOfDay, endTime, matchCategory)

--- a/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
@@ -57,7 +57,7 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 			);
 	}
 
-	@DisplayName("이전날짜나 다음날 새벽 6시 이후의 경기는 조회되지 않는다.")
+	@DisplayName("이전날짜나 일주일 이후의 경기는 조회되지 않는다.")
 	@Test
 	void findSchedulesBetweenDateTest2() {
 		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
@@ -67,7 +67,7 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().minusDays(1).atStartOfDay());
 		createMatch(team2, team3, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
 		createMatch(team3, team1, MatchCategory.FOOTBALL,
-			LocalDate.now().plusDays(1).atTime(LocalTime.of(7, 0)));
+			LocalDate.now().plusWeeks(1).atTime(LocalTime.of(7, 0)));
 
 		assertThat(matchReadService.findSchedulesBetweenDate(MatchCategory.FOOTBALL).getList())
 			.extracting(


### PR DESCRIPTION
## 기능 설명
- 경기 일주일치만 가져오도록 수정
- 경기일정 응답에 장소도 추가
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- memberid로 댓글 목록 조회 메소드 개발
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
