### PR TITLE
feat: 게임 이벤트, 할인 정보 조회 API 추가

### DIFF
--- a/src/main/java/org/myteam/server/game/controller/GameController.java
+++ b/src/main/java/org/myteam/server/game/controller/GameController.java
@@ -1,0 +1,63 @@
+package org.myteam.server.game.controller;
+
+
+import static org.myteam.server.global.web.response.ResponseStatus.SUCCESS;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.game.dto.response.GameDiscountListResponse;
+import org.myteam.server.game.dto.response.GameEventListResponse;
+import org.myteam.server.game.service.GameReadService;
+import org.myteam.server.global.exception.ErrorResponse;
+import org.myteam.server.global.page.request.PageInfoRequest;
+import org.myteam.server.global.web.response.ResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/game")
+@RequiredArgsConstructor
+@Tag(name = "게임 할인 및 이벤트 관련 API", description = "게임 할인 및 이벤트 정보 API")
+public class GameController {
+
+    private final GameReadService gameReadService;
+
+    /**
+     * 게임 이벤트 목록 조회 API
+     */
+    @Operation(summary = "게임 이벤트 목록 조회", description = "진행중인 게임 이벤트 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "게임 이벤트 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("/event")
+    public ResponseEntity<ResponseDto<GameEventListResponse>> getGameEventList(
+            @ModelAttribute @Valid PageInfoRequest pageInfoRequest) {
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게임 이벤트 목록 조회 성공",
+                gameReadService.getGameEventList(pageInfoRequest.toServiceRequest())));
+    }
+
+    /**
+     * 게임 할인 목록 조회 API
+     */
+    @Operation(summary = "게임 할인 목록 조회", description = "게임 할인 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "게임 할인 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("/discount")
+    public ResponseEntity<ResponseDto<GameDiscountListResponse>> getGameDiscountList(
+            @ModelAttribute @Valid PageInfoRequest pageInfoRequest) {
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게임 할인 목록 조회 성공",
+                gameReadService.getGameDiscountList(pageInfoRequest.toServiceRequest())));
+    }
+}

--- a/src/main/java/org/myteam/server/game/domain/GameDiscount.java
+++ b/src/main/java/org/myteam/server/game/domain/GameDiscount.java
@@ -1,0 +1,62 @@
+package org.myteam.server.game.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.global.domain.BaseTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_game_discount")
+public class GameDiscount extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    /**
+     * 게임 이미지
+     */
+    private String thumbImg;
+    /**
+     * 게임명
+     */
+    private String title;
+    /**
+     * 할인 전 가격
+     */
+    private String originalPrice;
+    /**
+     * 할인율
+     */
+    private String discountPercent;
+    /**
+     * 할인된 가격
+     */
+    private String finalPrice;
+    /**
+     * 연결 링크
+     */
+    private String link;
+    /**
+     * 노출 날짜
+     */
+    private LocalDateTime exposureDate;
+
+    @Builder
+    public GameDiscount(String thumbImg, String title, String originalPrice, String discountPercent,
+                        String finalPrice,
+                        String link, LocalDateTime exposureDate) {
+        this.thumbImg = thumbImg;
+        this.title = title;
+        this.originalPrice = originalPrice;
+        this.discountPercent = discountPercent;
+        this.finalPrice = finalPrice;
+        this.link = link;
+        this.exposureDate = exposureDate;
+    }
+}

--- a/src/main/java/org/myteam/server/game/domain/GameEvent.java
+++ b/src/main/java/org/myteam/server/game/domain/GameEvent.java
@@ -1,0 +1,56 @@
+package org.myteam.server.game.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.global.domain.BaseTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_game_event")
+public class GameEvent extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    /**
+     * 이벤트 이미지
+     */
+    private String thumbImg;
+    /**
+     * 이벤트 제목
+     */
+    private String title;
+    /**
+     * 이벤트 설명
+     */
+    private String description;
+    /**
+     * 이벤트 기간
+     */
+    private String period;
+    /**
+     * 연결 링크
+     */
+    private String link;
+    /**
+     * 노출 날짜
+     */
+    private LocalDateTime exposureDate;
+
+    @Builder
+    public GameEvent(String thumbImg, String title, String description, String period, String link,
+                     LocalDateTime exposureDate) {
+        this.thumbImg = thumbImg;
+        this.title = title;
+        this.description = description;
+        this.period = period;
+        this.link = link;
+        this.exposureDate = exposureDate;
+    }
+}

--- a/src/main/java/org/myteam/server/game/dto/response/GameDiscountDto.java
+++ b/src/main/java/org/myteam/server/game/dto/response/GameDiscountDto.java
@@ -1,0 +1,54 @@
+package org.myteam.server.game.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GameDiscountDto {
+    /**
+     * 게임 할인 ID
+     */
+    private Long id;
+    /**
+     * 게임 이미지
+     */
+    private String thumbImg;
+    /**
+     * 게임명
+     */
+    private String title;
+    /**
+     * 할인 전 가격
+     */
+    private String originalPrice;
+    /**
+     * 할인율
+     */
+    private String discountPercent;
+    /**
+     * 할인된 가격
+     */
+    private String finalPrice;
+    /**
+     * 연결 링크
+     */
+    private String link;
+    /**
+     * 노출 날짜
+     */
+    private LocalDateTime exposureDate;
+
+    public GameDiscountDto(Long id, String thumbImg, String title, String originalPrice, String discountPercent,
+                           String finalPrice, String link, LocalDateTime exposureDate) {
+        this.id = id;
+        this.thumbImg = thumbImg;
+        this.title = title;
+        this.originalPrice = originalPrice;
+        this.discountPercent = discountPercent;
+        this.finalPrice = finalPrice;
+        this.link = link;
+        this.exposureDate = exposureDate;
+    }
+}

--- a/src/main/java/org/myteam/server/game/dto/response/GameDiscountListResponse.java
+++ b/src/main/java/org/myteam/server/game/dto/response/GameDiscountListResponse.java
@@ -1,0 +1,24 @@
+package org.myteam.server.game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.global.page.response.PageCustomResponse;
+
+@Getter
+@NoArgsConstructor
+public class GameDiscountListResponse {
+
+    private PageCustomResponse<GameDiscountDto> list;
+
+    @Builder
+    public GameDiscountListResponse(PageCustomResponse<GameDiscountDto> list) {
+        this.list = list;
+    }
+
+    public static GameDiscountListResponse createResponse(PageCustomResponse<GameDiscountDto> list) {
+        return GameDiscountListResponse.builder()
+                .list(list)
+                .build();
+    }
+}

--- a/src/main/java/org/myteam/server/game/dto/response/GameEventDto.java
+++ b/src/main/java/org/myteam/server/game/dto/response/GameEventDto.java
@@ -1,0 +1,49 @@
+package org.myteam.server.game.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GameEventDto {
+    /**
+     * 게임 이벤트 ID
+     */
+    private Long id;
+    /**
+     * 이벤트 이미지
+     */
+    private String thumbImg;
+    /**
+     * 이벤트 제목
+     */
+    private String title;
+    /**
+     * 이벤트 설명
+     */
+    private String description;
+    /**
+     * 이벤트 기간
+     */
+    private String period;
+    /**
+     * 연결 링크
+     */
+    private String link;
+    /**
+     * 노출 날짜
+     */
+    private LocalDateTime exposureDate;
+
+    public GameEventDto(Long id, String thumbImg, String title, String description, String period, String link,
+                        LocalDateTime exposureDate) {
+        this.id = id;
+        this.thumbImg = thumbImg;
+        this.title = title;
+        this.description = description;
+        this.period = period;
+        this.link = link;
+        this.exposureDate = exposureDate;
+    }
+}

--- a/src/main/java/org/myteam/server/game/dto/response/GameEventListResponse.java
+++ b/src/main/java/org/myteam/server/game/dto/response/GameEventListResponse.java
@@ -1,0 +1,24 @@
+package org.myteam.server.game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.global.page.response.PageCustomResponse;
+
+@Getter
+@NoArgsConstructor
+public class GameEventListResponse {
+
+    private PageCustomResponse<GameEventDto> list;
+
+    @Builder
+    public GameEventListResponse(PageCustomResponse<GameEventDto> list) {
+        this.list = list;
+    }
+
+    public static GameEventListResponse createResponse(PageCustomResponse<GameEventDto> list) {
+        return GameEventListResponse.builder()
+                .list(list)
+                .build();
+    }
+}

--- a/src/main/java/org/myteam/server/game/repository/GameQueryRepository.java
+++ b/src/main/java/org/myteam/server/game/repository/GameQueryRepository.java
@@ -1,0 +1,102 @@
+package org.myteam.server.game.repository;
+
+import static org.myteam.server.game.domain.QGameDiscount.gameDiscount;
+import static org.myteam.server.game.domain.QGameEvent.gameEvent;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.myteam.server.game.dto.response.GameDiscountDto;
+import org.myteam.server.game.dto.response.GameEventDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class GameQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 게임 이벤트 목록 조회 (노출 날짜가 오늘인 것중 최대 10개 조회)
+     */
+    public Page<GameEventDto> getGameEventList(Pageable pageable) {
+        List<GameEventDto> content = queryFactory
+                .select(Projections.constructor(GameEventDto.class,
+                        gameEvent.id,
+                        gameEvent.thumbImg,
+                        gameEvent.title,
+                        gameEvent.description,
+                        gameEvent.period,
+                        gameEvent.link,
+                        gameEvent.exposureDate
+                ))
+                .from(gameEvent)
+                .where(gameEvent.exposureDate.eq(LocalDate.now().atStartOfDay()))
+                .orderBy(gameEvent.id.asc())
+                .offset(pageable.getOffset())
+                .limit(10)
+                .fetch();
+
+        long total = getTotalEventCount();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private long getTotalEventCount() {
+        // 전체 개수를 구할 때는 limit(10)을 제외하고 실제 데이터의 개수를 계산
+        long count = queryFactory
+                .select(gameEvent.count())
+                .from(gameEvent)
+                .where(gameEvent.exposureDate.eq(LocalDate.now().atStartOfDay()))
+                .fetchOne();
+
+        // 10개 이상이면 10을 반환
+        return Math.min(count, 10L);
+    }
+
+    /**
+     * 게임 할인 목록 조회 (노출 날짜가 오늘인 것중 최대 10개 조회)
+     */
+    public Page<GameDiscountDto> getGameDiscountList(Pageable pageable) {
+        List<GameDiscountDto> content = queryFactory
+                .select(Projections.constructor(GameDiscountDto.class,
+                        gameDiscount.id,
+                        gameDiscount.thumbImg,
+                        gameDiscount.title,
+                        gameDiscount.originalPrice,
+                        gameDiscount.discountPercent,
+                        gameDiscount.finalPrice,
+                        gameDiscount.link,
+                        gameDiscount.exposureDate
+                ))
+                .from(gameDiscount)
+                .where(gameDiscount.exposureDate.eq(LocalDate.now().atStartOfDay()))
+                .orderBy(gameDiscount.id.asc())
+                .offset(pageable.getOffset())
+                .limit(10)
+                .fetch();
+
+        long total = getTotalDiscountCount();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private long getTotalDiscountCount() {
+        // 전체 개수를 구할 때는 limit(10)을 제외하고 실제 데이터의 개수를 계산
+        long count = queryFactory
+                .select(gameDiscount.count())
+                .from(gameDiscount)
+                .where(gameDiscount.exposureDate.eq(LocalDate.now().atStartOfDay()))
+                .fetchOne();
+
+        // 10개 이상이면 10을 반환
+        return Math.min(count, 10L);
+    }
+}

--- a/src/main/java/org/myteam/server/game/service/GameReadService.java
+++ b/src/main/java/org/myteam/server/game/service/GameReadService.java
@@ -1,0 +1,35 @@
+package org.myteam.server.game.service;
+
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.game.dto.response.GameDiscountDto;
+import org.myteam.server.game.dto.response.GameDiscountListResponse;
+import org.myteam.server.game.dto.response.GameEventDto;
+import org.myteam.server.game.dto.response.GameEventListResponse;
+import org.myteam.server.game.repository.GameQueryRepository;
+import org.myteam.server.global.page.request.PageInfoServiceRequest;
+import org.myteam.server.global.page.response.PageCustomResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GameReadService {
+
+    private final GameQueryRepository gameQueryRepository;
+
+    public GameEventListResponse getGameEventList(PageInfoServiceRequest pageInfoServiceRequest) {
+        Page<GameEventDto> gameEventList = gameQueryRepository.getGameEventList(
+                pageInfoServiceRequest.toPageable()
+        );
+        return GameEventListResponse.createResponse(PageCustomResponse.of(gameEventList));
+    }
+
+    public GameDiscountListResponse getGameDiscountList(PageInfoServiceRequest pageInfoServiceRequest) {
+        Page<GameDiscountDto> gameDiscountList = gameQueryRepository.getGameDiscountList(
+                pageInfoServiceRequest.toPageable()
+        );
+        return GameDiscountListResponse.createResponse(PageCustomResponse.of(gameDiscountList));
+    }
+}

--- a/src/main/java/org/myteam/server/global/page/request/PageInfoRequest.java
+++ b/src/main/java/org/myteam/server/global/page/request/PageInfoRequest.java
@@ -10,13 +10,17 @@ import lombok.Setter;
 @NoArgsConstructor
 public class PageInfoRequest {
 
-	@Schema(description = "페이지 번호")
-	private int page = 1;
-	@Schema(description = "각 페이지 컨텐츠 갯수")
-	private int size = 12;
+    @Schema(description = "페이지 번호")
+    private int page = 1;
+    @Schema(description = "각 페이지 컨텐츠 갯수")
+    private int size = 12;
 
-	public PageInfoRequest(int page, int size) {
-		this.page = page;
-		this.size = size;
-	}
+    public PageInfoRequest(int page, int size) {
+        this.page = page;
+        this.size = size;
+    }
+
+    public PageInfoServiceRequest toServiceRequest() {
+        return new PageInfoServiceRequest(getPage(), getSize());
+    }
 }

--- a/src/main/java/org/myteam/server/global/page/request/PageInfoServiceRequest.java
+++ b/src/main/java/org/myteam/server/global/page/request/PageInfoServiceRequest.java
@@ -1,26 +1,23 @@
 package org.myteam.server.global.page.request;
 
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @Getter
 @NoArgsConstructor
 public class PageInfoServiceRequest {
 
-	private int page;
-	private int size;
+    private int page;
+    private int size;
 
-	public Pageable toPageable() {
-		return PageRequest.of(page - 1, size);
-	}
+    public Pageable toPageable() {
+        return PageRequest.of(page - 1, size);
+    }
 
-	public PageInfoServiceRequest(int page, int size) {
-		this.page = page;
-		this.size = size;
-	}
+    public PageInfoServiceRequest(int page, int size) {
+        this.page = page;
+        this.size = size;
+    }
 }

--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -1,8 +1,12 @@
 package org.myteam.server.global.security.config;
 
-import static org.myteam.server.auth.controller.ReIssueController.*;
-import static org.myteam.server.global.security.jwt.JwtProvider.*;
+import static org.myteam.server.auth.controller.ReIssueController.TOKEN_REISSUE_PATH;
+import static org.myteam.server.global.security.jwt.JwtProvider.HEADER_AUTHORIZATION;
+import static org.myteam.server.global.security.jwt.JwtProvider.REFRESH_TOKEN_KEY;
 
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.auth.repository.RefreshJpaRepository;
 import org.myteam.server.global.config.WebConfig;
 import org.myteam.server.global.security.filter.AuthenticationEntryPointHandler;
@@ -37,10 +41,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 @Configuration
 @EnableWebSecurity
@@ -48,224 +48,230 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	/* 권한 제외 대상 */
-	private static final String[] PERMIT_ALL_URLS = new String[] {
-		// Test Endpoints
-		/** @brief Exception Test */"/test/exception-test",
-		/** @brief Can Access All */"/test/all/**",
-		/** @brief Test login, create */"/api/test/**",
-		/** @brief Test Slack Integration */"/test/slack",
-		"/api/members/get-token/**", "/api/attachments/**", "/api/posts/**",
-		// Chat
-		"/ws-stomp/**",
-		// Health Check
-		/** @brief health check */
-		"/status",
-		// Swagger Documents
-		/** @brief Swagger Docs */
-		"/v3/api-docs/**", "/swagger-ui/**",
-		// Database console
-		/** @brief database url */
-		"/h2-console",
-		// Business Logic
-		/** @brief about login */"/auth/**",
-		/** @brief Allow static resource access */
-		"/upload/**",
-		/** @brief Allow user permission to change */
-		"/api/members/role",
-		"/api/certification/send",
-		"/api/certification/certify-code",
-		"/api/oauth2/members/email/**",
-		"/api/members/type/**",
-		"/api/me/create",
-		TOKEN_REISSUE_PATH,
+    /* 권한 제외 대상 */
+    private static final String[] PERMIT_ALL_URLS = new String[]{
+            // Test Endpoints
+            /** @brief Exception Test */"/test/exception-test",
+            /** @brief Can Access All */"/test/all/**",
+            /** @brief Test login, create */"/api/test/**",
+            /** @brief Test Slack Integration */"/test/slack",
+            "/api/members/get-token/**", "/api/attachments/**", "/api/posts/**",
+            // Chat
+            "/ws-stomp/**",
+            // Health Check
+            /** @brief health check */
+            "/status",
+            // Swagger Documents
+            /** @brief Swagger Docs */
+            "/v3/api-docs/**", "/swagger-ui/**",
+            // Database console
+            /** @brief database url */
+            "/h2-console",
+            // Business Logic
+            /** @brief about login */"/auth/**",
+            /** @brief Allow static resource access */
+            "/upload/**",
+            /** @brief Allow user permission to change */
+            "/api/members/role",
+            "/api/certification/send",
+            "/api/certification/certify-code",
+            "/api/oauth2/members/email/**",
+            "/api/members/type/**",
+            "/api/me/create",
+            TOKEN_REISSUE_PATH,
 
-		// 문의하기
-		"/api/inquiry",
+            // 문의하기
+            "/api/inquiry",
 
+            // 아이디-비밀번호 찾기
+            "/api/me/find-id/**",
+            "api/me/find-password",
+    };
 
-		// 아이디-비밀번호 찾기
-		"/api/me/find-id/**",
-		"api/me/find-password",
-	};
+    /**
+     * @brief Get 요청에서의 모든 사용자 인가
+     */
+    private static final String[] PUBLIC_GET_URLS = {
+            /** @brief 게시판 관련 URL */
+            "/api/board/{boardId}", // 게시글 상세 조회
+            "/api/board", // 게시글 목록 조회
+            "/api/board/comment/{boardCommentId}", // 게시판 댓글 상세 조회
+            "/api/board/{boardId}/comment",
 
-	/** @brief Get 요청에서의 모든 사용자 인가 */
-	private static final String[] PUBLIC_GET_URLS = {
-		/** @brief 게시판 관련 URL */
-		"/api/board/{boardId}", // 게시글 상세 조회
-		"/api/board", // 게시글 목록 조회
-		"/api/board/comment/{boardCommentId}", // 게시판 댓글 상세 조회
-		"/api/board/{boardId}/comment",
+            /** @brief 문의사항 관련 URL */
+            "/api/inquiry/{inquiryId}/comment",
+            "/api/inquiry/comment/{inquiryCommentId}",
 
-		/** @brief 문의사항 관련 URL */
-		"/api/inquiry/{inquiryId}/comment",
-		"/api/inquiry/comment/{inquiryCommentId}",
+            /** @brief 공지사항 관련 URL */
+            "/api/notice/{noticeId}",
+            "/api/notice",
+            "/api/notice/comment/{noticeCommentId}",
+            "/api/notice/{noticeId}/comment",
 
-		/** @brief 공지사항 관련 URL */
-		"/api/notice/{noticeId}",
-		"/api/notice",
-		"/api/notice/comment/{noticeCommentId}",
-		"/api/notice/{noticeId}/comment",
+            /** @brief 개선요청 관련 URL */
+            "/api/improvement/comment/{improvementCommentId}",
+            "/api/improvement/{improvementId}/comment",
+            "/api/improvement/{improvementId}",
+            "/api/improvement",
 
-		/** @brief 개선요청 관련 URL */
-		"/api/improvement/comment/{improvementCommentId}",
-		"/api/improvement/{improvementId}/comment",
-		"/api/improvement/{improvementId}",
-		"/api/improvement",
+            //뉴스
+            "/api/news",
+            "/api/news/{newId}",
+            "/api/news/comment",
+            "/api/news/comment/{newsCommentId}",
+            "/api/news/reply",
+            "/api/news/reply/{newReplyId}",
 
-		//뉴스
-		"/api/news",
-		"/api/news/{newId}",
-		"/api/news/comment",
-		"/api/news/comment/{newsCommentId}",
-		"/api/news/reply",
-		"/api/news/reply/{newReplyId}",
+            //경기일정
+            "/api/match/schedule/{matchCategory}",
+            "/api/match/{matchId}",
+            "/api/match/prediction/{matchId}",
 
-		//경기일정
-		"/api/match/schedule/{matchCategory}",
-		"/api/match/{matchId}",
-		"/api/match/prediction/{matchId}"
-	};
+            /** @brief 게임 할인, 이벤트 관련 URL */
+            "api/game/event",
+            "api/game/discount"
+    };
 
-	/* Admin 접근 권한 */
-	private static final String[] PERMIT_ADMIN_URLS = new String[] {
-		// Test Endpoints
-		/** @brief Check Access Admin */"/test/admin/**",
+    /* Admin 접근 권한 */
+    private static final String[] PERMIT_ADMIN_URLS = new String[]{
+            // Test Endpoints
+            /** @brief Check Access Admin */"/test/admin/**",
 
-		"/api/admin/**",
-		"/api/inquiries/answers/**",
-	};
+            "/api/admin/**",
+            "/api/inquiries/answers/**",
+    };
 
-	private static final String[] ADMIN_POST_URLS = {
-		"/api/notice"
-	};
+    private static final String[] ADMIN_POST_URLS = {
+            "/api/notice"
+    };
 
-	private static final String[] ADMIN_PUT_URLS = {
-		"/api/notice/{noticeId}"
-	};
+    private static final String[] ADMIN_PUT_URLS = {
+            "/api/notice/{noticeId}"
+    };
 
-	private static final String[] ADMIN_DELETE_URLS = {
-		"/api/notice/{noticeId}"
-	};
+    private static final String[] ADMIN_DELETE_URLS = {
+            "/api/notice/{noticeId}"
+    };
 
-	/* member 접근 권한 */
-	private static final String[] PERMIT_MEMBER_URLS = new String[] {
-		// Test Endpoints
-		/** @brief Check Access Member */"/test/cert",
-	};
+    /* member 접근 권한 */
+    private static final String[] PERMIT_MEMBER_URLS = new String[]{
+            // Test Endpoints
+            /** @brief Check Access Member */"/test/cert",
+    };
 
-	@Value("${FRONT_URL:http://localhost:3000}")
-	private String frontUrl;
-	private final JwtProvider jwtProvider;
-	private final WebConfig webConfig;
-	private final CustomUserDetailsService customUserDetailsService;
-	private final CustomOAuth2UserService customOAuth2UserService;
-	private final CustomOauth2SuccessHandler customOauth2SuccessHandler;
-	private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
-	private final RefreshJpaRepository refreshJpaRepository;
-	private final ApplicationEventPublisher eventPublisher;
+    @Value("${FRONT_URL:http://localhost:3000}")
+    private String frontUrl;
+    private final JwtProvider jwtProvider;
+    private final WebConfig webConfig;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOauth2SuccessHandler customOauth2SuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final RefreshJpaRepository refreshJpaRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
-	@PostConstruct
-	public void init() {
-		log.debug("init security config");
-		log.debug("frontUrl = {}", frontUrl);
-	}
+    @PostConstruct
+    public void init() {
+        log.debug("init security config");
+        log.debug("frontUrl = {}", frontUrl);
+    }
 
-	@Bean
-	public BCryptPasswordEncoder passwordEncoder() {
-		log.debug("BCryptPasswordEncoder 빈 등록됨");
-		return new BCryptPasswordEncoder();
-	}
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        log.debug("BCryptPasswordEncoder 빈 등록됨");
+        return new BCryptPasswordEncoder();
+    }
 
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		// HTTP 헤더 설정
-		http.headers(headers -> headers
-			.httpStrictTransportSecurity(HstsConfig::disable) // HSTS 비활성화
-			.frameOptions(FrameOptionsConfig::disable)        // FrameOptions 비활성화
-		);
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // HTTP 헤더 설정
+        http.headers(headers -> headers
+                .httpStrictTransportSecurity(HstsConfig::disable) // HSTS 비활성화
+                .frameOptions(FrameOptionsConfig::disable)        // FrameOptions 비활성화
+        );
 
-		// 기본 보안 설정 비활성화
-		http.logout((auth) -> auth.disable()) // 로그아웃 비활성화
-			.csrf((auth) -> auth.disable()) // csrf disable
-			.formLogin((auth) -> auth.disable()) // From 로그인 방식 disable
-			.httpBasic((auth) -> auth.disable()); // HTTP Basic 인증 방식 disable
+        // 기본 보안 설정 비활성화
+        http.logout((auth) -> auth.disable()) // 로그아웃 비활성화
+                .csrf((auth) -> auth.disable()) // csrf disable
+                .formLogin((auth) -> auth.disable()) // From 로그인 방식 disable
+                .httpBasic((auth) -> auth.disable()); // HTTP Basic 인증 방식 disable
 
-		// 세션 관리: Stateless
-		http.sessionManagement(session -> session
-			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-		);
+        // 세션 관리: Stateless
+        http.sessionManagement(session -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
 
-		// OAuth2 로그인 설정
-		http.oauth2Login(oauth2 -> oauth2
-			.userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
-			.successHandler(customOauth2SuccessHandler)
-			.failureHandler(oAuth2LoginFailureHandler)
-		);
+        // OAuth2 로그인 설정
+        http.oauth2Login(oauth2 -> oauth2
+                .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                .successHandler(customOauth2SuccessHandler)
+                .failureHandler(oAuth2LoginFailureHandler)
+        );
 
-		// JWT 인증 및 토큰 검증 필터 추가
-		http.addFilterAt(
-				new JwtAuthenticationFilter(authenticationManager(), jwtProvider, refreshJpaRepository, eventPublisher),
-				UsernamePasswordAuthenticationFilter.class
-			)
-			.addFilterAfter(new TokenAuthenticationFilter(jwtProvider), JwtAuthenticationFilter.class);
-		//                .addFilter(webConfig.corsFilter()); // CORS 필터 추가
+        // JWT 인증 및 토큰 검증 필터 추가
+        http.addFilterAt(
+                        new JwtAuthenticationFilter(authenticationManager(), jwtProvider, refreshJpaRepository, eventPublisher),
+                        UsernamePasswordAuthenticationFilter.class
+                )
+                .addFilterAfter(new TokenAuthenticationFilter(jwtProvider), JwtAuthenticationFilter.class);
+        //                .addFilter(webConfig.corsFilter()); // CORS 필터 추가
 
-		//        // cors 설정
-		http.cors((corsCustomizer) -> corsCustomizer.configurationSource(configurationSource()));
+        //        // cors 설정
+        http.cors((corsCustomizer) -> corsCustomizer.configurationSource(configurationSource()));
 
-		// 예외 처리 핸들러 설정
-		http.exceptionHandling(exceptionHandling -> exceptionHandling
-			.authenticationEntryPoint(new AuthenticationEntryPointHandler())
-			.accessDeniedHandler(new CustomAccessDeniedHandler())
-		);
+        // 예외 처리 핸들러 설정
+        http.exceptionHandling(exceptionHandling -> exceptionHandling
+                .authenticationEntryPoint(new AuthenticationEntryPointHandler())
+                .accessDeniedHandler(new CustomAccessDeniedHandler())
+        );
 
-		// 로그아웃 설정
-		http.logout(logout -> logout
-			.logoutUrl("/logout")
-			.invalidateHttpSession(true)
-			.logoutSuccessHandler(new LogoutSuccessHandler(jwtProvider, refreshJpaRepository))
-			.permitAll()
-		);
+        // 로그아웃 설정
+        http.logout(logout -> logout
+                .logoutUrl("/logout")
+                .invalidateHttpSession(true)
+                .logoutSuccessHandler(new LogoutSuccessHandler(jwtProvider, refreshJpaRepository))
+                .permitAll()
+        );
 
-		// 경로별 인가 작업
-		http.authorizeHttpRequests(authorizeRequests ->
-				authorizeRequests
-						.requestMatchers(PERMIT_ALL_URLS).permitAll()
-						.requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll() // 전체 접근 가능한 endpoint
+        // 경로별 인가 작업
+        http.authorizeHttpRequests(authorizeRequests ->
+                authorizeRequests
+                        .requestMatchers(PERMIT_ALL_URLS).permitAll()
+                        .requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll() // 전체 접근 가능한 endpoint
 
-						.requestMatchers(PERMIT_ADMIN_URLS).hasAnyAuthority(MemberRole.ADMIN.name())
-						.requestMatchers(HttpMethod.POST, ADMIN_POST_URLS).hasAuthority(MemberRole.ADMIN.name())
-						.requestMatchers(HttpMethod.PUT, ADMIN_PUT_URLS).hasAuthority(MemberRole.ADMIN.name())
-						.requestMatchers(HttpMethod.DELETE, ADMIN_DELETE_URLS).hasAuthority(MemberRole.ADMIN.name()) // 관리자만 접근 가능한 endpoint
+                        .requestMatchers(PERMIT_ADMIN_URLS).hasAnyAuthority(MemberRole.ADMIN.name())
+                        .requestMatchers(HttpMethod.POST, ADMIN_POST_URLS).hasAuthority(MemberRole.ADMIN.name())
+                        .requestMatchers(HttpMethod.PUT, ADMIN_PUT_URLS).hasAuthority(MemberRole.ADMIN.name())
+                        .requestMatchers(HttpMethod.DELETE, ADMIN_DELETE_URLS)
+                        .hasAuthority(MemberRole.ADMIN.name()) // 관리자만 접근 가능한 endpoint
 
-						.anyRequest().authenticated()                   // 나머지 요청은 모두 허용
-		);
+                        .anyRequest().authenticated()                   // 나머지 요청은 모두 허용
+        );
 
-		return http.build();
-	}
+        return http.build();
+    }
 
-	@Bean
-	public AuthenticationManager authenticationManager() {
-		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-		provider.setPasswordEncoder(passwordEncoder());
-		provider.setUserDetailsService(customUserDetailsService);
-		return new ProviderManager(provider);
-	}
+    @Bean
+    public AuthenticationManager authenticationManager() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setPasswordEncoder(passwordEncoder());
+        provider.setUserDetailsService(customUserDetailsService);
+        return new ProviderManager(provider);
+    }
 
-	public CorsConfigurationSource configurationSource() {
-		System.out.println("configurationSource cors 설정이 SecurityFilterChain에 등록됨");
-		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.addAllowedHeader("*");
-		configuration.addAllowedMethod("*");
-		configuration.addAllowedOriginPattern(frontUrl); // TODO_ 추후 변경 해야함 배포시
-		configuration.addAllowedOriginPattern("http://localhost:3000"); // TODO_ 추후 변경 해야함 배포시
-		configuration.setAllowCredentials(true);
-		configuration.addExposedHeader(HEADER_AUTHORIZATION);
-		configuration.addExposedHeader(REFRESH_TOKEN_KEY);
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", configuration);
-		return source;
-	}
+    public CorsConfigurationSource configurationSource() {
+        System.out.println("configurationSource cors 설정이 SecurityFilterChain에 등록됨");
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedOriginPattern(frontUrl); // TODO_ 추후 변경 해야함 배포시
+        configuration.addAllowedOriginPattern("http://localhost:3000"); // TODO_ 추후 변경 해야함 배포시
+        configuration.setAllowCredentials(true);
+        configuration.addExposedHeader(HEADER_AUTHORIZATION);
+        configuration.addExposedHeader(REFRESH_TOKEN_KEY);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 
 }


### PR DESCRIPTION
## 기능 설명
- 크롤링되어 저장된 진행중인 게임 이벤트와 게임 할인정보를 조회하는 API 입니다.
- 기획 확인 된 내용인 각각 최대 10개씩 조회(5개씩 2페이지) 될 수있도록 노출 날짜가 오늘인 것중 최대 10개 조회하여 조회합니다.
- 따로 검색필터 없이 페이징만 적용해서 page 관련 request부분도 page와 size만 받을 수 있도록 toServiceRequest추가하였습니다!

## 작업 내용
- 진행중인 게임 이벤트 목록 조회 API
- 게임 할인 목록 조회 API

## 수정 사항
- 

## 추가 작업 예정
- 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
