### PR TITLE
chore: 게시판 응답시 IP 뒷부분 마스크 처리

### DIFF
--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardCommentResponse.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardCommentResponse.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.myteam.server.board.domain.BoardComment;
 import org.myteam.server.member.entity.Member;
+import org.myteam.server.util.ClientUtils;
 
 @Getter
 @NoArgsConstructor
@@ -73,7 +74,7 @@ public class BoardCommentResponse {
                                 LocalDateTime lastModifiedDate, boolean isRecommended) {
         this.boardCommentId = boardCommentId;
         this.boardId = boardId;
-        this.createdIp = createdIp;
+        this.createdIp = ClientUtils.maskIp(createdIp);
         this.publicId = publicId;
         this.nickname = nickname;
         this.imageUrl = imageUrl;

--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardDto.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.myteam.server.board.domain.BoardType;
 import org.myteam.server.board.domain.CategoryType;
+import org.myteam.server.util.ClientUtils;
 
 @Getter
 @NoArgsConstructor
@@ -72,7 +73,7 @@ public class BoardDto {
         this.categoryType = categoryType;
         this.id = id;
         this.title = title;
-        this.createdIp = createdIp;
+        this.createdIp = ClientUtils.maskIp(createdIp);
         this.thumbnail = thumbnail;
         this.publicId = publicId;
         this.nickname = nickname;

--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardReplyResponse.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardReplyResponse.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.myteam.server.board.domain.BoardReply;
 import org.myteam.server.member.entity.Member;
+import org.myteam.server.util.ClientUtils;
 
 @Getter
 @NoArgsConstructor
@@ -75,7 +76,7 @@ public class BoardReplyResponse {
                               String mentionedNickname, LocalDateTime createDate, LocalDateTime lastModifiedDate) {
         this.boardCommentId = boardCommentId;
         this.boardReplyId = boardReplyId;
-        this.createdIp = createdIp;
+        this.createdIp = ClientUtils.maskIp(createdIp);
         this.publicId = publicId;
         this.nickname = nickname;
         this.imageUrl = imageUrl;

--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
@@ -10,6 +10,7 @@ import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.BoardCount;
 import org.myteam.server.board.domain.BoardType;
 import org.myteam.server.board.domain.CategoryType;
+import org.myteam.server.util.ClientUtils;
 
 @Getter
 @Setter
@@ -87,7 +88,7 @@ public class BoardResponse {
         this.boardId = board.getId();
         this.publicId = board.getMember().getPublicId();
         this.nickname = board.getMember().getNickname();
-        this.clientIp = board.getCreatedIp();
+        this.clientIp = ClientUtils.maskIp(board.getCreatedIp());
         this.title = board.getTitle();
         this.content = board.getContent();
         this.link = board.getLink();

--- a/src/main/java/org/myteam/server/util/ClientUtils.java
+++ b/src/main/java/org/myteam/server/util/ClientUtils.java
@@ -28,4 +28,14 @@ public class ClientUtils {
 
         return ip;
     }
+
+    /**
+     * IP 뒷자리 마스크 처리
+     */
+    public static String maskIp(String ip) {
+        if (ip == null || !ip.matches("\\d+\\.\\d+\\.\\d+\\.\\d+")) {
+            return ip;
+        }
+        return ip.replaceAll("(\\d+\\.\\d+\\.)(\\d+)(\\.)(\\d+)", "$1***$3**");
+    }
 }


### PR DESCRIPTION
## 기능 설명
- 
## 작업 내용
- 개발자 모드에서 response통해 IP 노출 안되도록 서버에서 IP 뒷부분 마스크 처리 하였습니다.

## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
