### PR TITLE
feat: 게시글 목록 조회시 최신 공지글 2개 고정 노출 추가

### DIFF
--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardListResponse.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardListResponse.java
@@ -1,23 +1,31 @@
 package org.myteam.server.board.dto.reponse;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.myteam.server.global.page.response.PageCustomResponse;
+import org.myteam.server.notice.dto.response.NoticeResponse.NoticeDto;
 
 @Getter
 @NoArgsConstructor
 public class BoardListResponse {
 
+    /**
+     * 공지사항
+     */
+    private List<NoticeDto> noticeList;
     private PageCustomResponse<BoardDto> list;
 
     @Builder
-    public BoardListResponse(PageCustomResponse<BoardDto> list) {
+    public BoardListResponse(List<NoticeDto> noticeList, PageCustomResponse<BoardDto> list) {
+        this.noticeList = noticeList;
         this.list = list;
     }
 
-    public static BoardListResponse createResponse(PageCustomResponse<BoardDto> list) {
+    public static BoardListResponse createResponse(List<NoticeDto> noticeList, PageCustomResponse<BoardDto> list) {
         return BoardListResponse.builder()
+                .noticeList(noticeList)
                 .list(list)
                 .build();
     }

--- a/src/main/java/org/myteam/server/board/service/BoardReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReadService.java
@@ -1,5 +1,6 @@
 package org.myteam.server.board.service;
 
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +14,8 @@ import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.page.response.PageCustomResponse;
 import org.myteam.server.mypage.dto.request.MyBoardServiceRequest;
+import org.myteam.server.notice.Repository.NoticeQueryRepository;
+import org.myteam.server.notice.dto.response.NoticeResponse.NoticeDto;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +28,7 @@ public class BoardReadService {
 
     private final BoardRepository boardRepository;
     private final BoardQueryRepository boardQueryRepository;
+    private final NoticeQueryRepository noticeQueryRepository;
 
     public Board findById(Long boardId) {
         return boardRepository.findById(boardId)
@@ -32,6 +36,7 @@ public class BoardReadService {
     }
 
     public BoardListResponse getBoardList(BoardServiceRequest boardServiceRequest) {
+        List<NoticeDto> noticeList = noticeQueryRepository.getFixNotice();
         Page<BoardDto> boardPagingList = boardQueryRepository.getBoardList(
                 boardServiceRequest.getBoardType(),
                 boardServiceRequest.getCategoryType(),
@@ -40,7 +45,7 @@ public class BoardReadService {
                 boardServiceRequest.getSearch(),
                 boardServiceRequest.toPageable()
         );
-        return BoardListResponse.createResponse(PageCustomResponse.of(boardPagingList));
+        return BoardListResponse.createResponse(noticeList, PageCustomResponse.of(boardPagingList));
     }
 
     public BoardListResponse getMyBoardList(MyBoardServiceRequest myBoardServiceRequest, UUID publicId) {
@@ -53,6 +58,8 @@ public class BoardReadService {
                 myBoardServiceRequest.getSize()
         );
 
+        List<NoticeDto> noticeList = noticeQueryRepository.getFixNotice();
+
         Page<BoardDto> myBoardList = boardQueryRepository.getMyBoardList(
                 myBoardServiceRequest.getOrderType(),
                 myBoardServiceRequest.getSearchType(),
@@ -60,7 +67,7 @@ public class BoardReadService {
                 myBoardServiceRequest.toPageable(),
                 publicId
         );
-        return BoardListResponse.createResponse(PageCustomResponse.of(myBoardList));
+        return BoardListResponse.createResponse(noticeList, PageCustomResponse.of(myBoardList));
     }
 
     public int getMyBoardListCount(UUID memberPublicId) {

--- a/src/main/java/org/myteam/server/notice/dto/response/NoticeResponse.java
+++ b/src/main/java/org/myteam/server/notice/dto/response/NoticeResponse.java
@@ -1,6 +1,8 @@
 package org.myteam.server.notice.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,9 +11,6 @@ import org.myteam.server.global.page.response.PageCustomResponse;
 import org.myteam.server.notice.domain.Notice;
 import org.myteam.server.notice.domain.NoticeCount;
 import org.myteam.server.util.ClientUtils;
-
-import java.time.LocalDateTime;
-import java.util.UUID;
 
 public record NoticeResponse() {
 
@@ -79,7 +78,6 @@ public record NoticeResponse() {
     public static final class NoticeDto {
         private Long id;
         private String title;
-        private String createdIp;
         private String thumbnail;
         private UUID publicId;
         private String nickname;


### PR DESCRIPTION
## 기능 설명
- 
## 작업 내용
- 게시글 목록 조회시 최신 공지글 최대 2개 고정 노출되도록 추가 하였습니다.

공지사항 최대 2개 고정 추가해야할 경우, noticeQueryRepository에 만들어두었으니 사용하시면 됩니다!
`List<NoticeDto> noticeList = noticeQueryRepository.getFixNotice();`

## 수정 사항
- NoticeDto에서 createdIP 응답으로는 안내려줘도 되어서 제거하였습니다!

## 추가 작업 예정
- 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
