### PR TITLE
chore: 게시글 목록 조회시 정렬 구체화 기획 반영

### DIFF
--- a/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
@@ -124,13 +124,14 @@ public class BoardQueryRepository {
         ).orElse(0L);
     }
 
-    private OrderSpecifier<?> isOrderByEqualToOrderCategory(BoardOrderType orderType) {
+    private OrderSpecifier<?>[] isOrderByEqualToOrderCategory(BoardOrderType orderType) {
         // default 최신순
         BoardOrderType boardOrderType = Optional.ofNullable(orderType).orElse(BoardOrderType.CREATE);
         return switch (boardOrderType) {
-            case CREATE -> board.createDate.desc();
-            case RECOMMEND -> boardCount.recommendCount.desc();
-            case COMMENT -> boardCount.commentCount.desc();
+            case CREATE -> new OrderSpecifier<?>[]{board.createDate.desc(), board.title.asc(), board.id.desc()};
+            case RECOMMEND -> new OrderSpecifier<?>[]{boardCount.recommendCount.desc(),
+                    boardCount.commentCount.add(boardCount.viewCount).desc(), board.title.asc(), board.id.desc()};
+            case COMMENT -> new OrderSpecifier<?>[]{boardCount.commentCount.desc(), board.title.asc(), board.id.desc()};
         };
     }
 


### PR DESCRIPTION
## 기능 설명
- 목록 조회시에 정렬 기준이 같을경우 N차 정렬에 대한 기획 확정을 받아 반영하였습니다 !

```
- 인기순
    - 추천수 내림차순 > 조회수 + 댓글수 내림차순 > 제목 오름차순
- 최신순
    - 날짜순 내림차순 > 제목 오름차순
- 댓글순
    - 댓글수 내림차순 > 제목 오름차순
```

이렇게 확정 지어주셨는데 저는 제목 오름차순 뒤에 id값 내림차순까지 추가하였습니다!

## 작업 내용
- 게시글 목록 조회 시 정렬 구체화

## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
