### PR TITLE
fix: 뉴스조회수 증가 controller단으로 옮김

### DIFF
--- a/src/main/java/org/myteam/server/news/news/controller/NewsController.java
+++ b/src/main/java/org/myteam/server/news/news/controller/NewsController.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class NewsController {
 
 	private final NewsReadService newsReadService;
+	private final NewsCountService newsCountService;
 
 	@Operation(summary = "뉴스 목록 조회 API", description = "뉴스의 목록을 조회합니다.")
 	@GetMapping
@@ -46,6 +47,7 @@ public class NewsController {
 		@Parameter(description = "뉴스 ID")
 		Long newsId
 	) {
+		newsCountService.addViewCount(newsId);
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
 			"뉴스 상세 조회 성공",

--- a/src/main/java/org/myteam/server/news/news/service/NewsReadService.java
+++ b/src/main/java/org/myteam/server/news/news/service/NewsReadService.java
@@ -1,6 +1,5 @@
 package org.myteam.server.news.news.service;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import org.myteam.server.global.exception.ErrorCode;
@@ -15,8 +14,6 @@ import org.myteam.server.news.news.dto.service.response.NewsResponse;
 import org.myteam.server.news.news.repository.NewsQueryRepository;
 import org.myteam.server.news.news.repository.NewsRepository;
 import org.myteam.server.news.newsCount.service.NewsCountReadService;
-import org.myteam.server.news.newsCount.service.NewsCountService;
-import org.myteam.server.news.newsCountMember.domain.NewsCountMember;
 import org.myteam.server.news.newsCountMember.service.NewsCountMemberReadService;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -34,7 +31,6 @@ public class NewsReadService {
 	private final NewsCountReadService newsCountReadService;
 	private final NewsCountMemberReadService newsCountMemberReadService;
 	private final SecurityReadService securityReadService;
-	private final NewsCountService newsCountService;
 
 	public NewsListResponse findAll(NewsServiceRequest newsServiceRequest) {
 		Page<NewsDto> newsPagingList = newsQueryRepository.getNewsList(newsServiceRequest);
@@ -46,7 +42,6 @@ public class NewsReadService {
 		UUID publicId = securityReadService.getAuthenticatedPublicId();
 
 		boolean recommendYn = publicId != null && newsCountMemberReadService.confirmRecommendMember(newsId, publicId);
-		newsCountService.addViewCount(newsId);
 
 		return NewsResponse.createResponse(
 			findById(newsId),
@@ -54,7 +49,6 @@ public class NewsReadService {
 			recommendYn
 		);
 	}
-
 
 	public News findById(Long newsId) {
 		return newsRepository.findById(newsId)


### PR DESCRIPTION
## 기능 설명
- 의존성 순환 문제로 인한 Controller에서 조회수 증가시키도록
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
