### PR TITLE
feat: 뉴스 리스트 조회시 댓글 수도 내려주도록 추가

### DIFF
--- a/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
+++ b/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
@@ -22,15 +22,18 @@ public class NewsDto {
 	private String thumbImg;
 	@Schema(description = "뉴스 본문")
 	private String content;
+	@Schema(description = "뉴스 댓글 수")
+	private int commentCount;
 	@Schema(description = "뉴스 계시 날짜")
 	private LocalDateTime postDate;
 
-	public NewsDto(Long id, NewsCategory category, String title, String thumbImg, String content, LocalDateTime postDate) {
+	public NewsDto(Long id, NewsCategory category, String title, String thumbImg, String content, int commentCount, LocalDateTime postDate) {
 		this.id = id;
 		this.category = category;
 		this.title = title;
 		this.thumbImg = thumbImg;
 		this.content = content;
+		this.commentCount = commentCount;
 		this.postDate = postDate;
 	}
 }

--- a/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
@@ -43,6 +43,7 @@ public class NewsQueryRepository {
 				news.title,
 				news.thumbImg,
 				news.content,
+				newsCount.commentCount,
 				news.postDate
 			))
 			.from(news)

--- a/src/test/java/org/myteam/server/news/news/service/NewsReadServiceTest.java
+++ b/src/test/java/org/myteam/server/news/news/service/NewsReadServiceTest.java
@@ -58,11 +58,11 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 3L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content")
+				.extracting("title", "category", "thumbImg", "content", "commentCount")
 				.containsExactly(
-					tuple("기사타이틀4", NewsCategory.BASEBALL, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀2", NewsCategory.BASEBALL, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문")
+					tuple("기사타이틀4", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 12),
+					tuple("기사타이틀2", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 14),
+					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 10)
 				)
 		);
 	}
@@ -103,12 +103,12 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 4L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content")
+				.extracting("title", "category", "thumbImg", "content", "commentCount")
 				.containsExactly(
-					tuple("기사타이틀7", NewsCategory.ESPORTS, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀6", NewsCategory.ESPORTS, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀5", NewsCategory.ESPORTS, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀4", NewsCategory.ESPORTS, "www.test.com", "뉴스본문")
+					tuple("기사타이틀7", NewsCategory.ESPORTS, "www.test.com", "뉴스본문", 15),
+					tuple("기사타이틀6", NewsCategory.ESPORTS, "www.test.com", "뉴스본문", 30),
+					tuple("기사타이틀5", NewsCategory.ESPORTS, "www.test.com", "뉴스본문", 20),
+					tuple("기사타이틀4", NewsCategory.ESPORTS, "www.test.com", "뉴스본문", 12)
 				)
 		);
 	}
@@ -153,12 +153,12 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 4L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content")
+				.extracting("title", "category", "thumbImg", "content", "commentCount")
 				.containsExactly(
-					tuple("기사타이틀11", NewsCategory.FOOTBALL, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀10", NewsCategory.FOOTBALL, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀9", NewsCategory.FOOTBALL, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀8", NewsCategory.FOOTBALL, "www.test.com", "뉴스본문")
+					tuple("기사타이틀11", NewsCategory.FOOTBALL, "www.test.com", "뉴스본문", 14),
+					tuple("기사타이틀10", NewsCategory.FOOTBALL, "www.test.com", "뉴스본문", 13),
+					tuple("기사타이틀9", NewsCategory.FOOTBALL, "www.test.com", "뉴스본문", 12),
+					tuple("기사타이틀8", NewsCategory.FOOTBALL, "www.test.com", "뉴스본문", 11)
 				)
 		);
 	}
@@ -189,12 +189,12 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 4L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content")
+				.extracting("title", "category", "thumbImg", "content", "commentCount")
 				.containsExactly(
-					tuple("기사타이틀4", NewsCategory.BASEBALL, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀2", NewsCategory.BASEBALL, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문")
+					tuple("기사타이틀4", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 12),
+					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문", 15),
+					tuple("기사타이틀2", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 14),
+					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 10)
 				)
 		);
 	}
@@ -226,10 +226,10 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 2L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content")
+				.extracting("title", "category", "thumbImg", "content", "commentCount")
 				.containsExactly(
-					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문")
+					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문", 15),
+					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 10)
 				)
 		);
 	}
@@ -261,10 +261,10 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 2L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content")
+				.extracting("title", "category", "thumbImg", "content", "commentCount")
 				.containsExactly(
-					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문")
+					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문", 15),
+					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 10)
 				)
 		);
 	}
@@ -296,10 +296,10 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 2L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content")
+				.extracting("title", "category", "thumbImg", "content", "commentCount")
 				.containsExactly(
-					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문")
+					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 10),
+					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문", 15)
 				)
 		);
 	}
@@ -331,10 +331,10 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 2L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content")
+				.extracting("title", "category", "thumbImg", "content", "commentCount")
 				.containsExactly(
-					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문"),
-					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문")
+					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 10),
+					tuple("기사타이틀3", NewsCategory.ESPORTS, "www.test.com", "뉴스본문", 15)
 				)
 		);
 	}
@@ -366,9 +366,9 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 1L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content")
+				.extracting("title", "category", "thumbImg", "content", "commentCount")
 				.containsExactly(
-					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문")
+					tuple("기사타이틀1", NewsCategory.BASEBALL, "www.test.com", "뉴스본문", 10)
 				)
 		);
 	}


### PR DESCRIPTION
## 기능 설명
- 뉴스 리스트 조회시 댓글 수도 내려주도록 추가했습니다.
## 작업 내용
- NewsQueryRepository commentCount 추가
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
