### PR TITLE
feat: 마이페이지 댓글 count 추가

### DIFF
--- a/src/main/java/org/myteam/server/board/repository/BoardCommentQueryRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardCommentQueryRepository.java
@@ -133,6 +133,24 @@ public class BoardCommentQueryRepository {
         return replies;
     }
 
+    public int getCommentCountByPublicId(UUID publicId) {
+        return queryFactory
+                .select(boardComment.count())
+                .from(boardComment)
+                .where(boardComment.member.publicId.eq(publicId))
+                .fetchOne()
+                .intValue();
+    }
+
+    public int getReplyCountByPublicId(UUID publicId) {
+        return queryFactory
+                .select(boardReply.count())
+                .from(boardReply)
+                .where(boardReply.member.publicId.eq(publicId))
+                .fetchOne()
+                .intValue();
+    }
+
     private BooleanExpression isBoardCommentEqualTo(Long boardCommentId) {
         return boardReply.boardComment.id.eq(boardCommentId);
     }

--- a/src/main/java/org/myteam/server/board/service/BoardCommentReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardCommentReadService.java
@@ -67,4 +67,8 @@ public class BoardCommentReadService {
     public boolean existsById(Long id) {
         return boardCommentRepository.existsById(id);
     }
+
+    public int getCommentCountByMemberPublicId(UUID publicId) {
+        return boardCommentQueryRepository.getCommentCountByPublicId(publicId);
+    }
 }

--- a/src/main/java/org/myteam/server/board/service/BoardReplyReadService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardReplyReadService.java
@@ -1,8 +1,11 @@
 package org.myteam.server.board.service;
 
 import java.util.List;
+import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import org.myteam.server.board.domain.BoardReply;
+import org.myteam.server.board.repository.BoardCommentQueryRepository;
 import org.myteam.server.board.repository.BoardReplyRepository;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
@@ -15,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BoardReplyReadService {
 
     private final BoardReplyRepository boardReplyRepository;
+    private final BoardCommentQueryRepository boardCommentQueryRepository;
 
     public BoardReply findById(Long boardReplyId) {
         return boardReplyRepository.findById(boardReplyId)
@@ -31,5 +35,9 @@ public class BoardReplyReadService {
 
     public boolean existsById(Long id) {
         return boardReplyRepository.existsById(id);
+    }
+
+    public int getReplyCountByMemberPublicId(UUID publicId) {
+        return boardCommentQueryRepository.getReplyCountByPublicId(publicId);
     }
 }

--- a/src/main/java/org/myteam/server/improvement/repository/ImprovementCommentQueryRepository.java
+++ b/src/main/java/org/myteam/server/improvement/repository/ImprovementCommentQueryRepository.java
@@ -103,6 +103,24 @@ public class ImprovementCommentQueryRepository {
         return replies;
     }
 
+    public int getCommentCountByPublicId(UUID publicId) {
+        return queryFactory
+                .select(improvementComment.count())
+                .from(improvementComment)
+                .where(improvementComment.member.publicId.eq(publicId))
+                .fetchOne()
+                .intValue();
+    }
+
+    public int getReplyCountByPublicId(UUID publicId) {
+        return queryFactory
+                .select(improvementReply.count())
+                .from(improvementReply)
+                .where(improvementReply.member.publicId.eq(publicId))
+                .fetchOne()
+                .intValue();
+    }
+
     private BooleanExpression isImprovementCommentEqualTo(Long improvementCommentId) {
         return improvementReply.improvementComment.id.eq(improvementCommentId);
     }

--- a/src/main/java/org/myteam/server/improvement/service/ImprovementCommentReadService.java
+++ b/src/main/java/org/myteam/server/improvement/service/ImprovementCommentReadService.java
@@ -68,4 +68,8 @@ public class ImprovementCommentReadService {
         log.info("개선요청 댓글: {} 상세 조회 성공", improvementCommentId);
         return response;
     }
+
+    public int getCommentCountByMemberPublicId(UUID publicId) {
+        return improvementCommentQueryRepository.getCommentCountByPublicId(publicId);
+    }
 }

--- a/src/main/java/org/myteam/server/improvement/service/ImprovementReplyReadService.java
+++ b/src/main/java/org/myteam/server/improvement/service/ImprovementReplyReadService.java
@@ -4,11 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.improvement.domain.ImprovementReply;
+import org.myteam.server.improvement.repository.ImprovementCommentQueryRepository;
 import org.myteam.server.improvement.repository.ImprovementReplyRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +18,7 @@ import java.util.List;
 public class ImprovementReplyReadService {
 
     private final ImprovementReplyRepository improvementReplyRepository;
+    private final ImprovementCommentQueryRepository improvementCommentQueryRepository;
 
     public ImprovementReply findById(Long improvementReplyId) {
         return improvementReplyRepository.findById(improvementReplyId)
@@ -24,5 +27,9 @@ public class ImprovementReplyReadService {
 
     public List<ImprovementReply> findByImprovementCommentId(Long improvementCommentId) {
         return improvementReplyRepository.findByImprovementCommentId(improvementCommentId);
+    }
+
+    public int getReplyCountByMemberPublicId(UUID publicId) {
+        return improvementCommentQueryRepository.getReplyCountByPublicId(publicId);
     }
 }

--- a/src/main/java/org/myteam/server/inquiry/repository/InquiryCommentQueryRepository.java
+++ b/src/main/java/org/myteam/server/inquiry/repository/InquiryCommentQueryRepository.java
@@ -1,5 +1,6 @@
 package org.myteam.server.inquiry.repository;
 
+import static org.myteam.server.inquiry.domain.QInquiryComment.inquiryComment;
 import static org.myteam.server.inquiry.domain.QInquiryReply.inquiryReply;
 
 import com.querydsl.core.types.Projections;
@@ -10,6 +11,7 @@ import org.myteam.server.inquiry.dto.response.InquiryCommentResponse.*;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.UUID;
 
 @Repository
 @RequiredArgsConstructor
@@ -39,6 +41,24 @@ public class InquiryCommentQueryRepository {
                 .fetch();
 
         return replies;
+    }
+
+    public int getCommentCountByPublicId(UUID publicId) {
+        return queryFactory
+                .select(inquiryComment.count())
+                .from(inquiryComment)
+                .where(inquiryComment.member.publicId.eq(publicId))
+                .fetchOne()
+                .intValue();
+    }
+
+    public int getReplyCountByPublicId(UUID publicId) {
+        return queryFactory
+                .select(inquiryReply.count())
+                .from(inquiryReply)
+                .where(inquiryReply.member.publicId.eq(publicId))
+                .fetchOne()
+                .intValue();
     }
 
     private BooleanExpression isInquiryCommentEqualTo(Long inquiryCommentId) {

--- a/src/main/java/org/myteam/server/inquiry/service/InquiryCommentReadService.java
+++ b/src/main/java/org/myteam/server/inquiry/service/InquiryCommentReadService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -49,5 +50,9 @@ public class InquiryCommentReadService {
 
     public boolean existsById(Long id) {
         return inquiryCommentRepository.existsById(id);
+    }
+
+    public int getCommentCountByMemberPublicId(UUID publicId) {
+        return inquiryCommentQueryRepository.getCommentCountByPublicId(publicId);
     }
 }

--- a/src/main/java/org/myteam/server/inquiry/service/InquiryReplyReadService.java
+++ b/src/main/java/org/myteam/server/inquiry/service/InquiryReplyReadService.java
@@ -5,11 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.inquiry.domain.InquiryReply;
+import org.myteam.server.inquiry.repository.InquiryCommentQueryRepository;
 import org.myteam.server.inquiry.repository.InquiryReplyRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -18,6 +20,7 @@ import java.util.List;
 public class InquiryReplyReadService {
 
     private final InquiryReplyRepository inquiryReplyRepository;
+    private final InquiryCommentQueryRepository inquiryCommentQueryRepository;
 
     public InquiryReply findById(Long inquiryReplyId) {
         return inquiryReplyRepository.findById(inquiryReplyId)
@@ -30,5 +33,9 @@ public class InquiryReplyReadService {
 
     public boolean existsById(Long id) {
         return inquiryReplyRepository.existsById(id);
+    }
+
+    public int getReplyCountByMemberPublicId(UUID publicId) {
+        return inquiryCommentQueryRepository.getReplyCountByPublicId(publicId);
     }
 }

--- a/src/main/java/org/myteam/server/mypage/controller/MyPageController.java
+++ b/src/main/java/org/myteam/server/mypage/controller/MyPageController.java
@@ -104,7 +104,9 @@ public class MyPageController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @PutMapping("/modify")
-    public ResponseEntity<ResponseDto<String>> updateMyInfo(@RequestBody MyPageUpdateRequest myPageUpdateRequest) {
+    public ResponseEntity<ResponseDto<String>> updateMyInfo(
+            @RequestBody MyPageUpdateRequest myPageUpdateRequest
+    ) {
         myPageService.updateMemberInfo(myPageUpdateRequest);
 
         return ResponseEntity.ok(new ResponseDto<>(
@@ -128,7 +130,8 @@ public class MyPageController {
     })
     @GetMapping("/board")
     public ResponseEntity<ResponseDto<BoardListResponse>> getMyBoard(
-            @Valid @ModelAttribute MyBoardSearchRequest myBoardSearchRequest) {
+            @Valid @ModelAttribute MyBoardSearchRequest myBoardSearchRequest
+    ) {
         BoardListResponse memberPosts = myPageReadService.getMemberPosts(myBoardSearchRequest.toServiceRequest());
 
         return ResponseEntity.ok(new ResponseDto<>(
@@ -159,8 +162,7 @@ public class MyPageController {
     public ResponseEntity<ResponseDto<InquiriesListResponse>> getMyInquiry(
             @Valid @ModelAttribute InquirySearchRequest request
     ) {
-        InquiriesListResponse inquiriesListResponse = inquiryReadService
-                .getInquiriesByMember(request.toServiceRequest());
+        InquiriesListResponse inquiriesListResponse = inquiryReadService.getInquiriesByMember(request.toServiceRequest());
 
         return ResponseEntity.ok(new ResponseDto<>(
                 SUCCESS.name(),

--- a/src/main/java/org/myteam/server/mypage/service/MyPageReadService.java
+++ b/src/main/java/org/myteam/server/mypage/service/MyPageReadService.java
@@ -4,13 +4,25 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.board.dto.reponse.BoardListResponse;
+import org.myteam.server.board.service.BoardCommentReadService;
 import org.myteam.server.board.service.BoardReadService;
+import org.myteam.server.board.service.BoardReplyReadService;
+import org.myteam.server.improvement.domain.Improvement;
+import org.myteam.server.improvement.domain.ImprovementReply;
+import org.myteam.server.improvement.service.ImprovementCommentReadService;
+import org.myteam.server.improvement.service.ImprovementReplyReadService;
+import org.myteam.server.inquiry.service.InquiryCommentReadService;
 import org.myteam.server.inquiry.service.InquiryReadService;
+import org.myteam.server.inquiry.service.InquiryReplyReadService;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.SecurityReadService;
 import org.myteam.server.mypage.dto.request.MyBoardServiceRequest;
 import org.myteam.server.mypage.dto.response.MyPageResponse.MemberModifyResponse;
 import org.myteam.server.mypage.dto.response.MyPageResponse.MemberStatsResponse;
+import org.myteam.server.news.newsComment.service.NewsCommentReadService;
+import org.myteam.server.news.newsReply.service.NewsReplyReadService;
+import org.myteam.server.notice.service.NoticeCommentReadService;
+import org.myteam.server.notice.service.NoticeReplyReadService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +34,18 @@ public class MyPageReadService {
 
     private final SecurityReadService securityReadService;
     private final BoardReadService boardReadService;
+
+    private final BoardCommentReadService boardCommentReadService;
+    private final BoardReplyReadService boardReplyReadService;
+    private final ImprovementCommentReadService improvementCommentReadService;
+    private final ImprovementReplyReadService improvementReplyReadService;
+    private final InquiryCommentReadService inquiryCommentReadService;
+    private final InquiryReplyReadService inquiryReplyReadService;
+    private final NewsCommentReadService newsCommentReadService;
+    private final NewsReplyReadService newsReplyReadService;
+    private final NoticeCommentReadService noticeCommentReadService;
+    private final NoticeReplyReadService noticeReplyReadService;
+
     private final InquiryReadService inquiryReadService;
 
     /**
@@ -33,21 +57,44 @@ public class MyPageReadService {
     public MemberStatsResponse getMemberInfo() {
         Member member = securityReadService.getMember();
         UUID publicId = member.getPublicId();
+        log.info("내 정보: {} 조회 요청", publicId);
 
         int postCount = boardReadService.getMyBoardListCount(publicId);
-        int commentCount = 0;
+        int commentCount = getTotalCommentCount(publicId);
         int inquiryCount = inquiryReadService.getInquiriesCountByMember(publicId);
+
+        log.info("내 정보: {} 조회 성공", publicId);
 
         return MemberStatsResponse.createResponse(member, postCount, commentCount, inquiryCount);
     }
 
     public MemberModifyResponse getMemberAllInfo() {
         Member member = securityReadService.getMember();
+        log.info("내 수정 정보: {} 조회 요청", member.getPublicId());
+
+        log.info("내 수정 정보: {} 조회 성공", member.getPublicId());
         return MemberModifyResponse.createResponse(member);
     }
 
     public BoardListResponse getMemberPosts(MyBoardServiceRequest myBoardServiceRequest) {
         Member member = securityReadService.getMember();
+        log.info("내가 쓴 게시글: {} 조회 요청", member.getPublicId());
         return boardReadService.getMyBoardList(myBoardServiceRequest, member.getPublicId());
+    }
+
+    /**
+     * 내가 작성한 모든 댓글 수를 계산하는 메서드
+     */
+    private int getTotalCommentCount(UUID publicId) {
+        return boardCommentReadService.getCommentCountByMemberPublicId(publicId)
+                + boardReplyReadService.getReplyCountByMemberPublicId(publicId)
+                + improvementCommentReadService.getCommentCountByMemberPublicId(publicId)
+                + improvementReplyReadService.getReplyCountByMemberPublicId(publicId)
+                + inquiryCommentReadService.getCommentCountByMemberPublicId(publicId)
+                + inquiryReplyReadService.getReplyCountByMemberPublicId(publicId)
+                + newsCommentReadService.getCommentCountByMemberPublicId(publicId)
+                + newsReplyReadService.getReplyCountByMemberPublicId(publicId)
+                + noticeCommentReadService.getCommentCountByMemberPublicId(publicId)
+                + noticeReplyReadService.getReplyCountByMemberPublicId(publicId);
     }
 }

--- a/src/main/java/org/myteam/server/mypage/service/MyPageService.java
+++ b/src/main/java/org/myteam/server/mypage/service/MyPageService.java
@@ -25,11 +25,11 @@ public class MyPageService {
     private final SecurityReadService securityReadService;
     private final MemberJpaRepository memberJpaRepository;
     private final MemberValidator memberValidator;
-    private final AESCryptoUtil cryptoUtil;
     private final PasswordEncoder passwordEncoder;
 
     public void updateMemberInfo(MyPageUpdateRequest request) {
         Member member = securityReadService.getMember();
+        log.info("회원 정보: {} 수정 요청", member.getPublicId());
 
         if (!member.verifyOwnEmail(request.getEmail())) {
             throw new PlayHiveException(ErrorCode.UNAUTHORIZED);
@@ -50,6 +50,6 @@ public class MyPageService {
         }
 
         memberJpaRepository.save(member);
-        log.info("저장되었습니다.");
+        log.info("회원 정보: {} 수정 성공", member.getPublicId());
     }
 }

--- a/src/main/java/org/myteam/server/news/newsComment/repository/NewsCommentQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/newsComment/repository/NewsCommentQueryRepository.java
@@ -3,6 +3,7 @@ package org.myteam.server.news.newsComment.repository;
 import static java.util.Optional.*;
 import static org.myteam.server.news.newsComment.domain.QNewsComment.*;
 import static org.myteam.server.news.newsCommentMember.domain.QNewsCommentMember.*;
+import static org.myteam.server.news.newsReply.domain.QNewsReply.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -81,6 +82,15 @@ public class NewsCommentQueryRepository {
 			.orderBy(newsComment.recommendCount.desc())
 			.limit(BEST_COMMENT_COUNT)
 			.fetch();
+	}
+
+	public int getCommentCountByPublicId(UUID publicId) {
+		return queryFactory
+				.select(newsComment.count())
+				.from(newsComment)
+				.where(newsComment.member.publicId.eq(publicId))
+				.fetchOne()
+				.intValue();
 	}
 
 	private long getTotalNewsCount(Long newsId) {

--- a/src/main/java/org/myteam/server/news/newsComment/service/NewsCommentReadService.java
+++ b/src/main/java/org/myteam/server/news/newsComment/service/NewsCommentReadService.java
@@ -1,6 +1,7 @@
 package org.myteam.server.news.newsComment.service;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
@@ -55,6 +56,10 @@ public class NewsCommentReadService {
 
 	public boolean existsById(Long id) {
 		return newsCommentRepository.existsById(id);
+	}
+
+	public int getCommentCountByMemberPublicId(UUID publicId) {
+		return newsCommentQueryRepository.getCommentCountByPublicId(publicId);
 	}
 
 }

--- a/src/main/java/org/myteam/server/news/newsReply/repository/NewsReplyQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/newsReply/repository/NewsReplyQueryRepository.java
@@ -57,6 +57,15 @@ public class NewsReplyQueryRepository {
 		return new PageImpl<>(content, pageable, total);
 	}
 
+	public int getReplyCountByPublicId(UUID publicId) {
+		return queryFactory
+				.select(newsReply.count())
+				.from(newsReply)
+				.where(newsReply.member.publicId.eq(publicId))
+				.fetchOne()
+				.intValue();
+	}
+
 	private long getTotalNewsCount(Long newsCommentId) {
 		return ofNullable(
 			queryFactory

--- a/src/main/java/org/myteam/server/news/newsReply/service/NewsReplyReadService.java
+++ b/src/main/java/org/myteam/server/news/newsReply/service/NewsReplyReadService.java
@@ -54,4 +54,8 @@ public class NewsReplyReadService {
 		return newsReplyRepository.existsById(id);
 	}
 
+	public int getReplyCountByMemberPublicId(UUID publicId) {
+		return newsReplyQueryRepository.getReplyCountByPublicId(publicId);
+	}
+
 }

--- a/src/main/java/org/myteam/server/notice/Repository/NoticeCommentQueryRepository.java
+++ b/src/main/java/org/myteam/server/notice/Repository/NoticeCommentQueryRepository.java
@@ -100,6 +100,24 @@ public class NoticeCommentQueryRepository {
         return replies;
     }
 
+    public int getCommentCountByPublicId(UUID publicId) {
+        return queryFactory
+                .select(noticeComment.count())
+                .from(noticeComment)
+                .where(noticeComment.member.publicId.eq(publicId))
+                .fetchOne()
+                .intValue();
+    }
+
+    public int getReplyCountByPublicId(UUID publicId) {
+        return queryFactory
+                .select(noticeReply.count())
+                .from(noticeReply)
+                .where(noticeReply.member.publicId.eq(publicId))
+                .fetchOne()
+                .intValue();
+    }
+
     private BooleanExpression isNoticeEqualTo(Long noticeId) {
         return noticeComment.notice.id.eq(noticeId);
     }

--- a/src/main/java/org/myteam/server/notice/service/NoticeCommentReadService.java
+++ b/src/main/java/org/myteam/server/notice/service/NoticeCommentReadService.java
@@ -61,4 +61,8 @@ public class NoticeCommentReadService {
 
         return response;
     }
+
+    public int getCommentCountByMemberPublicId(UUID publicId) {
+        return noticeCommentQueryRepository.getCommentCountByPublicId(publicId);
+    }
 }

--- a/src/main/java/org/myteam/server/notice/service/NoticeReplyReadService.java
+++ b/src/main/java/org/myteam/server/notice/service/NoticeReplyReadService.java
@@ -3,12 +3,14 @@ package org.myteam.server.notice.service;
 import lombok.RequiredArgsConstructor;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.notice.Repository.NoticeCommentQueryRepository;
 import org.myteam.server.notice.Repository.NoticeReplyRepository;
 import org.myteam.server.notice.domain.NoticeReply;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +18,7 @@ import java.util.List;
 public class NoticeReplyReadService {
 
     private final NoticeReplyRepository noticeReplyRepository;
+    private final NoticeCommentQueryRepository noticeCommentQueryRepository;
 
     public NoticeReply findById(Long noticeReplyId) {
         return noticeReplyRepository.findById(noticeReplyId)
@@ -24,5 +27,9 @@ public class NoticeReplyReadService {
 
     public List<NoticeReply> findByNoticeCommentId(Long noticeCommentId) {
         return noticeReplyRepository.findByNoticeCommentId(noticeCommentId);
+    }
+
+    public int getReplyCountByMemberPublicId(UUID publicId) {
+        return noticeCommentQueryRepository.getReplyCountByPublicId(publicId);
     }
 }


### PR DESCRIPTION
## 기능 설명
- 마이페이지 내 댓글 추가
## 작업 내용
- 마이페이지 내 댓글 카운트를 구현하였습니다.
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
