### PR TITLE
fix: member가 null이면 false로 반환되도록

### DIFF
--- a/src/main/java/org/myteam/server/news/newsComment/repository/NewsCommentQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/newsComment/repository/NewsCommentQueryRepository.java
@@ -100,7 +100,9 @@ public class NewsCommentQueryRepository {
 	}
 
 	private BooleanExpression existsNewsCommentMember(UUID memberId) {
-		return JPAExpressions.selectOne()
+		return memberId == null
+			? Expressions.FALSE
+			: JPAExpressions.selectOne()
 			.from(newsCommentMember)
 			.where(newsCommentMember.newsComment.id.eq(newsComment.id)
 				.and(newsCommentMember.member.publicId.eq(memberId)))


### PR DESCRIPTION
## 기능 설명
- jwt토큰을 안받았을시 사용자가 null이면 에러가 발생해 오류 수정하엿습니다
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
