### PR TITLE
fix: redis 캐시 설정

### DIFF
--- a/src/main/java/org/myteam/server/global/config/RedisConfig.java
+++ b/src/main/java/org/myteam/server/global/config/RedisConfig.java
@@ -6,7 +6,9 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
@@ -15,10 +17,14 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+
 @Configuration
 @EnableCaching
 @RequiredArgsConstructor
 public class RedisConfig {
+
+    private final int EXPIRED_CACHING_TIME = 10;
 
     @Value("${spring.data.redis.host}")
     private String host;
@@ -62,6 +68,9 @@ public class RedisConfig {
      */
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-        return RedisCacheManager.builder(redisConnectionFactory).build();
+        return RedisCacheManager.builder(RedisCacheWriter.nonLockingRedisCacheWriter(redisConnectionFactory))
+                .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig()
+                        .entryTtl(Duration.ofMinutes(EXPIRED_CACHING_TIME)))
+                .build();
     }
 }


### PR DESCRIPTION
## 기능 설명
- 레디스 캐시 디테일한 설정
## 작업 내용
- 레디스 캐시 설정 5분으로 하였습니다.
- `@Cacheable`을 통해서 캐싱할 수 있습니다.
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
