### PR TITLE
fix: 뉴스댓글 삭제시 하위 참조 테이블 데이터도 함께 삭제되도록 추가

### DIFF
--- a/src/main/java/org/myteam/server/news/newsComment/domain/NewsComment.java
+++ b/src/main/java/org/myteam/server/news/newsComment/domain/NewsComment.java
@@ -1,15 +1,22 @@
 package org.myteam.server.news.newsComment.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.myteam.server.global.domain.Base;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.news.news.domain.News;
+import org.myteam.server.news.newsCommentMember.domain.NewsCommentMember;
+import org.myteam.server.news.newsReply.domain.NewsReply;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,6 +44,12 @@ public class NewsComment extends Base {
 	private String imgUrl;
 
 	private int recommendCount;
+
+	@OneToMany(mappedBy = "newsComment", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<NewsCommentMember> newsCommentMemberList = new ArrayList<>();
+
+	@OneToMany(mappedBy = "newsComment", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<NewsReply> newsReplyList = new ArrayList<>();
 
 	@Builder
 	public NewsComment(Long id, News news, Member member, String comment, String ip, String imgUrl,

--- a/src/main/java/org/myteam/server/news/newsReply/domain/NewsReply.java
+++ b/src/main/java/org/myteam/server/news/newsReply/domain/NewsReply.java
@@ -4,6 +4,7 @@ import org.myteam.server.global.domain.Base;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.news.newsComment.domain.NewsComment;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/src/test/java/org/myteam/server/news/newsComment/service/NewsCommentServiceTest.java
+++ b/src/test/java/org/myteam/server/news/newsComment/service/NewsCommentServiceTest.java
@@ -15,13 +15,22 @@ import org.myteam.server.news.newsComment.domain.NewsComment;
 import org.myteam.server.news.newsComment.dto.service.request.NewsCommentSaveServiceRequest;
 import org.myteam.server.news.newsComment.dto.service.request.NewsCommentUpdateServiceRequest;
 import org.myteam.server.news.newsComment.dto.service.response.NewsCommentResponse;
+import org.myteam.server.news.newsReply.dto.service.request.NewsReplySaveServiceRequest;
+import org.myteam.server.news.newsReply.dto.service.response.NewsReplyResponse;
+import org.myteam.server.news.newsReply.service.NewsReplyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.persistence.EntityManager;
 
 public class NewsCommentServiceTest extends IntegrationTestSupport {
 
 	@Autowired
 	private NewsCommentService newsCommentService;
+	@Autowired
+	private NewsReplyService newsReplyService;
+	@Autowired
+	private EntityManager entityManager;
 
 	@DisplayName("뉴스댓글을 저장한다.")
 	@Test
@@ -76,6 +85,18 @@ public class NewsCommentServiceTest extends IntegrationTestSupport {
 		Member member = createMember(1);
 
 		NewsComment newsComment = createNewsComment(news, member, "뉴스 댓글 테스트", 10);
+
+		NewsReplySaveServiceRequest newsReplySaveServiceRequest = NewsReplySaveServiceRequest.builder()
+			.newsCommentId(newsComment.getId())
+			.comment("대댓글 테스트")
+			.ip("1.1.1.1")
+			.imgUrl("www.test.com")
+			.build();
+
+		NewsReplyResponse newsReplyResponse = newsReplyService.save(newsReplySaveServiceRequest);
+
+		entityManager.clear();
+
 		Long deletedCommentId = newsCommentService.delete(newsComment.getId());
 
 		assertAll(


### PR DESCRIPTION
## 기능 설명
-  뉴스댓글 삭제시 하위 참조 테이블 데이터도 함께 삭제되도록 추가
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
