### PR TITLE
feat: 뉴스 대댓글 댓글수 포함

### DIFF
--- a/src/main/java/org/myteam/server/news/newsComment/service/NewsCommentService.java
+++ b/src/main/java/org/myteam/server/news/newsComment/service/NewsCommentService.java
@@ -64,6 +64,7 @@ public class NewsCommentService {
 		newsCommentRepository.deleteById(newsCommentId);
 
 		newsCountService.minusCommendCount(newsComment.getNews().getId());
+		newsCountService.minusCommendCount(newsComment.getNews().getId(), newsComment.getNewsReplyList().size()); //대댓글의 삭제 숫자 만큼 마이너스
 
 		return newsComment.getId();
 	}

--- a/src/main/java/org/myteam/server/news/newsCount/domain/NewsCount.java
+++ b/src/main/java/org/myteam/server/news/newsCount/domain/NewsCount.java
@@ -54,6 +54,9 @@ public class NewsCount {
 	public void minusCommentCount() {
 		this.commentCount -= 1;
 	}
+	public void minusCommentCount(int count) {
+		this.commentCount -= count;
+	}
 
 	public void addViewCount() {
 		this.viewCount += 1;

--- a/src/main/java/org/myteam/server/news/newsCount/service/NewsCountService.java
+++ b/src/main/java/org/myteam/server/news/newsCount/service/NewsCountService.java
@@ -56,6 +56,10 @@ public class NewsCountService {
 		newsCountReadService.findByNewsIdLock(newsId).minusCommentCount();
 	}
 
+	public void minusCommendCount(Long newsId, int count) {
+		newsCountReadService.findByNewsIdLock(newsId).minusCommentCount(count);
+	}
+
 	public void addViewCount(Long newsId) {
 		newsCountReadService.findByNewsIdLock(newsId).addViewCount();
 	}

--- a/src/main/java/org/myteam/server/news/newsReply/service/NewsReplyService.java
+++ b/src/main/java/org/myteam/server/news/newsReply/service/NewsReplyService.java
@@ -4,6 +4,7 @@ import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.SecurityReadService;
 import org.myteam.server.news.newsComment.domain.NewsComment;
 import org.myteam.server.news.newsComment.service.NewsCommentReadService;
+import org.myteam.server.news.newsCount.service.NewsCountService;
 import org.myteam.server.news.newsReply.domain.NewsReply;
 import org.myteam.server.news.newsReply.dto.service.request.NewsReplySaveServiceRequest;
 import org.myteam.server.news.newsReply.dto.service.request.NewsReplyUpdateServiceRequest;
@@ -27,10 +28,13 @@ public class NewsReplyService {
 	private final SecurityReadService securityReadService;
 	private final NewsReplyMemberReadService newsReplyMemberReadService;
 	private final NewsReplyMemberService newsReplyMemberService;
+	private final NewsCountService newsCountService;
 
 	public NewsReplyResponse save(NewsReplySaveServiceRequest newsReplySaveServiceRequest) {
 		NewsComment newsComment = newsCommentReadService.findById(newsReplySaveServiceRequest.getNewsCommentId());
 		Member member = securityReadService.getMember();
+
+		newsCountService.addCommendCount(newsComment.getNews().getId());
 
 		return NewsReplyResponse.createResponse(
 			newsReplyRepository.save(
@@ -56,6 +60,7 @@ public class NewsReplyService {
 		newsReply.confirmMember(member);
 
 		newsReplyRepository.deleteById(newsReplyId);
+		newsCountService.minusCommendCount(newsReply.getNewsComment().getNews().getId());
 		return newsReply.getId();
 	}
 

--- a/src/test/java/org/myteam/server/news/newsComment/service/NewsCommentServiceTest.java
+++ b/src/test/java/org/myteam/server/news/newsComment/service/NewsCommentServiceTest.java
@@ -79,7 +79,6 @@ public class NewsCommentServiceTest extends IntegrationTestSupport {
 
 	@DisplayName("뉴스댓글을 삭제한다.")
 	@Test
-	@Transactional
 	void deleteTest() {
 		News news = createNews(1, NewsCategory.BASEBALL, 10);
 		Member member = createMember(1);


### PR DESCRIPTION
## 기능 설명
- 뉴스 대댓글 추가 삭제시 뉴스 댓글수 카운팅 증가, 감소하도록 수정했습니다.
## 작업 내용
- NewsCommentService, NewsReplyService에서 NewsCountService를 의존성 주입받아 사용하였습니다.
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
