### PR TITLE
chore: 게시판, 개선요청, 문의, 뉴스, 공지사항 상세조회 시 이전글, 다음글 ID 추가

### DIFF
--- a/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
+++ b/src/main/java/org/myteam/server/board/dto/reponse/BoardResponse.java
@@ -80,9 +80,17 @@ public class BoardResponse {
      * 수정 일시
      */
     private LocalDateTime lastModifiedDate;
+    /**
+     * 이전글
+     */
+    private Long previousId;
+    /**
+     * 다음글
+     */
+    private Long nextId;
 
     @Builder
-    public BoardResponse(Board board, BoardCount boardCount, boolean isRecommended) {
+    public BoardResponse(Board board, BoardCount boardCount, boolean isRecommended, Long previousId, Long nextId) {
         this.boardType = board.getBoardType();
         this.categoryType = board.getCategoryType();
         this.boardId = board.getId();
@@ -99,13 +107,18 @@ public class BoardResponse {
         this.viewCount = boardCount.getViewCount();
         this.createDate = board.getCreateDate();
         this.lastModifiedDate = board.getLastModifiedDate();
+        this.previousId = previousId;
+        this.nextId = nextId;
     }
 
-    public static BoardResponse createResponse(Board board, BoardCount boardCount, boolean isRecommended) {
+    public static BoardResponse createResponse(Board board, BoardCount boardCount, boolean isRecommended,
+                                               Long previousId, Long nextId) {
         return BoardResponse.builder()
                 .board(board)
                 .boardCount(boardCount)
                 .isRecommended(isRecommended)
+                .previousId(previousId)
+                .nextId(nextId)
                 .build();
     }
 }

--- a/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
+++ b/src/main/java/org/myteam/server/board/repository/BoardQueryRepository.java
@@ -304,4 +304,28 @@ public class BoardQueryRepository {
 
         return hotBoardList;
     }
+
+    public Long findPreviousBoardId(Long boardId, Category boardType, CategoryType categoryType) {
+        return queryFactory
+                .select(board.id)
+                .from(board)
+                .where(board.id.lt(boardId), // 현재 게시글보다 작은 ID
+                        board.boardType.eq(boardType),
+                        board.categoryType.eq(categoryType))
+                .orderBy(board.id.desc()) // 가장 큰 ID (즉, 이전 글)
+                .limit(1)
+                .fetchOne();
+    }
+
+    public Long findNextBoardId(Long boardId, Category boardType, CategoryType categoryType) {
+        return queryFactory
+                .select(board.id)
+                .from(board)
+                .where(board.id.gt(boardId), // 현재 게시글보다 큰 ID
+                        board.boardType.eq(boardType),
+                        board.categoryType.eq(categoryType))
+                .orderBy(board.id.asc()) // 가장 작은 ID (즉, 다음 글)
+                .limit(1)
+                .fetchOne();
+    }
 }

--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -9,6 +9,7 @@ import org.myteam.server.board.domain.CategoryType;
 import org.myteam.server.board.dto.reponse.BoardResponse;
 import org.myteam.server.board.dto.request.BoardRequest;
 import org.myteam.server.board.repository.BoardCountRepository;
+import org.myteam.server.board.repository.BoardQueryRepository;
 import org.myteam.server.board.repository.BoardRecommendRepository;
 import org.myteam.server.board.repository.BoardRepository;
 import org.myteam.server.comment.domain.CommentType;
@@ -33,6 +34,7 @@ public class BoardService {
     private final BoardCountRepository boardCountRepository;
     private final BoardRecommendRepository boardRecommendRepository;
     private final MemberRepository memberRepository;
+    private final BoardQueryRepository boardQueryRepository;
 
     private final SecurityReadService securityReadService;
     private final BoardReadService boardReadService;
@@ -60,8 +62,14 @@ public class BoardService {
 
         boolean isRecommended = boardRecommendReadService.isRecommended(board.getId(), loginUser);
 
+        // 이전글/다음글 ID 조회 (게시판 타입(BASEBALL, FOOTBALL...), 카테고리 타입(FREE,QUESTION...) 기준으로 조회)
+        Long previousId = boardQueryRepository.findPreviousBoardId(board.getId(), board.getBoardType(),
+                board.getCategoryType());
+        Long nextId = boardQueryRepository.findNextBoardId(board.getId(), board.getBoardType(),
+                board.getCategoryType());
+
         log.info("게시판 생성: {}", loginUser);
-        return BoardResponse.createResponse(board, boardCount, isRecommended);
+        return BoardResponse.createResponse(board, boardCount, isRecommended, previousId, nextId);
     }
 
     /**
@@ -113,7 +121,13 @@ public class BoardService {
             isRecommended = boardRecommendReadService.isRecommended(board.getId(), loginUser);
         }
 
-        return BoardResponse.createResponse(board, boardCount, isRecommended);
+        // 이전글/다음글 ID 조회 (게시판 타입(BASEBALL, FOOTBALL...), 카테고리 타입(FREE,QUESTION...) 기준으로 조회)
+        Long previousId = boardQueryRepository.findPreviousBoardId(boardId, board.getBoardType(),
+                board.getCategoryType());
+        Long nextId = boardQueryRepository.findNextBoardId(boardId, board.getBoardType(), board.getCategoryType());
+
+        return BoardResponse.createResponse(board, boardCount, isRecommended, previousId,
+                nextId);
     }
 
     /**
@@ -136,7 +150,14 @@ public class BoardService {
         BoardCount boardCount = boardCountReadService.findByBoardId(board.getId());
 
         boolean isRecommended = boardRecommendReadService.isRecommended(board.getId(), loginUser);
-        return BoardResponse.createResponse(board, boardCount, isRecommended);
+
+        // 이전글/다음글 ID 조회 (게시판 타입(BASEBALL, FOOTBALL...), 카테고리 타입(FREE,QUESTION...) 기준으로 조회)
+        Long previousId = boardQueryRepository.findPreviousBoardId(board.getId(), board.getBoardType(),
+                board.getCategoryType());
+        Long nextId = boardQueryRepository.findNextBoardId(board.getId(), board.getBoardType(),
+                board.getCategoryType());
+
+        return BoardResponse.createResponse(board, boardCount, isRecommended, previousId, nextId);
     }
 
     /**

--- a/src/main/java/org/myteam/server/improvement/dto/response/ImprovementResponse.java
+++ b/src/main/java/org/myteam/server/improvement/dto/response/ImprovementResponse.java
@@ -35,9 +35,17 @@ public record ImprovementResponse() {
         private int viewCount; // 조회 수
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
+        /**
+         * 이전글
+         */
+        private Long previousId;
+        /**
+         * 다음글
+         */
+        private Long nextId;
 
         public static ImprovementSaveResponse createResponse(Improvement improvement, ImprovementCount improvementCount,
-                                                             boolean isRecommended) {
+                                                             boolean isRecommended, Long previousId, Long nextId) {
             return ImprovementSaveResponse.builder()
                     .noticeId(improvement.getId())
                     .publicId(improvement.getMember().getPublicId())
@@ -53,6 +61,8 @@ public record ImprovementResponse() {
                     .viewCount(improvementCount.getViewCount())
                     .createdAt(improvement.getCreateDate())
                     .modifiedAt(improvement.getLastModifiedDate())
+                    .previousId(previousId)
+                    .nextId(nextId)
                     .build();
         }
     }

--- a/src/main/java/org/myteam/server/improvement/repository/ImprovementQueryRepository.java
+++ b/src/main/java/org/myteam/server/improvement/repository/ImprovementQueryRepository.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.myteam.server.comment.domain.CommentType;
 import org.myteam.server.comment.domain.QComment;
 import org.myteam.server.comment.domain.QImprovementComment;
@@ -83,7 +82,8 @@ public class ImprovementQueryRepository {
                     .where(
                             QComment.comment1.comment.like("%" + search + "%")
                                     .and(QComment.comment1.commentType.eq(CommentType.IMPROVEMENT))
-                                    .and(QComment.comment1.as(QImprovementComment.class).improvement.id.eq(improvement.id))
+                                    .and(QComment.comment1.as(QImprovementComment.class).improvement.id.eq(
+                                            improvement.id))
                     )
                     .exists();
             default -> null;
@@ -109,5 +109,26 @@ public class ImprovementQueryRepository {
                         .where(isSearchTypeLikeTo(searchType, search))
                         .fetchOne()
         ).orElse(0L);
+    }
+
+    public Long findPreviousImprovementId(Long improvementId) {
+        return queryFactory
+                .select(improvement.id)
+                .from(improvement)
+                .where(improvement.id.lt(improvementId))
+                .orderBy(improvement.id.desc()) // 가장 큰 ID (즉, 이전 글)
+                .limit(1)
+                .fetchOne();
+    }
+
+
+    public Long findNextImprovementId(Long improvementId) {
+        return queryFactory
+                .select(improvement.id)
+                .from(improvement)
+                .where(improvement.id.gt(improvementId))
+                .orderBy(improvement.id.asc()) // 가장 작은 ID (즉, 다음 글)
+                .limit(1)
+                .fetchOne();
     }
 }

--- a/src/main/java/org/myteam/server/improvement/service/ImprovementReadService.java
+++ b/src/main/java/org/myteam/server/improvement/service/ImprovementReadService.java
@@ -1,15 +1,17 @@
 package org.myteam.server.improvement.service;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.page.response.PageCustomResponse;
-import org.myteam.server.global.security.dto.CustomUserDetails;
 import org.myteam.server.improvement.domain.Improvement;
 import org.myteam.server.improvement.domain.ImprovementCount;
-import org.myteam.server.improvement.dto.request.ImprovementRequest.*;
-import org.myteam.server.improvement.dto.response.ImprovementResponse.*;
+import org.myteam.server.improvement.dto.request.ImprovementRequest.ImprovementServiceRequest;
+import org.myteam.server.improvement.dto.response.ImprovementResponse.ImprovementDto;
+import org.myteam.server.improvement.dto.response.ImprovementResponse.ImprovementListResponse;
+import org.myteam.server.improvement.dto.response.ImprovementResponse.ImprovementSaveResponse;
 import org.myteam.server.improvement.repository.ImprovementQueryRepository;
 import org.myteam.server.improvement.repository.ImprovementRepository;
 import org.myteam.server.member.repository.MemberRepository;
@@ -17,8 +19,6 @@ import org.myteam.server.member.service.SecurityReadService;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -56,7 +56,10 @@ public class ImprovementReadService {
         }
 
         log.info("개선요청 상세 조회 성공: {}", improvementId);
-        return ImprovementSaveResponse.createResponse(improvement, improvementCount, isRecommended);
+        Long previousId = improvementQueryRepository.findPreviousImprovementId(improvement.getId());
+        Long nextId = improvementQueryRepository.findNextImprovementId(improvement.getId());
+
+        return ImprovementSaveResponse.createResponse(improvement, improvementCount, isRecommended, previousId, nextId);
     }
 
     /**

--- a/src/main/java/org/myteam/server/improvement/service/ImprovementService.java
+++ b/src/main/java/org/myteam/server/improvement/service/ImprovementService.java
@@ -12,6 +12,7 @@ import org.myteam.server.improvement.domain.ImprovementCount;
 import org.myteam.server.improvement.dto.request.ImprovementRequest.ImprovementSaveRequest;
 import org.myteam.server.improvement.dto.response.ImprovementResponse.ImprovementSaveResponse;
 import org.myteam.server.improvement.repository.ImprovementCountRepository;
+import org.myteam.server.improvement.repository.ImprovementQueryRepository;
 import org.myteam.server.improvement.repository.ImprovementRepository;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.SecurityReadService;
@@ -25,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ImprovementService {
     private final ImprovementRepository improvementRepository;
+    private final ImprovementQueryRepository improvementQueryRepository;
     private final ImprovementCountRepository improvementCountRepository;
     private final SecurityReadService securityReadService;
     private final ImprovementRecommendReadService improvementRecommendReadService;
@@ -49,7 +51,11 @@ public class ImprovementService {
                 member.getPublicId());
 
         log.info("개선요청 생성: {}", improvement.getId());
-        return ImprovementSaveResponse.createResponse(improvement, improvementCount, isRecommended);
+
+        Long previousId = improvementQueryRepository.findPreviousImprovementId(improvement.getId());
+        Long nextId = improvementQueryRepository.findNextImprovementId(improvement.getId());
+
+        return ImprovementSaveResponse.createResponse(improvement, improvementCount, isRecommended, previousId, nextId);
     }
 
     /**
@@ -76,7 +82,11 @@ public class ImprovementService {
         boolean isRecommended = improvementRecommendReadService.isRecommended(improvement.getId(),
                 member.getPublicId());
         log.info("개선요청 수정: {}", improvement.getId());
-        return ImprovementSaveResponse.createResponse(improvement, improvementCount, isRecommended);
+
+        Long previousId = improvementQueryRepository.findPreviousImprovementId(improvement.getId());
+        Long nextId = improvementQueryRepository.findNextImprovementId(improvement.getId());
+
+        return ImprovementSaveResponse.createResponse(improvement, improvementCount, isRecommended, previousId, nextId);
     }
 
     /**

--- a/src/main/java/org/myteam/server/inquiry/dto/response/InquiryResponse.java
+++ b/src/main/java/org/myteam/server/inquiry/dto/response/InquiryResponse.java
@@ -1,13 +1,15 @@
 package org.myteam.server.inquiry.dto.response;
 
-import lombok.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.myteam.server.global.page.response.PageCustomResponse;
 import org.myteam.server.inquiry.domain.Inquiry;
 import org.myteam.server.inquiry.domain.InquiryCount;
 import org.myteam.server.util.ClientUtils;
-
-import java.time.LocalDateTime;
-import java.util.UUID;
 
 public record InquiryResponse() {
 
@@ -70,9 +72,18 @@ public record InquiryResponse() {
         private String content; // 게시글 내용
         private LocalDateTime createdAt; // 작성일시
         private int commentCount; // 댓글 수
+        /**
+         * 이전글
+         */
+        private Long previousId;
+        /**
+         * 다음글
+         */
+        private Long nextId;
+
 
         @Builder
-        public InquiryDetailsResponse(Inquiry inquiry, InquiryCount inquiryCount) {
+        public InquiryDetailsResponse(Inquiry inquiry, InquiryCount inquiryCount, Long previousId, Long nextId) {
             this.inquiryId = inquiry.getId();
             this.publicID = inquiry.getMember().getPublicId();
             this.nickname = inquiry.getMember().getNickname();
@@ -80,12 +91,17 @@ public record InquiryResponse() {
             this.content = inquiry.getContent();
             this.createdAt = inquiry.getCreatedAt();
             this.commentCount = inquiryCount.getCommentCount();
+            this.previousId = previousId;
+            this.nextId = nextId;
         }
 
-        public static InquiryDetailsResponse createResponse(Inquiry inquiry, InquiryCount inquiryCount) {
+        public static InquiryDetailsResponse createResponse(Inquiry inquiry, InquiryCount inquiryCount, Long previousId,
+                                                            Long nextId) {
             return InquiryDetailsResponse.builder()
                     .inquiry(inquiry)
                     .inquiryCount(inquiryCount)
+                    .previousId(previousId)
+                    .nextId(nextId)
                     .build();
         }
     }

--- a/src/main/java/org/myteam/server/inquiry/repository/InquiryQueryRepository.java
+++ b/src/main/java/org/myteam/server/inquiry/repository/InquiryQueryRepository.java
@@ -98,6 +98,7 @@ public class InquiryQueryRepository {
                 .fetchOne()
         ).orElse(0L);
     }
+
     private OrderSpecifier<?> getOrderSpecifier(InquiryOrderType orderType, QInquiry inquiry) {
         if (orderType == InquiryOrderType.ANSWERED) {
             return inquiry.isAdminAnswered.desc();
@@ -126,5 +127,26 @@ public class InquiryQueryRepository {
             return inquiry.isAdminAnswered.isTrue();
         }
         return null;
+    }
+
+    public Long findPreviousInquiryI(Long inquiryId) {
+        return queryFactory
+                .select(inquiry.id)
+                .from(inquiry)
+                .where(inquiry.id.lt(inquiryId))
+                .orderBy(inquiry.id.desc()) // 가장 큰 ID (즉, 이전 글)
+                .limit(1)
+                .fetchOne();
+    }
+
+
+    public Long findNextInquiryId(Long inquiryId) {
+        return queryFactory
+                .select(inquiry.id)
+                .from(inquiry)
+                .where(inquiry.id.gt(inquiryId))
+                .orderBy(inquiry.id.asc()) // 가장 작은 ID (즉, 다음 글)
+                .limit(1)
+                .fetchOne();
     }
 }

--- a/src/main/java/org/myteam/server/inquiry/service/InquiryReadService.java
+++ b/src/main/java/org/myteam/server/inquiry/service/InquiryReadService.java
@@ -1,15 +1,18 @@
 package org.myteam.server.inquiry.service;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.page.response.PageCustomResponse;
-import org.myteam.server.inquiry.domain.InquiryCount;
-import org.myteam.server.inquiry.dto.request.InquiryRequest.*;
-import org.myteam.server.inquiry.dto.response.InquiryResponse.*;
-import org.myteam.server.inquiry.repository.InquiryQueryRepository;
 import org.myteam.server.inquiry.domain.Inquiry;
+import org.myteam.server.inquiry.domain.InquiryCount;
+import org.myteam.server.inquiry.dto.request.InquiryRequest.InquiryServiceRequest;
+import org.myteam.server.inquiry.dto.response.InquiryResponse.InquiriesListResponse;
+import org.myteam.server.inquiry.dto.response.InquiryResponse.InquiryDetailsResponse;
+import org.myteam.server.inquiry.dto.response.InquiryResponse.InquirySaveResponse;
+import org.myteam.server.inquiry.repository.InquiryQueryRepository;
 import org.myteam.server.inquiry.repository.InquiryRepository;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.SecurityReadService;
@@ -17,8 +20,6 @@ import org.myteam.server.util.ClientUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -32,6 +33,7 @@ public class InquiryReadService {
 
     /**
      * 검색 + 정렬 기능
+     *
      * @param inquiryServiceRequest
      * @return
      */
@@ -48,7 +50,7 @@ public class InquiryReadService {
         );
 
         log.info("내 문의내역: {} 조회 성공", member.getPublicId());
-        inquiryResponses.getContent().forEach(response ->{
+        inquiryResponses.getContent().forEach(response -> {
             log.info("ip: {}, maskedIp:{}", response.getClientIp(), ClientUtils.maskIp(response.getClientIp()));
             response.setClientIp(ClientUtils.maskIp(response.getClientIp()));
         });
@@ -58,6 +60,7 @@ public class InquiryReadService {
 
     /**
      * 내 문의하기 수
+     *
      * @param memberPublicId
      * @return
      */
@@ -81,7 +84,10 @@ public class InquiryReadService {
 
         log.info("요청 멤버: {}, 조회 문의내역: {} 성공", member.getPublicId(), inquiryId);
 
-        return InquiryDetailsResponse.createResponse(inquiry, inquiryCount);
+        Long previousId = inquiryQueryRepository.findPreviousInquiryI(inquiry.getId());
+        Long nextId = inquiryQueryRepository.findNextInquiryId(inquiry.getId());
+
+        return InquiryDetailsResponse.createResponse(inquiry, inquiryCount, previousId, nextId);
     }
 
     public Inquiry findInquiryById(Long inquiryId) {

--- a/src/main/java/org/myteam/server/news/news/dto/service/response/NewsResponse.java
+++ b/src/main/java/org/myteam/server/news/news/dto/service/response/NewsResponse.java
@@ -1,73 +1,81 @@
 package org.myteam.server.news.news.dto.service.response;
 
-import java.time.LocalDateTime;
-
-import org.myteam.server.global.domain.Category;
-import org.myteam.server.news.news.domain.News;
-import org.myteam.server.news.newsCount.domain.NewsCount;
-
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.myteam.server.global.domain.Category;
+import org.myteam.server.news.news.domain.News;
+import org.myteam.server.news.newsCount.domain.NewsCount;
 
 @Getter
 @NoArgsConstructor
 public class NewsResponse {
 
-	@Schema(description = "뉴스 ID")
-	private Long id;
-	@Schema(description = "뉴스 카테고리")
-	private Category category;
-	@Schema(description = "뉴스 제목")
-	private String title;
-	@Schema(description = "뉴스 썸네일 이미지")
-	private String thumbImg;
-	@Schema(description = "뉴스 추천수")
-	private int recommendCount;
-	@Schema(description = "뉴스 댓글수")
-	private int commentCount;
-	@Schema(description = "뉴스 조회수")
-	private int viewCount;
-	@Schema(description = "뉴스 계시 날짜")
-	private LocalDateTime postDate;
-	@Schema(description = "개인 추천 여부")
-	private boolean isRecommend;
-	@Schema(description = "출처")
-	private String source;
-	@Schema(description = "본문")
-	private String content;
+    @Schema(description = "뉴스 ID")
+    private Long id;
+    @Schema(description = "뉴스 카테고리")
+    private Category category;
+    @Schema(description = "뉴스 제목")
+    private String title;
+    @Schema(description = "뉴스 썸네일 이미지")
+    private String thumbImg;
+    @Schema(description = "뉴스 추천수")
+    private int recommendCount;
+    @Schema(description = "뉴스 댓글수")
+    private int commentCount;
+    @Schema(description = "뉴스 조회수")
+    private int viewCount;
+    @Schema(description = "뉴스 계시 날짜")
+    private LocalDateTime postDate;
+    @Schema(description = "개인 추천 여부")
+    private boolean isRecommend;
+    @Schema(description = "출처")
+    private String source;
+    @Schema(description = "본문")
+    private String content;
+    @Schema(description = "이전글")
+    private Long previousId;
+    @Schema(description = "다음글")
+    private Long nextId;
 
-	@Builder
-	public NewsResponse(Long id, Category category, String title, String thumbImg, int recommendCount,
-		int commentCount,
-		int viewCount, LocalDateTime postDate, boolean isRecommend, String source, String content) {
-		this.id = id;
-		this.category = category;
-		this.title = title;
-		this.thumbImg = thumbImg;
-		this.recommendCount = recommendCount;
-		this.commentCount = commentCount;
-		this.viewCount = viewCount;
-		this.postDate = postDate;
-		this.isRecommend = isRecommend;
-		this.source = source;
-		this.content = content;
-	}
+    @Builder
+    public NewsResponse(Long id, Category category, String title, String thumbImg, int recommendCount,
+                        int commentCount,
+                        int viewCount, LocalDateTime postDate, boolean isRecommend, String source, String content,
+                        Long previousId, Long nextId) {
+        this.id = id;
+        this.category = category;
+        this.title = title;
+        this.thumbImg = thumbImg;
+        this.recommendCount = recommendCount;
+        this.commentCount = commentCount;
+        this.viewCount = viewCount;
+        this.postDate = postDate;
+        this.isRecommend = isRecommend;
+        this.source = source;
+        this.content = content;
+        this.previousId = previousId;
+        this.nextId = nextId;
+    }
 
-	public static NewsResponse createResponse(News news, NewsCount newsCount, boolean isRecommend) {
-		return NewsResponse.builder()
-			.id(news.getId())
-			.category(news.getCategory())
-			.title(news.getTitle())
-			.thumbImg(news.getThumbImg())
-			.postDate(news.getPostDate())
-			.recommendCount(newsCount.getRecommendCount())
-			.commentCount(newsCount.getCommentCount())
-			.viewCount(newsCount.getViewCount())
-			.isRecommend(isRecommend)
-			.source(news.getSource())
-			.content(news.getContent())
-			.build();
-	}
+    public static NewsResponse createResponse(News news, NewsCount newsCount, boolean isRecommend, Long previousId,
+                                              Long nextId) {
+        return NewsResponse.builder()
+                .id(news.getId())
+                .category(news.getCategory())
+                .title(news.getTitle())
+                .thumbImg(news.getThumbImg())
+                .postDate(news.getPostDate())
+                .recommendCount(newsCount.getRecommendCount())
+                .commentCount(newsCount.getCommentCount())
+                .viewCount(newsCount.getViewCount())
+                .isRecommend(isRecommend)
+                .source(news.getSource())
+                .content(news.getContent())
+                .previousId(previousId)
+                .nextId(nextId)
+                .build();
+    }
 }

--- a/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
@@ -1,12 +1,16 @@
 package org.myteam.server.news.news.repository;
 
-import static java.util.Optional.*;
-import static org.myteam.server.news.news.domain.QNews.*;
-import static org.myteam.server.news.newsCount.domain.QNewsCount.*;
+import static java.util.Optional.ofNullable;
+import static org.myteam.server.news.news.domain.QNews.news;
+import static org.myteam.server.news.newsCount.domain.QNewsCount.newsCount;
 
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
 import org.myteam.server.global.domain.Category;
 import org.myteam.server.news.news.dto.repository.NewsDto;
 import org.myteam.server.news.news.dto.service.request.NewsServiceRequest;
@@ -15,94 +19,109 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-
-import lombok.RequiredArgsConstructor;
-
 @Repository
 @RequiredArgsConstructor
 public class NewsQueryRepository {
 
-	private final JPAQueryFactory queryFactory;
+    private final JPAQueryFactory queryFactory;
 
-	public Page<NewsDto> getNewsList(NewsServiceRequest newsServiceRequest) {
-		Category category = newsServiceRequest.getCategory();
-		OrderType orderType = newsServiceRequest.getOrderType();
-		String content = newsServiceRequest.getContent();
-		TimePeriod timePeriod = newsServiceRequest.getTimePeriod();
-		Pageable pageable = newsServiceRequest.toPageable();
+    public Page<NewsDto> getNewsList(NewsServiceRequest newsServiceRequest) {
+        Category category = newsServiceRequest.getCategory();
+        OrderType orderType = newsServiceRequest.getOrderType();
+        String content = newsServiceRequest.getContent();
+        TimePeriod timePeriod = newsServiceRequest.getTimePeriod();
+        Pageable pageable = newsServiceRequest.toPageable();
 
-		List<NewsDto> contents = queryFactory
-			.select(Projections.constructor(NewsDto.class,
-				news.id,
-				news.category,
-				news.title,
-				news.thumbImg,
-				news.content,
-				newsCount.commentCount,
-				news.postDate
-			))
-			.from(news)
-			.join(newsCount).on(newsCount.news.id.eq(news.id))
-			.where(
-				isCategoryEqualTo(category),
-				isTitleLikeTo(content),
-				isPostDateAfter(timePeriod)
-			)
-			.orderBy(isOrderByEqualToOrderType(orderType))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
+        List<NewsDto> contents = queryFactory
+                .select(Projections.constructor(NewsDto.class,
+                        news.id,
+                        news.category,
+                        news.title,
+                        news.thumbImg,
+                        news.content,
+                        newsCount.commentCount,
+                        news.postDate
+                ))
+                .from(news)
+                .join(newsCount).on(newsCount.news.id.eq(news.id))
+                .where(
+                        isCategoryEqualTo(category),
+                        isTitleLikeTo(content),
+                        isPostDateAfter(timePeriod)
+                )
+                .orderBy(isOrderByEqualToOrderType(orderType))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
-		long total = getTotalNewsCount(category, content, timePeriod);
+        long total = getTotalNewsCount(category, content, timePeriod);
 
-		return new PageImpl<>(contents, pageable, total);
-	}
+        return new PageImpl<>(contents, pageable, total);
+    }
 
-	private long getTotalNewsCount(Category category, String content, TimePeriod timePeriod) {
-		return ofNullable(
-				queryFactory
-						.select(news.count())
-						.from(news)
-						.where(
-								isCategoryEqualTo(category),
-								isTitleLikeTo(content),
-								isPostDateAfter(timePeriod)
-						)
-						.fetchOne()
-		).orElse(0L);
-	}
+    private long getTotalNewsCount(Category category, String content, TimePeriod timePeriod) {
+        return ofNullable(
+                queryFactory
+                        .select(news.count())
+                        .from(news)
+                        .where(
+                                isCategoryEqualTo(category),
+                                isTitleLikeTo(content),
+                                isPostDateAfter(timePeriod)
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+    }
 
-	private LocalDateTime calculateFromDate(TimePeriod timePeriod) {
-		LocalDateTime now = LocalDateTime.now();
-		return switch (timePeriod) {
-			case DAILY -> now.minusDays(1);
-			case WEEKLY -> now.minusWeeks(1);
-			case MONTHLY -> now.minusMonths(1);
-			case YEARLY -> now.minusYears(1);
-		};
-	}
+    private LocalDateTime calculateFromDate(TimePeriod timePeriod) {
+        LocalDateTime now = LocalDateTime.now();
+        return switch (timePeriod) {
+            case DAILY -> now.minusDays(1);
+            case WEEKLY -> now.minusWeeks(1);
+            case MONTHLY -> now.minusMonths(1);
+            case YEARLY -> now.minusYears(1);
+        };
+    }
 
-	private OrderSpecifier<?> isOrderByEqualToOrderType(OrderType orderType) {
-		return switch (orderType) {
-			case DATE -> news.postDate.desc();
-			case VIEW -> newsCount.viewCount.desc();
-			case COMMENT -> newsCount.commentCount.desc();
-		};
-	}
+    private OrderSpecifier<?> isOrderByEqualToOrderType(OrderType orderType) {
+        return switch (orderType) {
+            case DATE -> news.postDate.desc();
+            case VIEW -> newsCount.viewCount.desc();
+            case COMMENT -> newsCount.commentCount.desc();
+        };
+    }
 
-	private BooleanExpression isCategoryEqualTo(Category category) {
-		return category != null ? news.category.eq(category) : null;
-	}
+    private BooleanExpression isCategoryEqualTo(Category category) {
+        return category != null ? news.category.eq(category) : null;
+    }
 
-	private BooleanExpression isTitleLikeTo(String content) {
-		return content != null ? news.title.like("%"+content+"%") : null;
-	}
+    private BooleanExpression isTitleLikeTo(String content) {
+        return content != null ? news.title.like("%" + content + "%") : null;
+    }
 
-	private BooleanExpression isPostDateAfter(TimePeriod timePeriod) {
-		return timePeriod != null ? news.postDate.after(calculateFromDate(timePeriod)) : null;
-	}
+    private BooleanExpression isPostDateAfter(TimePeriod timePeriod) {
+        return timePeriod != null ? news.postDate.after(calculateFromDate(timePeriod)) : null;
+    }
+
+    public Long findPreviousNewsId(Long newsId, Category category) {
+        return queryFactory
+                .select(news.id)
+                .from(news)
+                .where(news.id.lt(newsId), // 현재 게시글보다 작은 ID
+                        news.category.eq(category))
+                .orderBy(news.id.desc()) // 가장 큰 ID (즉, 이전 글)
+                .limit(1)
+                .fetchOne();
+    }
+
+    public Long findNextNewsId(Long newsId, Category category) {
+        return queryFactory
+                .select(news.id)
+                .from(news)
+                .where(news.id.gt(newsId), // 현재 게시글보다 큰 ID
+                        news.category.eq(category))
+                .orderBy(news.id.asc()) // 가장 작은 ID (즉, 다음 글)
+                .limit(1)
+                .fetchOne();
+    }
 }

--- a/src/main/java/org/myteam/server/news/news/service/NewsReadService.java
+++ b/src/main/java/org/myteam/server/news/news/service/NewsReadService.java
@@ -1,7 +1,7 @@
 package org.myteam.server.news.news.service;
 
 import java.util.UUID;
-
+import lombok.RequiredArgsConstructor;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.page.response.PageCustomResponse;
@@ -19,44 +19,48 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NewsReadService {
 
-	private final NewsQueryRepository newsQueryRepository;
-	private final NewsRepository newsRepository;
-	private final NewsCountReadService newsCountReadService;
-	private final NewsCountMemberReadService newsCountMemberReadService;
-	private final SecurityReadService securityReadService;
+    private final NewsQueryRepository newsQueryRepository;
+    private final NewsRepository newsRepository;
+    private final NewsCountReadService newsCountReadService;
+    private final NewsCountMemberReadService newsCountMemberReadService;
+    private final SecurityReadService securityReadService;
 
-	public NewsListResponse findAll(NewsServiceRequest newsServiceRequest) {
-		Page<NewsDto> newsPagingList = newsQueryRepository.getNewsList(newsServiceRequest);
+    public NewsListResponse findAll(NewsServiceRequest newsServiceRequest) {
+        Page<NewsDto> newsPagingList = newsQueryRepository.getNewsList(newsServiceRequest);
 
-		return NewsListResponse.createResponse(PageCustomResponse.of(newsPagingList));
-	}
+        return NewsListResponse.createResponse(PageCustomResponse.of(newsPagingList));
+    }
 
-	public NewsResponse findOne(Long newsId) {
-		UUID publicId = securityReadService.getAuthenticatedPublicId();
+    public NewsResponse findOne(Long newsId) {
+        UUID publicId = securityReadService.getAuthenticatedPublicId();
 
-		boolean recommendYn = publicId != null && newsCountMemberReadService.confirmRecommendMember(newsId, publicId);
+        boolean recommendYn = publicId != null && newsCountMemberReadService.confirmRecommendMember(newsId, publicId);
 
-		return NewsResponse.createResponse(
-			findById(newsId),
-			newsCountReadService.findByNewsId(newsId),
-			recommendYn
-		);
-	}
+        News news = findById(newsId);
+        Long previousId = newsQueryRepository.findPreviousNewsId(news.getId(), news.getCategory());
+        Long nextId = newsQueryRepository.findNextNewsId(news.getId(), news.getCategory());
 
-	public News findById(Long newsId) {
-		return newsRepository.findById(newsId)
-			.orElseThrow(() -> new PlayHiveException(ErrorCode.NEWS_NOT_FOUND));
-	}
+        return NewsResponse.createResponse(
+                news,
+                newsCountReadService.findByNewsId(newsId),
+                recommendYn,
+                previousId,
+                nextId
+        );
+    }
 
-	public boolean existsById(Long id) {
-		return newsRepository.existsById(id);
-	}
+    public News findById(Long newsId) {
+        return newsRepository.findById(newsId)
+                .orElseThrow(() -> new PlayHiveException(ErrorCode.NEWS_NOT_FOUND));
+    }
+
+    public boolean existsById(Long id) {
+        return newsRepository.existsById(id);
+    }
 
 }

--- a/src/main/java/org/myteam/server/notice/dto/response/NoticeResponse.java
+++ b/src/main/java/org/myteam/server/notice/dto/response/NoticeResponse.java
@@ -33,8 +33,17 @@ public record NoticeResponse() {
         private int viewCount; // 조회 수
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
+        /**
+         * 이전글
+         */
+        private Long previousId;
+        /**
+         * 다음글
+         */
+        private Long nextId;
 
-        public static NoticeSaveResponse createResponse(Notice notice, NoticeCount noticeCount, boolean isRecommended) {
+        public static NoticeSaveResponse createResponse(Notice notice, NoticeCount noticeCount, boolean isRecommended,
+                                                        Long previousId, Long nextId) {
             return NoticeSaveResponse.builder()
                     .noticeId(notice.getId())
                     .publicId(notice.getMember().getPublicId())
@@ -49,6 +58,8 @@ public record NoticeResponse() {
                     .viewCount(noticeCount.getViewCount())
                     .createdAt(notice.getCreateDate())
                     .modifiedAt(notice.getLastModifiedDate())
+                    .previousId(previousId)
+                    .nextId(nextId)
                     .build();
         }
     }

--- a/src/main/java/org/myteam/server/notice/repository/NoticeQueryRepository.java
+++ b/src/main/java/org/myteam/server/notice/repository/NoticeQueryRepository.java
@@ -116,4 +116,24 @@ public class NoticeQueryRepository {
                 .limit(2)
                 .fetch();
     }
+
+    public Long findPreviousNoticeId(Long noticeId) {
+        return queryFactory
+                .select(notice.id)
+                .from(notice)
+                .where(notice.id.lt(noticeId)) // 현재 게시글보다 작은 ID
+                .orderBy(notice.id.desc()) // 가장 큰 ID (즉, 이전 글)
+                .limit(1)
+                .fetchOne();
+    }
+
+    public Long findNextNoticeId(Long noticeId) {
+        return queryFactory
+                .select(notice.id)
+                .from(notice)
+                .where(notice.id.gt(noticeId)) // 현재 게시글보다 큰 ID
+                .orderBy(notice.id.asc()) // 가장 작은 ID (즉, 다음 글)
+                .limit(1)
+                .fetchOne();
+    }
 }

--- a/src/main/java/org/myteam/server/notice/service/NoticeReadService.java
+++ b/src/main/java/org/myteam/server/notice/service/NoticeReadService.java
@@ -1,24 +1,24 @@
 package org.myteam.server.notice.service;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.page.response.PageCustomResponse;
-import org.myteam.server.global.security.dto.CustomUserDetails;
 import org.myteam.server.member.repository.MemberRepository;
 import org.myteam.server.member.service.SecurityReadService;
-import org.myteam.server.notice.repository.NoticeQueryRepository;
-import org.myteam.server.notice.repository.NoticeRepository;
 import org.myteam.server.notice.domain.Notice;
 import org.myteam.server.notice.domain.NoticeCount;
 import org.myteam.server.notice.dto.request.NoticeRequest.NoticeServiceRequest;
-import org.myteam.server.notice.dto.response.NoticeResponse.*;
+import org.myteam.server.notice.dto.response.NoticeResponse.NoticeDto;
+import org.myteam.server.notice.dto.response.NoticeResponse.NoticeListResponse;
+import org.myteam.server.notice.dto.response.NoticeResponse.NoticeSaveResponse;
+import org.myteam.server.notice.repository.NoticeQueryRepository;
+import org.myteam.server.notice.repository.NoticeRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -56,7 +56,10 @@ public class NoticeReadService {
 
         log.info("공지사항 상세 조회 성공: {}", noticeId);
 
-        return NoticeSaveResponse.createResponse(notice, noticeCount, isRecommended);
+        Long previousId = noticeQueryRepository.findPreviousNoticeId(notice.getId());
+        Long nextId = noticeQueryRepository.findNextNoticeId(notice.getId());
+
+        return NoticeSaveResponse.createResponse(notice, noticeCount, isRecommended, previousId, nextId);
     }
 
     /**

--- a/src/main/java/org/myteam/server/notice/service/NoticeService.java
+++ b/src/main/java/org/myteam/server/notice/service/NoticeService.java
@@ -14,6 +14,7 @@ import org.myteam.server.notice.domain.NoticeCount;
 import org.myteam.server.notice.dto.request.NoticeRequest.NoticeSaveRequest;
 import org.myteam.server.notice.dto.response.NoticeResponse.NoticeSaveResponse;
 import org.myteam.server.notice.repository.NoticeCountRepository;
+import org.myteam.server.notice.repository.NoticeQueryRepository;
 import org.myteam.server.notice.repository.NoticeRepository;
 import org.myteam.server.upload.service.StorageService;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ public class NoticeService {
 
     private final NoticeRepository noticeRepository;
     private final NoticeCountRepository noticeCountRepository;
+    private final NoticeQueryRepository noticeQueryRepository;
     private final SecurityReadService securityReadService;
     private final NoticeRecommendReadService noticeRecommendReadService;
     private final NoticeReadService noticeReadService;
@@ -53,7 +55,11 @@ public class NoticeService {
         boolean isRecommended = noticeRecommendReadService.isRecommended(notice.getId(), member.getPublicId());
 
         log.info("공지사항 생성: {}", notice.getId());
-        return NoticeSaveResponse.createResponse(notice, noticeCount, isRecommended);
+
+        Long previousId = noticeQueryRepository.findPreviousNoticeId(notice.getId());
+        Long nextId = noticeQueryRepository.findNextNoticeId(notice.getId());
+
+        return NoticeSaveResponse.createResponse(notice, noticeCount, isRecommended, previousId, nextId);
 
     }
 
@@ -98,7 +104,11 @@ public class NoticeService {
         boolean isRecommended = noticeRecommendReadService.isRecommended(notice.getId(), member.getPublicId());
 
         log.info("공지사항 수정: {}", notice.getId());
-        return NoticeSaveResponse.createResponse(notice, noticeCount, isRecommended);
+
+        Long previousId = noticeQueryRepository.findPreviousNoticeId(notice.getId());
+        Long nextId = noticeQueryRepository.findNextNoticeId(notice.getId());
+
+        return NoticeSaveResponse.createResponse(notice, noticeCount, isRecommended, previousId, nextId);
     }
 
     /**


### PR DESCRIPTION
## 기능 설명
- 상세 조회시 ID값을 가지고 이전글 다음글을 조회하였습니다. 
- 게시판은 상세 조회한 게시판 타입/카테고리 타입을 기준으로 이전글 다음글을 불러오게했고, 뉴스도 타입을 기준으로 불러왔습니다.
나머지는 분류 타입이 없어 해당 ID를 기준으로 불러왔습니다.

## 작업 내용
- 게시판, 개선요청, 문의, 뉴스, 공지사항 상세조회 시 이전글, 다음글 ID 추가하였습니다.

## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
