### PR TITLE
fix: 경기일정에 시간 추가

### DIFF
--- a/src/main/java/org/myteam/server/match/match/dto/service/response/MatchResponse.java
+++ b/src/main/java/org/myteam/server/match/match/dto/service/response/MatchResponse.java
@@ -1,5 +1,7 @@
 package org.myteam.server.match.match.dto.service.response;
 
+import java.time.LocalDateTime;
+
 import org.myteam.server.match.match.domain.Match;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,15 +19,18 @@ public class MatchResponse {
 	private TeamResponse awayTeam;
 	@Schema(description = "경기장소")
 	private String place;
+	@Schema(description = "경기 시작 시간")
+	private LocalDateTime startTime;
 	@Schema(description = "경기 유형 ID")
 	private String category;
 
 	@Builder
-	public MatchResponse(Long id, TeamResponse homeTeam, TeamResponse awayTeam, String place, String category) {
+	public MatchResponse(Long id, TeamResponse homeTeam, TeamResponse awayTeam, String place, LocalDateTime startTime, String category) {
 		this.id = id;
 		this.homeTeam = homeTeam;
 		this.awayTeam = awayTeam;
 		this.place = place;
+		this.startTime = startTime;
 		this.category = category;
 	}
 
@@ -35,6 +40,7 @@ public class MatchResponse {
 			.homeTeam(TeamResponse.createResponse(match.getHomeTeam()))
 			.awayTeam(TeamResponse.createResponse(match.getAwayTeam()))
 			.place(match.getPlace())
+			.startTime(match.getStartTime())
 			.category(match.getCategory().name())
 			.build();
 	}

--- a/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
@@ -36,22 +36,25 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		assertThat(matchReadService.findSchedulesBetweenDate(null).getList())
 			.extracting(
 				"homeTeam.name", "homeTeam.logo", "homeTeam.category",
-				"awayTeam.name", "awayTeam.logo", "awayTeam.category",
+				"awayTeam.name", "awayTeam.logo", "awayTeam.category", "startTime",
 				"category")
 			.containsExactly(
 				tuple(
 					team1.getName(), team1.getLogo(), team1.getCategory().name(),
 					team2.getName(), team2.getLogo(), team2.getCategory().name(),
+					LocalDate.now().atStartOfDay(),
 					MatchCategory.FOOTBALL.name()
 				),
 				tuple(
 					team2.getName(), team2.getLogo(), team2.getCategory().name(),
 					team3.getName(), team3.getLogo(), team3.getCategory().name(),
+					LocalDate.now().atStartOfDay(),
 					MatchCategory.FOOTBALL.name()
 				),
 				tuple(
 					team3.getName(), team3.getLogo(), team3.getCategory().name(),
 					team4.getName(), team4.getLogo(), team4.getCategory().name(),
+					LocalDate.now().atStartOfDay(),
 					MatchCategory.ESPORTS.name()
 				)
 			);
@@ -72,12 +75,13 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		assertThat(matchReadService.findSchedulesBetweenDate(MatchCategory.FOOTBALL).getList())
 			.extracting(
 				"homeTeam.name", "homeTeam.logo", "homeTeam.category",
-				"awayTeam.name", "awayTeam.logo", "awayTeam.category",
+				"awayTeam.name", "awayTeam.logo", "awayTeam.category", "startTime",
 				"category")
 			.containsExactly(
 				tuple(
 					team2.getName(), team2.getLogo(), team2.getCategory().name(),
 					team3.getName(), team3.getLogo(), team3.getCategory().name(),
+					LocalDate.now().atStartOfDay(),
 					MatchCategory.FOOTBALL.name()
 				)
 			);
@@ -98,17 +102,19 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		assertThat(matchReadService.findSchedulesBetweenDate(MatchCategory.FOOTBALL).getList())
 			.extracting(
 				"homeTeam.name", "homeTeam.logo", "homeTeam.category",
-				"awayTeam.name", "awayTeam.logo", "awayTeam.category",
+				"awayTeam.name", "awayTeam.logo", "awayTeam.category", "startTime",
 				"category")
 			.containsExactly(
 				tuple(
 					team1.getName(), team1.getLogo(), team1.getCategory().name(),
 					team2.getName(), team2.getLogo(), team2.getCategory().name(),
+					LocalDate.now().atStartOfDay(),
 					MatchCategory.FOOTBALL.name()
 				),
 				tuple(
 					team2.getName(), team2.getLogo(), team2.getCategory().name(),
 					team1.getName(), team1.getLogo(), team1.getCategory().name(),
+					LocalDate.now().atStartOfDay(),
 					MatchCategory.FOOTBALL.name()
 				)
 			);
@@ -125,12 +131,13 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		assertThat(matchReadService.findOne(match.getId()))
 			.extracting(
 				"homeTeam.name", "homeTeam.logo", "homeTeam.category",
-				"awayTeam.name", "awayTeam.logo", "awayTeam.category",
+				"awayTeam.name", "awayTeam.logo", "awayTeam.category", "startTime",
 				"category")
 			.contains(
-					team1.getName(), team1.getLogo(), team1.getCategory().name(),
-					team2.getName(), team2.getLogo(), team2.getCategory().name(),
-					MatchCategory.FOOTBALL.name()
+				team1.getName(), team1.getLogo(), team1.getCategory().name(),
+				team2.getName(), team2.getLogo(), team2.getCategory().name(),
+				LocalDate.now().atStartOfDay(),
+				MatchCategory.FOOTBALL.name()
 			);
 	}
 
@@ -139,7 +146,7 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 	void findByIdThrowException() {
 		assertThatThrownBy(() -> matchReadService.findOne(1L))
 			.isInstanceOf(PlayHiveException.class)
-				.hasMessage(ErrorCode.MATCH_NOT_FOUNT.getMsg());
+			.hasMessage(ErrorCode.MATCH_NOT_FOUNT.getMsg());
 	}
 
 }


### PR DESCRIPTION
## 기능 설명
- 경기일정에 시간 추가
## 작업 내용
- MatchController 응답값 객체에 startTime추가
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
