### PR TITLE
feat: 쿠키 사용하여 조회수 중복 방지

### DIFF
--- a/src/main/java/org/myteam/server/board/controller/BoardController.java
+++ b/src/main/java/org/myteam/server/board/controller/BoardController.java
@@ -1,17 +1,7 @@
 package org.myteam.server.board.controller;
 
-import static org.myteam.server.global.web.response.ResponseStatus.SUCCESS;
+import static org.myteam.server.global.web.response.ResponseStatus.*;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.board.dto.reponse.BoardListResponse;
 import org.myteam.server.board.dto.reponse.BoardResponse;
 import org.myteam.server.board.dto.request.BoardRequest;
@@ -23,6 +13,7 @@ import org.myteam.server.global.exception.ErrorResponse;
 import org.myteam.server.global.security.dto.CustomUserDetails;
 import org.myteam.server.global.web.response.ResponseDto;
 import org.myteam.server.util.ClientUtils;
+import org.myteam.server.viewCountMember.domain.ViewType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -35,6 +26,18 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/board")
@@ -42,90 +45,93 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "게시판 CRUD API", description = "게시글 생성, 수정, 상세 조회, 삭제 API")
 public class BoardController {
 
-    private final BoardService boardService;
-    private final BoardCountService boardCountService;
-    private final BoardReadService boardReadService;
+	private final BoardService boardService;
+	private final BoardCountService boardCountService;
+	private final BoardReadService boardReadService;
 
-    /**
-     * 게시글 생성
-     */
-    @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "게시글 생성 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "회원, 게시글이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @PostMapping
-    public ResponseEntity<ResponseDto<BoardResponse>> saveBoard(
-            @Valid @RequestBody final BoardRequest boardRequest,
-            final HttpServletRequest request) {
-        final String clientIP = ClientUtils.getRemoteIP(request);
-        final BoardResponse response = boardService.saveBoard(boardRequest, clientIP);
-        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 생성 성공", response));
-    }
+	/**
+	 * 게시글 생성
+	 */
+	@Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "게시글 생성 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "404", description = "회원, 게시글이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	@PostMapping
+	public ResponseEntity<ResponseDto<BoardResponse>> saveBoard(
+		@Valid @RequestBody final BoardRequest boardRequest,
+		final HttpServletRequest request) {
+		final String clientIP = ClientUtils.getRemoteIP(request);
+		final BoardResponse response = boardService.saveBoard(boardRequest, clientIP);
+		return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 생성 성공", response));
+	}
 
-    /**
-     * 게시글 수정
-     */
-    @Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "게시글 수정 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "작성자나 관리자만 수정 가능", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "회원, 게시글이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @PutMapping("/{boardId}")
-    public ResponseEntity<ResponseDto<BoardResponse>> updateBoard(
-            @PathVariable final Long boardId, @Valid @RequestBody final BoardRequest boardRequest) {
-        final BoardResponse response = boardService.updateBoard(boardRequest, boardId);
-        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 수정 성공", response));
-    }
+	/**
+	 * 게시글 수정
+	 */
+	@Operation(summary = "게시글 수정", description = "게시글을 수정합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "게시글 수정 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "403", description = "작성자나 관리자만 수정 가능", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "404", description = "회원, 게시글이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	@PutMapping("/{boardId}")
+	public ResponseEntity<ResponseDto<BoardResponse>> updateBoard(
+		@PathVariable final Long boardId, @Valid @RequestBody final BoardRequest boardRequest) {
+		final BoardResponse response = boardService.updateBoard(boardRequest, boardId);
+		return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 수정 성공", response));
+	}
 
-    /**
-     * 게시글 삭제
-     */
-    @Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "게시글 삭제 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "작성자나 관리자만 삭제 가능", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "회원, 게시글이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "s3 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @DeleteMapping("/{boardId}")
-    public ResponseEntity<ResponseDto<Void>> deleteBoard(@PathVariable final Long boardId) {
-        boardService.deleteBoard(boardId);
-        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 삭제 성공", null));
-    }
+	/**
+	 * 게시글 삭제
+	 */
+	@Operation(summary = "게시글 삭제", description = "게시글을 삭제합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "게시글 삭제 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "403", description = "작성자나 관리자만 삭제 가능", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "404", description = "회원, 게시글이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+		@ApiResponse(responseCode = "500", description = "s3 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	@DeleteMapping("/{boardId}")
+	public ResponseEntity<ResponseDto<Void>> deleteBoard(@PathVariable final Long boardId) {
+		boardService.deleteBoard(boardId);
+		return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 삭제 성공", null));
+	}
 
-    /**
-     * 게시글 상세 조회
-     */
-    @Operation(summary = "게시글 상세 조회", description = "게시글을 상세 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "게시글이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping("/{boardId}")
-    public ResponseEntity<ResponseDto<BoardResponse>> getBoard(@PathVariable final Long boardId,
-                                                               @AuthenticationPrincipal final CustomUserDetails userDetails) {
-        final BoardResponse response = boardService.getBoard(boardId, userDetails);
-        boardCountService.addViewCount(boardId);
-        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 조회 성공", response));
-    }
+	/**
+	 * 게시글 상세 조회
+	 */
+	@Operation(summary = "게시글 상세 조회", description = "게시글을 상세 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공"),
+		@ApiResponse(responseCode = "404", description = "게시글이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	@GetMapping("/{boardId}")
+	public ResponseEntity<ResponseDto<BoardResponse>> getBoard(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		@PathVariable final Long boardId,
+		@AuthenticationPrincipal final CustomUserDetails userDetails) {
+		final BoardResponse boardResponse = boardService.getBoard(boardId, userDetails);
+		boardCountService.addViewCount(request, response, boardId);
+		return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 조회 성공", boardResponse));
+	}
 
-    /**
-     * 게시글 목록 조회
-     */
-    @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-    })
-    @GetMapping
-    public ResponseEntity<ResponseDto<BoardListResponse>> getBoardList(
-            @ModelAttribute @Valid BoardSearchRequest request) {
-        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 목록 조회",
-                boardReadService.getBoardList(request.toServiceRequest())));
-    }
+	/**
+	 * 게시글 목록 조회
+	 */
+	@Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+	})
+	@GetMapping
+	public ResponseEntity<ResponseDto<BoardListResponse>> getBoardList(
+		@ModelAttribute @Valid BoardSearchRequest request) {
+		return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "게시글 목록 조회",
+			boardReadService.getBoardList(request.toServiceRequest())));
+	}
 }

--- a/src/main/java/org/myteam/server/board/service/BoardCountService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardCountService.java
@@ -1,5 +1,7 @@
 package org.myteam.server.board.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.BoardRecommend;
@@ -7,6 +9,8 @@ import org.myteam.server.board.repository.BoardRecommendRepository;
 import org.myteam.server.comment.service.CommentCountService;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.SecurityReadService;
+import org.myteam.server.viewCountMember.domain.ViewType;
+import org.myteam.server.viewCountMember.service.ViewCountService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +25,8 @@ public class BoardCountService implements CommentCountService {
     private final BoardRecommendReadService boardRecommendReadService;
 
     private final BoardRecommendRepository boardRecommendRepository;
+
+    private final ViewCountService viewCountService;
 
     public void recommendBoard(Long boardId) {
         Board board = boardReadService.findById(boardId);
@@ -105,7 +111,10 @@ public class BoardCountService implements CommentCountService {
         boardCountReadService.findByBoardIdLock(boardId).minusCommentCount(count);
     }
 
-    public void addViewCount(Long boardId) {
-        boardCountReadService.findByBoardIdLock(boardId).addViewCount();
+    public void addViewCount(HttpServletRequest request, HttpServletResponse response, Long boardId) {
+        if (!viewCountService.confirmPostView(request, response, ViewType.BOARD, boardId,
+            securityReadService.getAuthenticatedPublicId())) {
+            boardCountReadService.findByBoardIdLock(boardId).addViewCount();
+        }
     }
 }

--- a/src/main/java/org/myteam/server/global/cookie/CookieHandler.java
+++ b/src/main/java/org/myteam/server/global/cookie/CookieHandler.java
@@ -1,0 +1,47 @@
+package org.myteam.server.global.cookie;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CookieHandler {
+
+	// 요청에서 쿠키 값을 가져오는 메서드
+	public String getCookieValue(HttpServletRequest request, String cookieName) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(cookieName)) {
+					return cookie.getValue();
+				}
+			}
+		}
+		return null;
+	}
+
+	// 쿠키에 ID 포함 여부 확인
+	public boolean hasPostBeenViewed(Long id, String postViewCookieValue, List<String> postViewList) {
+		if (postViewCookieValue != null) {
+			postViewList.addAll(Arrays.asList(postViewCookieValue.split("\\|")));
+			return postViewList.contains(String.valueOf(id));
+		}
+		return false;
+	}
+
+	// 쿠키 업데이트
+	public void updatePostViewCookie(HttpServletResponse response, Long id, boolean hasViewed,
+		String postViewCookieName, List<String> postViewList) {
+		if (!hasViewed) {
+			postViewList.add(String.valueOf(id));
+			String updatedCookieValue = String.join("|", postViewList);
+			Cookie postViewCookie = new Cookie(postViewCookieName, updatedCookieValue);
+			response.addCookie(postViewCookie);
+		}
+	}
+}

--- a/src/main/java/org/myteam/server/news/news/controller/NewsController.java
+++ b/src/main/java/org/myteam/server/news/news/controller/NewsController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -43,15 +45,18 @@ public class NewsController {
 	@Operation(summary = "뉴스 상세 조회 API", description = "뉴스의 상세를 조회합니다.")
 	@GetMapping("/{newsId}")
 	public ResponseEntity<ResponseDto<NewsResponse>> findOne(
+		HttpServletRequest request,
+		HttpServletResponse response,
 		@PathVariable
 		@Parameter(description = "뉴스 ID")
 		Long newsId
 	) {
-		newsCountService.addViewCount(newsId);
+		NewsResponse newsResponse = newsReadService.findOne(newsId);
+		newsCountService.addViewCount(request, response, newsId);
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
 			"뉴스 상세 조회 성공",
-			newsReadService.findOne(newsId)));
+			newsResponse));
 	}
 
 }

--- a/src/main/java/org/myteam/server/news/newsCount/service/NewsCountService.java
+++ b/src/main/java/org/myteam/server/news/newsCount/service/NewsCountService.java
@@ -7,9 +7,13 @@ import org.myteam.server.member.service.SecurityReadService;
 import org.myteam.server.news.newsCount.dto.service.response.NewsRecommendResponse;
 import org.myteam.server.news.newsCountMember.service.NewsCountMemberReadService;
 import org.myteam.server.news.newsCountMember.service.NewsCountMemberService;
+import org.myteam.server.viewCountMember.domain.ViewType;
+import org.myteam.server.viewCountMember.service.ViewCountService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -21,6 +25,7 @@ public class NewsCountService implements CommentCountService {
 	private final SecurityReadService securityReadService;
 	private final NewsCountMemberReadService newsCountMemberReadService;
 	private final NewsCountMemberService newsCountMemberService;
+	private final ViewCountService viewCountService;
 
 	public NewsRecommendResponse recommendNews(Long newsId) {
 		UUID memberId = securityReadService.getMember().getPublicId();
@@ -64,8 +69,11 @@ public class NewsCountService implements CommentCountService {
 		newsCountReadService.findByNewsIdLock(newsId).minusCommentCount(minusCount);
 	}
 
-	public void addViewCount(Long newsId) {
-		newsCountReadService.findByNewsIdLock(newsId).addViewCount();
+	public void addViewCount(HttpServletRequest request, HttpServletResponse response, Long newsId) {
+		if (!viewCountService.confirmPostView(request, response, ViewType.NEWS, newsId,
+			securityReadService.getAuthenticatedPublicId())) {
+			newsCountReadService.findByNewsIdLock(newsId).addViewCount();
+		}
 	}
 
 	public void minusViewCont(Long newsId) {

--- a/src/main/java/org/myteam/server/viewCountMember/domain/ViewCountMember.java
+++ b/src/main/java/org/myteam/server/viewCountMember/domain/ViewCountMember.java
@@ -1,0 +1,50 @@
+package org.myteam.server.viewCountMember.domain;
+
+import org.myteam.server.global.domain.Base;
+import org.myteam.server.member.entity.Member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ViewCountMember extends Base {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private Long viewId;
+
+	@OneToOne
+	private Member member;
+
+	@Enumerated(EnumType.STRING)
+	private ViewType viewType;
+
+	@Builder
+	public ViewCountMember(Long id, Long viewId, Member member, ViewType viewType) {
+		this.id = id;
+		this.viewId = viewId;
+		this.member = member;
+		this.viewType = viewType;
+	}
+
+	public static ViewCountMember createEntity(Long viewId, Member member, ViewType viewType) {
+		return ViewCountMember.builder()
+			.viewId(viewId)
+			.member(member)
+			.viewType(viewType)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/viewCountMember/domain/ViewType.java
+++ b/src/main/java/org/myteam/server/viewCountMember/domain/ViewType.java
@@ -1,0 +1,12 @@
+package org.myteam.server.viewCountMember.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ViewType {
+	BOARD("board"), NEWS("news");
+
+	private final String value;
+}

--- a/src/main/java/org/myteam/server/viewCountMember/repository/ViewCountMemberRepository.java
+++ b/src/main/java/org/myteam/server/viewCountMember/repository/ViewCountMemberRepository.java
@@ -1,0 +1,10 @@
+package org.myteam.server.viewCountMember.repository;
+
+import java.util.UUID;
+
+import org.myteam.server.viewCountMember.domain.ViewCountMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ViewCountMemberRepository extends JpaRepository<ViewCountMember, Long> {
+	boolean existsByViewIdAndMemberPublicId(Long viewId, UUID memberId);
+}

--- a/src/main/java/org/myteam/server/viewCountMember/service/ViewCountMemberReadService.java
+++ b/src/main/java/org/myteam/server/viewCountMember/service/ViewCountMemberReadService.java
@@ -1,0 +1,22 @@
+package org.myteam.server.viewCountMember.service;
+
+import java.util.UUID;
+
+import org.myteam.server.viewCountMember.repository.ViewCountMemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ViewCountMemberReadService {
+
+	private final ViewCountMemberRepository viewCountMemberRepository;
+
+	public boolean existsByViewIdAndMemberPublicId(Long viewId, UUID publicId) {
+		return viewCountMemberRepository.existsByViewIdAndMemberPublicId(viewId, publicId);
+	}
+
+}

--- a/src/main/java/org/myteam/server/viewCountMember/service/ViewCountService.java
+++ b/src/main/java/org/myteam/server/viewCountMember/service/ViewCountService.java
@@ -1,0 +1,56 @@
+package org.myteam.server.viewCountMember.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.myteam.server.global.cookie.CookieHandler;
+import org.myteam.server.member.service.MemberReadService;
+import org.myteam.server.viewCountMember.domain.ViewCountMember;
+import org.myteam.server.viewCountMember.domain.ViewType;
+import org.myteam.server.viewCountMember.repository.ViewCountMemberRepository;
+import org.springframework.stereotype.Service;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ViewCountService {
+
+	private final CookieHandler cookieHandler;
+	private final ViewCountMemberRepository viewCountMemberRepository;
+	private final ViewCountMemberReadService viewCountMemberReadService;
+	private final MemberReadService memberReadService;
+
+	public boolean confirmPostView(HttpServletRequest request, HttpServletResponse response, ViewType viewType,
+		Long id, UUID publicId) {
+		if (publicId != null) {
+			if (!viewCountMemberReadService.existsByViewIdAndMemberPublicId(id, publicId)) {
+				save(viewType, id, publicId);
+				return false;
+			}
+			return true;
+		}
+		return checkCookiePostView(request, response, viewType, id);
+	}
+
+	public void save(ViewType viewType, Long id, UUID publicId) {
+		viewCountMemberRepository.save(
+			ViewCountMember.createEntity(id, memberReadService.findById(publicId), viewType));
+	}
+
+	private boolean checkCookiePostView(HttpServletRequest request, HttpServletResponse response, ViewType viewType,
+		Long id) {
+		String postViewCookieName = "postView_" + viewType.getValue();
+		String postViewCookieValue = cookieHandler.getCookieValue(request, postViewCookieName);
+
+		List<String> postViewList = new ArrayList<>();
+		boolean hasViewed = cookieHandler.hasPostBeenViewed(id, postViewCookieValue, postViewList);
+
+		cookieHandler.updatePostViewCookie(response, id, hasViewed, postViewCookieName, postViewList);
+
+		return hasViewed;
+	}
+}

--- a/src/test/java/org/myteam/server/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/IntegrationTestSupport.java
@@ -1,9 +1,10 @@
 package org.myteam.server;
 
-import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+
 import org.junit.jupiter.api.AfterEach;
 import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.BoardCount;
@@ -63,335 +64,346 @@ import org.myteam.server.upload.config.S3ConfigLocal;
 import org.myteam.server.upload.controller.S3Controller;
 import org.myteam.server.upload.service.StorageService;
 import org.myteam.server.util.slack.service.SlackService;
+import org.myteam.server.viewCountMember.domain.ViewCountMember;
+import org.myteam.server.viewCountMember.domain.ViewType;
+import org.myteam.server.viewCountMember.repository.ViewCountMemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @ActiveProfiles("test")
 @SpringBootTest
 public abstract class IntegrationTestSupport {
 
-    /**
-     * ================== Repository ========================
-     */
-    @Autowired
-    protected TeamRepository teamRepository;
-    @Autowired
-    protected MatchRepository matchRepository;
-    @Autowired
-    protected NewsRepository newsRepository;
-    @Autowired
-    protected NewsCountRepository newsCountRepository;
-    @Autowired
-    protected MemberJpaRepository memberJpaRepository;
-    @Autowired
-    protected MemberActivityRepository memberActivityRepository;
-    @Autowired
-    protected NewsCountMemberRepository newsCountMemberRepository;
-    @Autowired
-    protected InquiryRepository inquiryRepository;
-    @Autowired
-    protected InquiryCountRepository inquiryCountRepository;
-    @Autowired
-    protected MatchPredictionRepository matchPredictionRepository;
-    @Autowired
-    protected BoardRepository boardRepository;
-    @Autowired
-    protected BoardCountRepository boardCountRepository;
-    @Autowired
-    protected BoardRecommendRepository boardRecommendRepository;
-    @Autowired
-    protected NoticeRepository noticeRepository;
-    @Autowired
-    protected NoticeCountRepository noticeCountRepository;
+	/**
+	 * ================== Repository ========================
+	 */
+	@Autowired
+	protected TeamRepository teamRepository;
+	@Autowired
+	protected MatchRepository matchRepository;
+	@Autowired
+	protected NewsRepository newsRepository;
+	@Autowired
+	protected NewsCountRepository newsCountRepository;
+	@Autowired
+	protected MemberJpaRepository memberJpaRepository;
+	@Autowired
+	protected MemberActivityRepository memberActivityRepository;
+	@Autowired
+	protected NewsCountMemberRepository newsCountMemberRepository;
+	@Autowired
+	protected InquiryRepository inquiryRepository;
+	@Autowired
+	protected InquiryCountRepository inquiryCountRepository;
+	@Autowired
+	protected MatchPredictionRepository matchPredictionRepository;
+	@Autowired
+	protected BoardRepository boardRepository;
+	@Autowired
+	protected BoardCountRepository boardCountRepository;
+	@Autowired
+	protected BoardRecommendRepository boardRecommendRepository;
+	@Autowired
+	protected NoticeRepository noticeRepository;
+	@Autowired
+	protected NoticeCountRepository noticeCountRepository;
+	@Autowired
+	protected ImprovementRepository improvementRepository;
+	@Autowired
+	protected ImprovementCountRepository improvementCountRepository;
+	@Autowired
+	protected CommentRepository commentRepository;
+	@Autowired
+	protected ViewCountMemberRepository viewCountMemberRepository;
 
-    @Autowired
-    protected ImprovementRepository improvementRepository;
-    @Autowired
-    protected ImprovementCountRepository improvementCountRepository;
-    @Autowired
-    protected CommentRepository commentRepository;
+	/**
+	 * ================== Service ========================
+	 */
+	@MockBean
+	protected InquiryReadService inquiryReadService;
+	@MockBean
+	protected SecurityReadService securityReadService;
+	@Autowired
+	protected MemberService memberService;
+	@Autowired
+	protected MyPageReadService myPageReadService;
+	@MockBean
+	protected BoardService boardService;
+	@Autowired
+	protected BoardReadService boardReadService;
+	@Autowired
+	protected MemberReadService memberReadService;
+	@Autowired
+	protected BoardCountReadService boardCountReadService;
+	@Autowired
+	protected BoardRecommendReadService boardRecommendReadService;
+	@Autowired
+	protected BoardCountService boardCountService;
+	@Autowired
+	protected InquiryService inquiryService;
+	@Autowired
+	protected CommentService commentService;
+	@Autowired
+	protected CommentReadService commentReadService;
 
-    /**
-     * ================== Service ========================
-     */
-    @MockBean
-    protected InquiryReadService inquiryReadService;
-    @MockBean
-    protected SecurityReadService securityReadService;
-    @Autowired
-    protected MemberService memberService;
-    @Autowired
-    protected MyPageReadService myPageReadService;
-    @MockBean
-    protected BoardService boardService;
-    @Autowired
-    protected BoardReadService boardReadService;
-    @MockBean
-    protected MemberReadService memberReadService;
-    @Autowired
-    protected BoardCountReadService boardCountReadService;
-    @Autowired
-    protected BoardRecommendReadService boardRecommendReadService;
-    @Autowired
-    protected BoardCountService boardCountService;
-    @Autowired
-    protected InquiryService inquiryService;
-    @Autowired
-    protected CommentService commentService;
-    @Autowired
-    protected CommentReadService commentReadService;
+	/**
+	 * ================== Config ========================
+	 */
+	@MockBean
+	protected S3ConfigLocal s3ConfigLocal;
+	@MockBean
+	protected S3Presigner s3Presigner;
+	@MockBean
+	protected S3Controller s3Controller;
+	@MockBean
+	protected StorageService s3Service;
+	@MockBean
+	protected SlackService slackService;
 
-    /**
-     * ================== Config ========================
-     */
-    @MockBean
-    protected S3ConfigLocal s3ConfigLocal;
-    @MockBean
-    protected S3Presigner s3Presigner;
-    @MockBean
-    protected S3Controller s3Controller;
-    @MockBean
-    protected StorageService s3Service;
-    @MockBean
-    protected SlackService slackService;
+	@AfterEach
+	void tearDown() {
+		viewCountMemberRepository.deleteAllInBatch();
+		matchPredictionRepository.deleteAllInBatch();
+		matchRepository.deleteAllInBatch();
+		teamRepository.deleteAllInBatch();
+		inquiryRepository.deleteAllInBatch();
+		newsCountMemberRepository.deleteAllInBatch();
+		newsCountRepository.deleteAllInBatch();
+		newsRepository.deleteAllInBatch();
+		boardRecommendRepository.deleteAllInBatch();
+		boardCountRepository.deleteAllInBatch();
+		boardRepository.deleteAllInBatch();
+		memberActivityRepository.deleteAllInBatch();
+		memberJpaRepository.deleteAllInBatch();
+	}
 
-    @AfterEach
-    void tearDown() {
-        matchPredictionRepository.deleteAllInBatch();
-        matchRepository.deleteAllInBatch();
-        teamRepository.deleteAllInBatch();
-        inquiryRepository.deleteAllInBatch();
-        newsCountMemberRepository.deleteAllInBatch();
-        newsCountRepository.deleteAllInBatch();
-        newsRepository.deleteAllInBatch();
-        boardRecommendRepository.deleteAllInBatch();
-        boardCountRepository.deleteAllInBatch();
-        boardRepository.deleteAllInBatch();
-        memberActivityRepository.deleteAllInBatch();
-        memberJpaRepository.deleteAllInBatch();
-    }
+	protected Member createMember(int index) {
+		Member member = Member.builder()
+			.email("test" + index + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.USER)
+			.type(MemberType.LOCAL)
+			.publicId(UUID.randomUUID())
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-    protected Member createMember(int index) {
-        Member member = Member.builder()
-                .email("test" + index + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.USER)
-                .type(MemberType.LOCAL)
-                .publicId(UUID.randomUUID())
-                .status(MemberStatus.ACTIVE)
-                .build();
+		Member savedMember = memberJpaRepository.save(member);
 
-        Member savedMember = memberJpaRepository.save(member);
+		given(securityReadService.getMember())
+			.willReturn(savedMember);
 
-        given(securityReadService.getMember())
-                .willReturn(savedMember);
+		given(securityReadService.getAuthenticatedPublicId())
+			.willReturn(member.getPublicId());
 
-        given(securityReadService.getAuthenticatedPublicId())
-                .willReturn(member.getPublicId());
+		return savedMember;
+	}
 
-        return savedMember;
-    }
+	protected Member createAdmin(int index) {
+		Member admin = Member.builder()
+			.email("test" + index + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.ADMIN)
+			.type(MemberType.LOCAL)
+			.publicId(UUID.randomUUID())
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-    protected Member createAdmin(int index) {
-        Member admin = Member.builder()
-                .email("test" + index + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.ADMIN)
-                .type(MemberType.LOCAL)
-                .publicId(UUID.randomUUID())
-                .status(MemberStatus.ACTIVE)
-                .build();
+		Member savedMember = memberJpaRepository.save(admin);
 
-        Member savedMember = memberJpaRepository.save(admin);
+		given(securityReadService.getMember())
+			.willReturn(savedMember);
 
-        given(securityReadService.getMember())
-                .willReturn(savedMember);
+		given(securityReadService.getAuthenticatedPublicId())
+			.willReturn(admin.getPublicId());
 
-        given(securityReadService.getAuthenticatedPublicId())
-                .willReturn(admin.getPublicId());
+		return savedMember;
+	}
 
-        return savedMember;
-    }
+	protected News createNews(int index, Category category, int count) {
+		News savedNews = newsRepository.save(News.builder()
+			.title("기사타이틀" + index)
+			.category(category)
+			.thumbImg("www.test.com")
+			.postDate(LocalDateTime.now())
+			.source("www.test.com")
+			.content("뉴스본문")
+			.build());
 
-    protected News createNews(int index, Category category, int count) {
-        News savedNews = newsRepository.save(News.builder()
-                .title("기사타이틀" + index)
-                .category(category)
-                .thumbImg("www.test.com")
-                .postDate(LocalDateTime.now())
-                .source("www.test.com")
-                .content("뉴스본문")
-                .build());
+		NewsCount newsCount = NewsCount.builder()
+			.recommendCount(count)
+			.commentCount(count)
+			.viewCount(count)
+			.build();
 
-        NewsCount newsCount = NewsCount.builder()
-                .recommendCount(count)
-                .commentCount(count)
-                .viewCount(count)
-                .build();
+		newsCount.updateNews(savedNews);
 
-        newsCount.updateNews(savedNews);
+		newsCountRepository.save(newsCount);
 
-        newsCountRepository.save(newsCount);
+		return savedNews;
+	}
 
-        return savedNews;
-    }
+	protected News createNewsWithPostDate(int index, Category category, int count, LocalDateTime postTime) {
+		News savedNews = newsRepository.save(News.builder()
+			.title("기사타이틀" + index)
+			.category(category)
+			.thumbImg("www.test.com")
+			.postDate(postTime)
+			.source("www.test.com")
+			.content("뉴스본문")
+			.build());
 
-    protected News createNewsWithPostDate(int index, Category category, int count, LocalDateTime postTime) {
-        News savedNews = newsRepository.save(News.builder()
-                .title("기사타이틀" + index)
-                .category(category)
-                .thumbImg("www.test.com")
-                .postDate(postTime)
-                .source("www.test.com")
-                .content("뉴스본문")
-                .build());
+		NewsCount newsCount = NewsCount.builder()
+			.recommendCount(count)
+			.commentCount(count)
+			.viewCount(count)
+			.build();
 
-        NewsCount newsCount = NewsCount.builder()
-                .recommendCount(count)
-                .commentCount(count)
-                .viewCount(count)
-                .build();
+		newsCount.updateNews(savedNews);
 
-        newsCount.updateNews(savedNews);
+		newsCountRepository.save(newsCount);
 
-        newsCountRepository.save(newsCount);
+		return savedNews;
+	}
 
-        return savedNews;
-    }
+	protected NewsCountMember createNewsCountMember(Member member, News news) {
+		return newsCountMemberRepository.save(
+			NewsCountMember.builder()
+				.news(news)
+				.member(member)
+				.build()
+		);
+	}
 
-    protected NewsCountMember createNewsCountMember(Member member, News news) {
-        return newsCountMemberRepository.save(
-                NewsCountMember.builder()
-                        .news(news)
-                        .member(member)
-                        .build()
-        );
-    }
+	protected Team createTeam(int index, TeamCategory category) {
+		return teamRepository.save(Team.builder()
+			.name("테스트팀" + index)
+			.logo("www.test.com")
+			.category(category)
+			.build());
+	}
 
-    protected Team createTeam(int index, TeamCategory category) {
-        return teamRepository.save(Team.builder()
-                .name("테스트팀" + index)
-                .logo("www.test.com")
-                .category(category)
-                .build());
-    }
+	protected Match createMatch(Team homeTeam, Team awayTeam, MatchCategory category,
+		LocalDateTime startDate) {
+		return matchRepository.save(Match.builder()
+			.homeTeam(homeTeam)
+			.awayTeam(awayTeam)
+			.category(category)
+			.startTime(startDate)
+			.build());
+	}
 
-    protected Match createMatch(Team homeTeam, Team awayTeam, MatchCategory category,
-                                LocalDateTime startDate) {
-        return matchRepository.save(Match.builder()
-                .homeTeam(homeTeam)
-                .awayTeam(awayTeam)
-                .category(category)
-                .startTime(startDate)
-                .build());
-    }
+	protected MatchPrediction createMatchPrediction(Match match, int home, int away) {
+		return matchPredictionRepository.save(MatchPrediction.builder()
+			.match(match)
+			.home(home)
+			.away(away)
+			.build());
+	}
 
-    protected MatchPrediction createMatchPrediction(Match match, int home, int away) {
-        return matchPredictionRepository.save(MatchPrediction.builder()
-                .match(match)
-                .home(home)
-                .away(away)
-                .build());
-    }
+	protected Board createBoard(Member member, Category boardType, CategoryType categoryType, String title,
+		String content) {
 
-    protected Board createBoard(Member member, Category boardType, CategoryType categoryType, String title,
-                                String content) {
+		Board board = Board.builder()
+			.member(member)
+			.boardType(boardType)
+			.categoryType(categoryType)
+			.title(title)
+			.content(content)
+			.link("https://www.naver.com")
+			.createdIp("127.0.0.1")
+			.thumbnail("http://localhost:9000/devbucket/inage/1235.png")
+			.build();
 
-        Board board = Board.builder()
-                .member(member)
-                .boardType(boardType)
-                .categoryType(categoryType)
-                .title(title)
-                .content(content)
-                .link("https://www.naver.com")
-                .createdIp("127.0.0.1")
-                .thumbnail("http://localhost:9000/devbucket/inage/1235.png")
-                .build();
+		boardRepository.save(board);
 
-        boardRepository.save(board);
+		BoardCount boardCount = BoardCount.builder()
+			.board(board)
+			.recommendCount(0)
+			.commentCount(0)
+			.viewCount(0)
+			.build();
 
-        BoardCount boardCount = BoardCount.builder()
-                .board(board)
-                .recommendCount(0)
-                .commentCount(0)
-                .viewCount(0)
-                .build();
+		boardCountRepository.save(boardCount);
 
-        boardCountRepository.save(boardCount);
+		return board;
+	}
 
-        return board;
-    }
+	protected BoardRecommend createBoardRecommend(Board board, Member member) {
+		BoardRecommend recommend = BoardRecommend.builder()
+			.board(board)
+			.member(member)
+			.build();
+		boardRecommendRepository.save(recommend);
 
-    protected BoardRecommend createBoardRecommend(Board board, Member member) {
-        BoardRecommend recommend = BoardRecommend.builder()
-                .board(board)
-                .member(member)
-                .build();
-        boardRecommendRepository.save(recommend);
+		return recommend;
+	}
 
-        return recommend;
-    }
+	protected Notice createNotice(Member member) {
+		Notice notice = Notice.builder()
+			.member(member)
+			.title("공지사하아앙 제목")
+			.content("공지공지공지")
+			.createdIP("0.0.0.1")
+			.imgUrl(null)
+			.build();
 
-    protected Notice createNotice(Member member) {
-        Notice notice = Notice.builder()
-                .member(member)
-                .title("공지사하아앙 제목")
-                .content("공지공지공지")
-                .createdIP("0.0.0.1")
-                .imgUrl(null)
-                .build();
+		noticeRepository.save(notice);
 
-        noticeRepository.save(notice);
+		NoticeCount noticeCount = NoticeCount.builder()
+			.notice(notice)
+			.recommendCount(0)
+			.commentCount(0)
+			.viewCount(0)
+			.build();
 
-        NoticeCount noticeCount = NoticeCount.builder()
-                .notice(notice)
-                .recommendCount(0)
-                .commentCount(0)
-                .viewCount(0)
-                .build();
+		noticeCountRepository.save(noticeCount);
 
-        noticeCountRepository.save(noticeCount);
+		return notice;
+	}
 
-        return notice;
-    }
+	protected Inquiry createInquiry(Member member) {
+		Inquiry inquiry = Inquiry.builder()
+			.content("문의사항ㅇㅇㅇ")
+			.member(member)
+			.clientIp("0.0.0.1")
+			.createdAt(LocalDateTime.now())
+			.isAdminAnswered(false)
+			.build();
 
-    protected Inquiry createInquiry(Member member) {
-        Inquiry inquiry = Inquiry.builder()
-                .content("문의사항ㅇㅇㅇ")
-                .member(member)
-                .clientIp("0.0.0.1")
-                .createdAt(LocalDateTime.now())
-                .isAdminAnswered(false)
-                .build();
+		inquiryRepository.save(inquiry);
 
-        inquiryRepository.save(inquiry);
+		InquiryCount inquiryCount = InquiryCount.createCount(inquiry);
+		inquiryCountRepository.save(inquiryCount);
 
-        InquiryCount inquiryCount = InquiryCount.createCount(inquiry);
-        inquiryCountRepository.save(inquiryCount);
+		return inquiry;
+	}
 
-        return inquiry;
-    }
+	protected Improvement createImprovement(Member member) {
+		Improvement improvement = Improvement.builder()
+			.member(member)
+			.title("개선요처어엉ㅇ 제목")
+			.content("개선개선개선")
+			.createdIP("0.0.0.1")
+			.imgUrl(null)
+			.build();
+		improvementRepository.save(improvement);
 
-    protected Improvement createImprovement(Member member) {
-        Improvement improvement = Improvement.builder()
-                .member(member)
-                .title("개선요처어엉ㅇ 제목")
-                .content("개선개선개선")
-                .createdIP("0.0.0.1")
-                .imgUrl(null)
-                .build();
-        improvementRepository.save(improvement);
+		ImprovementCount improvementCount = ImprovementCount.createImprovementCount(improvement);
+		improvementCountRepository.save(improvementCount);
 
-        ImprovementCount improvementCount = ImprovementCount.createImprovementCount(improvement);
-        improvementCountRepository.save(improvementCount);
+		return improvement;
+	}
 
-        return improvement;
-    }
+	protected ViewCountMember createViewCountMember(Long id, Member member, ViewType viewType) {
+		return viewCountMemberRepository.save(
+			ViewCountMember.createEntity(id, member, viewType));
+	}
 }

--- a/src/test/java/org/myteam/server/board/service/BoardCountServiceTest.java
+++ b/src/test/java/org/myteam/server/board/service/BoardCountServiceTest.java
@@ -1,14 +1,15 @@
 package org.myteam.server.board.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,325 +23,334 @@ import org.myteam.server.member.domain.MemberRole;
 import org.myteam.server.member.domain.MemberStatus;
 import org.myteam.server.member.domain.MemberType;
 import org.myteam.server.member.entity.Member;
+import org.myteam.server.viewCountMember.domain.ViewType;
+import org.myteam.server.viewCountMember.service.ViewCountService;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 public class BoardCountServiceTest extends IntegrationTestSupport {
 
-    @DisplayName("게시글 추천 클릭시 사용자 좋아요 추가를 테스트한다.")
-    @Test
-    @Transactional
-    void recommendBoardTest() {
-        // given
-        Member member = createMember(1);
-        Board board = createBoard(member, Category.BASEBALL, CategoryType.FREE, "야구 카테고리 제목", "야구 카테고리 내용");
-        // when
-        boardCountService.recommendBoard(board.getId());
+	@MockBean
+	private ViewCountService viewCountService;
 
-        // then
-        assertAll(
-                () -> Assertions.assertThat(boardCountRepository.findByBoardId(board.getId()).get().getRecommendCount())
-                        .isEqualTo(1),
-                () -> Assertions.assertThat(
-                                boardRecommendRepository.findByBoardIdAndMemberPublicId(board.getId(), member.getPublicId())
-                                        .get())
-                        .extracting("board.id", "member.publicId")
-                        .contains(board.getId(), member.getPublicId())
-        );
-    }
+	@DisplayName("게시글 추천 클릭시 사용자 좋아요 추가를 테스트한다.")
+	@Test
+	@Transactional
+	void recommendBoardTest() {
+		// given
+		Member member = createMember(1);
+		Board board = createBoard(member, Category.BASEBALL, CategoryType.FREE, "야구 카테고리 제목", "야구 카테고리 내용");
+		// when
+		boardCountService.recommendBoard(board.getId());
 
-    @DisplayName("게시글 추천 취소시 사용자 좋아요 제거를 테스트한다.")
-    @Test
-    @Transactional
-    void cancelRecommendTest() {
-        // given
-        Member member = createMember(1);
-        Board board = createBoard(member, Category.BASEBALL, CategoryType.FREE, "야구 카테고리 제목", "야구 카테고리 내용");
+		// then
+		assertAll(
+			() -> Assertions.assertThat(boardCountRepository.findByBoardId(board.getId()).get().getRecommendCount())
+				.isEqualTo(1),
+			() -> Assertions.assertThat(
+					boardRecommendRepository.findByBoardIdAndMemberPublicId(board.getId(), member.getPublicId())
+						.get())
+				.extracting("board.id", "member.publicId")
+				.contains(board.getId(), member.getPublicId())
+		);
+	}
 
-        boardCountService.addRecommendCount(board.getId());
-        BoardRecommend boardRecommend = createBoardRecommend(board, member);
+	@DisplayName("게시글 추천 취소시 사용자 좋아요 제거를 테스트한다.")
+	@Test
+	@Transactional
+	void cancelRecommendTest() {
+		// given
+		Member member = createMember(1);
+		Board board = createBoard(member, Category.BASEBALL, CategoryType.FREE, "야구 카테고리 제목", "야구 카테고리 내용");
 
-        // when
-        boardCountService.deleteRecommendBoard(board.getId());
+		boardCountService.addRecommendCount(board.getId());
+		BoardRecommend boardRecommend = createBoardRecommend(board, member);
 
-        //then
-        assertAll(
-                () -> assertThat(boardCountRepository.findByBoardId(board.getId()).get().getRecommendCount()).isEqualTo(
-                        0),
-                () -> assertThatThrownBy(() -> boardRecommendRepository.findById(boardRecommend.getId()).get())
-                        .isInstanceOf(NoSuchElementException.class)
-                        .hasMessage("No value present")
-        );
-    }
+		// when
+		boardCountService.deleteRecommendBoard(board.getId());
 
-    @DisplayName("게시글 추천수 증가 동시성 테스트한다.")
-    @Test
-    void addRecommendCountTest() throws InterruptedException, ExecutionException {
-        int threadCount = 50;
+		//then
+		assertAll(
+			() -> assertThat(boardCountRepository.findByBoardId(board.getId()).get().getRecommendCount()).isEqualTo(
+				0),
+			() -> assertThatThrownBy(() -> boardRecommendRepository.findById(boardRecommend.getId()).get())
+				.isInstanceOf(NoSuchElementException.class)
+				.hasMessage("No value present")
+		);
+	}
 
-        ExecutorService executorService = Executors.newFixedThreadPool(25);
-        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+	@DisplayName("게시글 추천수 증가 동시성 테스트한다.")
+	@Test
+	void addRecommendCountTest() throws InterruptedException, ExecutionException {
+		int threadCount = 50;
 
-        Member member = Member.builder()
-                .email("test" + 1 + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.USER)
-                .type(MemberType.LOCAL)
-                .status(MemberStatus.ACTIVE)
-                .build();
+		ExecutorService executorService = Executors.newFixedThreadPool(25);
+		CountDownLatch countDownLatch = new CountDownLatch(threadCount);
 
-        Board board = Board.builder()
-                .member(member)
-                .boardType(Category.BASEBALL)
-                .categoryType(CategoryType.FREE)
-                .title("title")
-                .content("content")
-                .link("https://www.naver.com")
-                .createdIp("127.0.0.1")
-                .thumbnail("http://localhost:9000/devbucket/inage/1235.png")
-                .build();
+		Member member = Member.builder()
+			.email("test" + 1 + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.USER)
+			.type(MemberType.LOCAL)
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-        BoardCount savedBoardCount = BoardCount.builder()
-                .board(board)
-                .build();
+		Board board = Board.builder()
+			.member(member)
+			.boardType(Category.BASEBALL)
+			.categoryType(CategoryType.FREE)
+			.title("title")
+			.content("content")
+			.link("https://www.naver.com")
+			.createdIp("127.0.0.1")
+			.thumbnail("http://localhost:9000/devbucket/inage/1235.png")
+			.build();
 
-        executorService.submit(() -> {
-            memberJpaRepository.save(member);
-            boardRepository.save(board);
-            boardCountRepository.save(savedBoardCount);
-        }).get();
+		BoardCount savedBoardCount = BoardCount.builder()
+			.board(board)
+			.build();
 
-        for (int i = 0; i < threadCount; i++) {
-            executorService.execute(() -> {
-                try {
-                    boardCountService.addRecommendCount(board.getId());
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
-        }
+		executorService.submit(() -> {
+			memberJpaRepository.save(member);
+			boardRepository.save(board);
+			boardCountRepository.save(savedBoardCount);
+		}).get();
 
-        countDownLatch.await();
+		for (int i = 0; i < threadCount; i++) {
+			executorService.execute(() -> {
+				try {
+					boardCountService.addRecommendCount(board.getId());
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
 
-        assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getRecommendCount()).isEqualTo(50);
-    }
+		countDownLatch.await();
 
-    @DisplayName("게시글 추천수 감소 동시성 테스트한다.")
-    @Test
-    void minusRecommendCountTest() throws InterruptedException, ExecutionException {
-        int threadCount = 50;
+		assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getRecommendCount()).isEqualTo(50);
+	}
 
-        ExecutorService executorService = Executors.newFixedThreadPool(25);
-        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+	@DisplayName("게시글 추천수 감소 동시성 테스트한다.")
+	@Test
+	void minusRecommendCountTest() throws InterruptedException, ExecutionException {
+		int threadCount = 50;
 
-        Member member = Member.builder()
-                .email("test" + 1 + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.USER)
-                .type(MemberType.LOCAL)
-                .status(MemberStatus.ACTIVE)
-                .build();
+		ExecutorService executorService = Executors.newFixedThreadPool(25);
+		CountDownLatch countDownLatch = new CountDownLatch(threadCount);
 
-        Board board = Board.builder()
-                .member(member)
-                .boardType(Category.BASEBALL)
-                .categoryType(CategoryType.FREE)
-                .title("title")
-                .content("content")
-                .link("https://www.naver.com")
-                .createdIp("127.0.0.1")
-                .thumbnail("http://localhost:9000/devbucket/inage/1235.png")
-                .build();
+		Member member = Member.builder()
+			.email("test" + 1 + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.USER)
+			.type(MemberType.LOCAL)
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-        BoardCount savedBoardCount = BoardCount.builder()
-                .board(board)
-                .recommendCount(50)
-                .build();
+		Board board = Board.builder()
+			.member(member)
+			.boardType(Category.BASEBALL)
+			.categoryType(CategoryType.FREE)
+			.title("title")
+			.content("content")
+			.link("https://www.naver.com")
+			.createdIp("127.0.0.1")
+			.thumbnail("http://localhost:9000/devbucket/inage/1235.png")
+			.build();
 
-        executorService.submit(() -> {
-            memberJpaRepository.save(member);
-            boardRepository.save(board);
-            boardCountRepository.save(savedBoardCount);
-        }).get();
+		BoardCount savedBoardCount = BoardCount.builder()
+			.board(board)
+			.recommendCount(50)
+			.build();
 
-        // when
-        for (int i = 0; i < threadCount; i++) {
-            executorService.execute(() -> {
-                try {
-                    boardCountService.minusRecommendCount(board.getId());
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
-        }
+		executorService.submit(() -> {
+			memberJpaRepository.save(member);
+			boardRepository.save(board);
+			boardCountRepository.save(savedBoardCount);
+		}).get();
 
-        countDownLatch.await();
+		// when
+		for (int i = 0; i < threadCount; i++) {
+			executorService.execute(() -> {
+				try {
+					boardCountService.minusRecommendCount(board.getId());
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
 
-        assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getRecommendCount()).isEqualTo(0);
-    }
+		countDownLatch.await();
 
-    @DisplayName("게시판 댓글수 증가 동시성 테스트한다.")
-    @Test
-    void addCommentCountTest() throws InterruptedException, ExecutionException {
-        int threadCount = 50;
+		assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getRecommendCount()).isEqualTo(0);
+	}
 
-        ExecutorService executorService = Executors.newFixedThreadPool(25);
-        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+	@DisplayName("게시판 댓글수 증가 동시성 테스트한다.")
+	@Test
+	void addCommentCountTest() throws InterruptedException, ExecutionException {
+		int threadCount = 50;
 
-        Member member = Member.builder()
-                .email("test" + 1 + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.USER)
-                .type(MemberType.LOCAL)
-                .status(MemberStatus.ACTIVE)
-                .build();
+		ExecutorService executorService = Executors.newFixedThreadPool(25);
+		CountDownLatch countDownLatch = new CountDownLatch(threadCount);
 
-        Board board = Board.builder()
-                .member(member)
-                .boardType(Category.BASEBALL)
-                .categoryType(CategoryType.FREE)
-                .title("title")
-                .content("content")
-                .link("https://www.naver.com")
-                .createdIp("127.0.0.1")
-                .thumbnail("http://localhost:9000/devbucket/inage/1235.png")
-                .build();
+		Member member = Member.builder()
+			.email("test" + 1 + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.USER)
+			.type(MemberType.LOCAL)
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-        BoardCount savedBoardCount = BoardCount.builder()
-                .board(board)
-                .build();
+		Board board = Board.builder()
+			.member(member)
+			.boardType(Category.BASEBALL)
+			.categoryType(CategoryType.FREE)
+			.title("title")
+			.content("content")
+			.link("https://www.naver.com")
+			.createdIp("127.0.0.1")
+			.thumbnail("http://localhost:9000/devbucket/inage/1235.png")
+			.build();
 
-        executorService.submit(() -> {
-            memberJpaRepository.save(member);
-            boardRepository.save(board);
-            boardCountRepository.save(savedBoardCount);
-        }).get();
+		BoardCount savedBoardCount = BoardCount.builder()
+			.board(board)
+			.build();
 
-        for (int i = 0; i < threadCount; i++) {
-            executorService.execute(() -> {
-                try {
-                    boardCountService.addCommentCount(board.getId());
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
-        }
-        countDownLatch.await();
+		executorService.submit(() -> {
+			memberJpaRepository.save(member);
+			boardRepository.save(board);
+			boardCountRepository.save(savedBoardCount);
+		}).get();
 
-        assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getCommentCount())
-                .isEqualTo(50);
-    }
+		for (int i = 0; i < threadCount; i++) {
+			executorService.execute(() -> {
+				try {
+					boardCountService.addCommentCount(board.getId());
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
+		countDownLatch.await();
 
-    @DisplayName("게시판 댓글수 감소 동시성 테스트한다.")
-    @Test
-    void minusCommentCountTest() throws InterruptedException, ExecutionException {
-        int threadCount = 50;
+		assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getCommentCount())
+			.isEqualTo(50);
+	}
 
-        ExecutorService executorService = Executors.newFixedThreadPool(25);
-        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+	@DisplayName("게시판 댓글수 감소 동시성 테스트한다.")
+	@Test
+	void minusCommentCountTest() throws InterruptedException, ExecutionException {
+		int threadCount = 50;
 
-        Member member = Member.builder()
-                .email("test" + 1 + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.USER)
-                .type(MemberType.LOCAL)
-                .status(MemberStatus.ACTIVE)
-                .build();
+		ExecutorService executorService = Executors.newFixedThreadPool(25);
+		CountDownLatch countDownLatch = new CountDownLatch(threadCount);
 
-        Board board = Board.builder()
-                .member(member)
-                .boardType(Category.BASEBALL)
-                .categoryType(CategoryType.FREE)
-                .title("title")
-                .content("content")
-                .link("https://www.naver.com")
-                .createdIp("127.0.0.1")
-                .thumbnail("http://localhost:9000/devbucket/inage/1235.png")
-                .build();
+		Member member = Member.builder()
+			.email("test" + 1 + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.USER)
+			.type(MemberType.LOCAL)
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-        BoardCount savedBoardCount = BoardCount.builder()
-                .board(board)
-                .commentCount(50)
-                .build();
+		Board board = Board.builder()
+			.member(member)
+			.boardType(Category.BASEBALL)
+			.categoryType(CategoryType.FREE)
+			.title("title")
+			.content("content")
+			.link("https://www.naver.com")
+			.createdIp("127.0.0.1")
+			.thumbnail("http://localhost:9000/devbucket/inage/1235.png")
+			.build();
 
-        executorService.submit(() -> {
-            memberJpaRepository.save(member);
-            boardRepository.save(board);
-            boardCountRepository.save(savedBoardCount);
-        }).get();
+		BoardCount savedBoardCount = BoardCount.builder()
+			.board(board)
+			.commentCount(50)
+			.build();
 
-        for (int i = 0; i < threadCount; i++) {
-            executorService.execute(() -> {
-                try {
-                    boardCountService.minusCommentCount(board.getId());
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
-        }
+		executorService.submit(() -> {
+			memberJpaRepository.save(member);
+			boardRepository.save(board);
+			boardCountRepository.save(savedBoardCount);
+		}).get();
 
-        countDownLatch.await();
+		for (int i = 0; i < threadCount; i++) {
+			executorService.execute(() -> {
+				try {
+					boardCountService.minusCommentCount(board.getId());
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
 
-        assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getCommentCount())
-                .isEqualTo(0);
-    }
+		countDownLatch.await();
 
-    @DisplayName("게시판 조회수 증가 동시성 테스트한다.")
-    @Test
-    void addViewCountCountTest() throws InterruptedException, ExecutionException {
-        int threadCount = 50;
-        ExecutorService executorService = Executors.newFixedThreadPool(25);
-        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+		assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getCommentCount())
+			.isEqualTo(0);
+	}
 
-        Member member = Member.builder()
-                .email("test" + 1 + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.USER)
-                .type(MemberType.LOCAL)
-                .status(MemberStatus.ACTIVE)
-                .build();
+	@DisplayName("게시판 조회수 증가 동시성 테스트한다.")
+	@Test
+	void addViewCountCountTest() throws InterruptedException, ExecutionException {
+		int threadCount = 50;
+		ExecutorService executorService = Executors.newFixedThreadPool(25);
+		CountDownLatch countDownLatch = new CountDownLatch(threadCount);
 
-        Board board = Board.builder()
-                .member(member)
-                .boardType(Category.BASEBALL)
-                .categoryType(CategoryType.FREE)
-                .title("title")
-                .content("content")
-                .link("https://www.naver.com")
-                .createdIp("127.0.0.1")
-                .thumbnail("http://localhost:9000/devbucket/inage/1235.png")
-                .build();
+		Member member = Member.builder()
+			.email("test" + 1 + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.USER)
+			.type(MemberType.LOCAL)
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-        BoardCount savedBoardCount = BoardCount.builder()
-                .board(board)
-                .build();
+		Board board = Board.builder()
+			.member(member)
+			.boardType(Category.BASEBALL)
+			.categoryType(CategoryType.FREE)
+			.title("title")
+			.content("content")
+			.link("https://www.naver.com")
+			.createdIp("127.0.0.1")
+			.thumbnail("http://localhost:9000/devbucket/inage/1235.png")
+			.build();
 
-        executorService.submit(() -> {
-            memberJpaRepository.save(member);
-            boardRepository.save(board);
-            boardCountRepository.save(savedBoardCount);
-        }).get();
+		BoardCount savedBoardCount = BoardCount.builder()
+			.board(board)
+			.build();
 
-        for (int i = 0; i < threadCount; i++) {
-            executorService.execute(() -> {
-                try {
-                    boardCountService.addViewCount(board.getId());
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
-        }
-        countDownLatch.await();
+		given(viewCountService.confirmPostView(null, null, ViewType.BOARD, 1L, null))
+			.willReturn(false);
 
-        assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getViewCount()).isEqualTo(50);
-    }
+		executorService.submit(() -> {
+			memberJpaRepository.save(member);
+			boardRepository.save(board);
+			boardCountRepository.save(savedBoardCount);
+		}).get();
+
+		for (int i = 0; i < threadCount; i++) {
+			executorService.execute(() -> {
+				try {
+					boardCountService.addViewCount(null, null, board.getId());
+				} finally {
+					countDownLatch.countDown();
+				}
+			});
+		}
+		countDownLatch.await();
+
+		assertThat(boardCountRepository.findById(savedBoardCount.getId()).get().getViewCount()).isEqualTo(50);
+	}
 }

--- a/src/test/java/org/myteam/server/news/newsCount/service/NewsCountServiceTest.java
+++ b/src/test/java/org/myteam/server/news/newsCount/service/NewsCountServiceTest.java
@@ -2,6 +2,7 @@ package org.myteam.server.news.newsCount.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
 import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
@@ -19,7 +20,10 @@ import org.myteam.server.news.news.repository.NewsRepository;
 import org.myteam.server.news.newsCount.domain.NewsCount;
 import org.myteam.server.news.newsCount.repository.NewsCountRepository;
 import org.myteam.server.news.newsCountMember.domain.NewsCountMember;
+import org.myteam.server.viewCountMember.domain.ViewType;
+import org.myteam.server.viewCountMember.service.ViewCountService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 public class NewsCountServiceTest extends IntegrationTestSupport {
@@ -30,6 +34,9 @@ public class NewsCountServiceTest extends IntegrationTestSupport {
 	private NewsRepository newsRepository;
 	@Autowired
 	private NewsCountRepository newsCountRepository;
+
+	@MockBean
+	private ViewCountService viewCountService;
 
 	@DisplayName("뉴스 추천 클릭시 사용자 좋아요 추가를 테스트한다.")
 	@Test
@@ -260,6 +267,9 @@ public class NewsCountServiceTest extends IntegrationTestSupport {
 			.news(news)
 			.build();
 
+		given(viewCountService.confirmPostView(null, null, ViewType.BOARD, 1L, null))
+			.willReturn(false);
+
 		executorService.submit(() -> {
 			newsRepository.save(news);
 			newsCountRepository.save(savedNewsCount);
@@ -269,7 +279,7 @@ public class NewsCountServiceTest extends IntegrationTestSupport {
 		for (int i = 0; i < threadCount; i++) {
 			executorService.execute(() -> {
 				try {
-					newsCountService.addViewCount(news.getId());
+					newsCountService.addViewCount(null, null, news.getId());
 				} finally {
 					countDownLatch.countDown();
 				}

--- a/src/test/java/org/myteam/server/viewCountMember/service/ViewCountMemberReadServiceTest.java
+++ b/src/test/java/org/myteam/server/viewCountMember/service/ViewCountMemberReadServiceTest.java
@@ -1,0 +1,26 @@
+package org.myteam.server.viewCountMember.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.viewCountMember.domain.ViewCountMember;
+import org.myteam.server.viewCountMember.domain.ViewType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ViewCountMemberReadServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private ViewCountMemberReadService viewCountMemberReadService;
+
+	@DisplayName("로그인한 사용자가 조회한 계시물인지 조회한다..")
+	@Test
+	void existsByViewIdAndMemberPublicId() {
+		Member member = createMember(1);
+		ViewCountMember viewCountMember = createViewCountMember(1L, member, ViewType.BOARD);
+
+		assertThat(viewCountMemberReadService.existsByViewIdAndMemberPublicId(1L, member.getPublicId())).isTrue();
+	}
+}

--- a/src/test/java/org/myteam/server/viewCountMember/service/ViewCountServiceTest.java
+++ b/src/test/java/org/myteam/server/viewCountMember/service/ViewCountServiceTest.java
@@ -1,0 +1,37 @@
+package org.myteam.server.viewCountMember.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.viewCountMember.domain.ViewType;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ViewCountServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private ViewCountService viewCountService;
+
+	@DisplayName("publicId가 있는 경우 저장이 되는지 테스트한다.")
+	@Test
+	void confirmPostViewTest() {
+		Member member = createMember(1);
+
+		boolean isView = viewCountService.confirmPostView(null, null, ViewType.NEWS, 1L, member.getPublicId());
+
+		assertAll(
+			() -> assertThat(isView).isFalse(),
+			() -> assertThat(viewCountMemberRepository.findAll())
+				.extracting(
+					"viewId", "member.publicId", "viewType")
+				.containsExactly(
+					tuple(
+						1L, member.getPublicId(), ViewType.NEWS
+					)
+				)
+		);
+	}
+}


### PR DESCRIPTION
## 기능 설명
- 쿠키에 계시물ID를 저장하여 중복 방지 하도록 하였습니다.
- 로그인 안했을 시 주호님께서 회의때 IP 기준이라 하셨는데 IP 기준이면 아래와 같은 문제점이 있어서 쿠키에 저장하는 방식으로 했는데 어떤지 의견 부탁드립니다. 물론 쿠키를 개발자모드 켜서 초기화 시키면 조회수 가 카운팅 되긴합니다. 좋은 방법있으면 추천 부탁드립니다.
<img width="799" alt="스크린샷 2025-03-21 오후 3 06 37" src="https://github.com/user-attachments/assets/10918971-1967-452a-909e-a1380776ba76" />

## 작업 내용
- 로그인한 사용자라면 DB에 계시물 ID와 같이 저장하여 관리
- 로그인 안한 사용자라면 쿠키 조회하여 확인
## 수정 사항
- 
## 추가 작업 예정
-
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
