### PR TITLE
feat: 경기일정 리그명추가, 종료시간 기준으로 조건 수정

### DIFF
--- a/src/main/java/org/myteam/server/match/match/domain/Match.java
+++ b/src/main/java/org/myteam/server/match/match/domain/Match.java
@@ -35,18 +35,23 @@ public class Match extends BaseTime {
 
 	private String place;
 
+	private String leagueName;
+
 	@Enumerated(EnumType.STRING)
 	private MatchCategory category;
 
 	private LocalDateTime startTime;
 
+	private LocalDateTime endTime;
 	@Builder
-	public Match(Long id, Team homeTeam, Team awayTeam, String place, MatchCategory category, LocalDateTime startTime) {
+	public Match(Long id, Team homeTeam, Team awayTeam, String place, String leagueName, MatchCategory category, LocalDateTime startTime, LocalDateTime endTime) {
 		this.id = id;
 		this.homeTeam = homeTeam;
 		this.awayTeam = awayTeam;
 		this.place = place;
+		this.leagueName = leagueName;
 		this.category = category;
 		this.startTime = startTime;
+		this.endTime = endTime;
 	}
 }

--- a/src/main/java/org/myteam/server/match/match/dto/service/response/MatchResponse.java
+++ b/src/main/java/org/myteam/server/match/match/dto/service/response/MatchResponse.java
@@ -19,17 +19,20 @@ public class MatchResponse {
 	private TeamResponse awayTeam;
 	@Schema(description = "경기장소")
 	private String place;
+	@Schema(description = "리그명")
+	private String leagueName;
 	@Schema(description = "경기 시작 시간")
 	private LocalDateTime startTime;
 	@Schema(description = "경기 유형 ID")
 	private String category;
 
 	@Builder
-	public MatchResponse(Long id, TeamResponse homeTeam, TeamResponse awayTeam, String place, LocalDateTime startTime, String category) {
+	public MatchResponse(Long id, TeamResponse homeTeam, TeamResponse awayTeam, String place, String leagueName, LocalDateTime startTime, String category) {
 		this.id = id;
 		this.homeTeam = homeTeam;
 		this.awayTeam = awayTeam;
 		this.place = place;
+		this.leagueName = leagueName;
 		this.startTime = startTime;
 		this.category = category;
 	}
@@ -40,6 +43,7 @@ public class MatchResponse {
 			.homeTeam(TeamResponse.createResponse(match.getHomeTeam()))
 			.awayTeam(TeamResponse.createResponse(match.getAwayTeam()))
 			.place(match.getPlace())
+			.leagueName(match.getLeagueName())
 			.startTime(match.getStartTime())
 			.category(match.getCategory().name())
 			.build();

--- a/src/main/java/org/myteam/server/match/match/repository/MatchQueryRepository.java
+++ b/src/main/java/org/myteam/server/match/match/repository/MatchQueryRepository.java
@@ -31,7 +31,7 @@ public class MatchQueryRepository {
 	}
 
 	private BooleanExpression isBetweenDate(LocalDateTime startOfDay, LocalDateTime endTime) {
-		return match.startTime.between(startOfDay, endTime);
+		return match.endTime.between(startOfDay, endTime);
 	}
 
 	private BooleanExpression isCategoryEqualTo(MatchCategory matchCategory) {

--- a/src/test/java/org/myteam/server/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/IntegrationTestSupport.java
@@ -1,9 +1,10 @@
 package org.myteam.server;
 
-import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+
 import org.junit.jupiter.api.AfterEach;
 import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.BoardCount;
@@ -67,331 +68,333 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @ActiveProfiles("test")
 @SpringBootTest
 public abstract class IntegrationTestSupport {
 
-    /**
-     * ================== Repository ========================
-     */
-    @Autowired
-    protected TeamRepository teamRepository;
-    @Autowired
-    protected MatchRepository matchRepository;
-    @Autowired
-    protected NewsRepository newsRepository;
-    @Autowired
-    protected NewsCountRepository newsCountRepository;
-    @Autowired
-    protected MemberJpaRepository memberJpaRepository;
-    @Autowired
-    protected MemberActivityRepository memberActivityRepository;
-    @Autowired
-    protected NewsCountMemberRepository newsCountMemberRepository;
-    @Autowired
-    protected InquiryRepository inquiryRepository;
-    @Autowired
-    protected InquiryCountRepository inquiryCountRepository;
-    @Autowired
-    protected MatchPredictionRepository matchPredictionRepository;
-    @Autowired
-    protected BoardRepository boardRepository;
-    @Autowired
-    protected BoardCountRepository boardCountRepository;
-    @Autowired
-    protected BoardRecommendRepository boardRecommendRepository;
-    @Autowired
-    protected NoticeRepository noticeRepository;
-    @Autowired
-    protected NoticeCountRepository noticeCountRepository;
+	/**
+	 * ================== Repository ========================
+	 */
+	@Autowired
+	protected TeamRepository teamRepository;
+	@Autowired
+	protected MatchRepository matchRepository;
+	@Autowired
+	protected NewsRepository newsRepository;
+	@Autowired
+	protected NewsCountRepository newsCountRepository;
+	@Autowired
+	protected MemberJpaRepository memberJpaRepository;
+	@Autowired
+	protected MemberActivityRepository memberActivityRepository;
+	@Autowired
+	protected NewsCountMemberRepository newsCountMemberRepository;
+	@Autowired
+	protected InquiryRepository inquiryRepository;
+	@Autowired
+	protected InquiryCountRepository inquiryCountRepository;
+	@Autowired
+	protected MatchPredictionRepository matchPredictionRepository;
+	@Autowired
+	protected BoardRepository boardRepository;
+	@Autowired
+	protected BoardCountRepository boardCountRepository;
+	@Autowired
+	protected BoardRecommendRepository boardRecommendRepository;
+	@Autowired
+	protected NoticeRepository noticeRepository;
+	@Autowired
+	protected NoticeCountRepository noticeCountRepository;
 
-    @Autowired
-    protected ImprovementRepository improvementRepository;
-    @Autowired
-    protected ImprovementCountRepository improvementCountRepository;
-    @Autowired
-    protected CommentRepository commentRepository;
+	@Autowired
+	protected ImprovementRepository improvementRepository;
+	@Autowired
+	protected ImprovementCountRepository improvementCountRepository;
+	@Autowired
+	protected CommentRepository commentRepository;
 
-    /**
-     * ================== Service ========================
-     */
-    @MockBean
-    protected InquiryReadService inquiryReadService;
-    @MockBean
-    protected SecurityReadService securityReadService;
-    @Autowired
-    protected MemberService memberService;
-    @Autowired
-    protected MyPageReadService myPageReadService;
-    @MockBean
-    protected BoardService boardService;
-    @Autowired
-    protected BoardReadService boardReadService;
-    @MockBean
-    protected MemberReadService memberReadService;
-    @Autowired
-    protected BoardCountReadService boardCountReadService;
-    @Autowired
-    protected BoardRecommendReadService boardRecommendReadService;
-    @Autowired
-    protected BoardCountService boardCountService;
-    @Autowired
-    protected InquiryService inquiryService;
-    @Autowired
-    protected CommentService commentService;
-    @Autowired
-    protected CommentReadService commentReadService;
+	/**
+	 * ================== Service ========================
+	 */
+	@MockBean
+	protected InquiryReadService inquiryReadService;
+	@MockBean
+	protected SecurityReadService securityReadService;
+	@Autowired
+	protected MemberService memberService;
+	@Autowired
+	protected MyPageReadService myPageReadService;
+	@MockBean
+	protected BoardService boardService;
+	@Autowired
+	protected BoardReadService boardReadService;
+	@MockBean
+	protected MemberReadService memberReadService;
+	@Autowired
+	protected BoardCountReadService boardCountReadService;
+	@Autowired
+	protected BoardRecommendReadService boardRecommendReadService;
+	@Autowired
+	protected BoardCountService boardCountService;
+	@Autowired
+	protected InquiryService inquiryService;
+	@Autowired
+	protected CommentService commentService;
+	@Autowired
+	protected CommentReadService commentReadService;
 
-    /**
-     * ================== Config ========================
-     */
-    @MockBean
-    protected S3ConfigLocal s3ConfigLocal;
-    @MockBean
-    protected S3Presigner s3Presigner;
-    @MockBean
-    protected S3Controller s3Controller;
-    @MockBean
-    protected StorageService s3Service;
-    @MockBean
-    protected SlackService slackService;
+	/**
+	 * ================== Config ========================
+	 */
+	@MockBean
+	protected S3ConfigLocal s3ConfigLocal;
+	@MockBean
+	protected S3Presigner s3Presigner;
+	@MockBean
+	protected S3Controller s3Controller;
+	@MockBean
+	protected StorageService s3Service;
+	@MockBean
+	protected SlackService slackService;
 
-    @AfterEach
-    void tearDown() {
-        matchPredictionRepository.deleteAllInBatch();
-        matchRepository.deleteAllInBatch();
-        teamRepository.deleteAllInBatch();
-        inquiryRepository.deleteAllInBatch();
-        newsCountMemberRepository.deleteAllInBatch();
-        newsCountRepository.deleteAllInBatch();
-        newsRepository.deleteAllInBatch();
-        boardRecommendRepository.deleteAllInBatch();
-        boardCountRepository.deleteAllInBatch();
-        boardRepository.deleteAllInBatch();
-        memberActivityRepository.deleteAllInBatch();
-        memberJpaRepository.deleteAllInBatch();
-    }
+	@AfterEach
+	void tearDown() {
+		matchPredictionRepository.deleteAllInBatch();
+		matchRepository.deleteAllInBatch();
+		teamRepository.deleteAllInBatch();
+		inquiryRepository.deleteAllInBatch();
+		newsCountMemberRepository.deleteAllInBatch();
+		newsCountRepository.deleteAllInBatch();
+		newsRepository.deleteAllInBatch();
+		boardRecommendRepository.deleteAllInBatch();
+		boardCountRepository.deleteAllInBatch();
+		boardRepository.deleteAllInBatch();
+		memberActivityRepository.deleteAllInBatch();
+		memberJpaRepository.deleteAllInBatch();
+	}
 
-    protected Member createMember(int index) {
-        Member member = Member.builder()
-                .email("test" + index + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.USER)
-                .type(MemberType.LOCAL)
-                .publicId(UUID.randomUUID())
-                .status(MemberStatus.ACTIVE)
-                .build();
+	protected Member createMember(int index) {
+		Member member = Member.builder()
+			.email("test" + index + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.USER)
+			.type(MemberType.LOCAL)
+			.publicId(UUID.randomUUID())
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-        Member savedMember = memberJpaRepository.save(member);
+		Member savedMember = memberJpaRepository.save(member);
 
-        given(securityReadService.getMember())
-                .willReturn(savedMember);
+		given(securityReadService.getMember())
+			.willReturn(savedMember);
 
-        given(securityReadService.getAuthenticatedPublicId())
-                .willReturn(member.getPublicId());
+		given(securityReadService.getAuthenticatedPublicId())
+			.willReturn(member.getPublicId());
 
-        return savedMember;
-    }
+		return savedMember;
+	}
 
-    protected Member createAdmin(int index) {
-        Member admin = Member.builder()
-                .email("test" + index + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.ADMIN)
-                .type(MemberType.LOCAL)
-                .publicId(UUID.randomUUID())
-                .status(MemberStatus.ACTIVE)
-                .build();
+	protected Member createAdmin(int index) {
+		Member admin = Member.builder()
+			.email("test" + index + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.ADMIN)
+			.type(MemberType.LOCAL)
+			.publicId(UUID.randomUUID())
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-        Member savedMember = memberJpaRepository.save(admin);
+		Member savedMember = memberJpaRepository.save(admin);
 
-        given(securityReadService.getMember())
-                .willReturn(savedMember);
+		given(securityReadService.getMember())
+			.willReturn(savedMember);
 
-        given(securityReadService.getAuthenticatedPublicId())
-                .willReturn(admin.getPublicId());
+		given(securityReadService.getAuthenticatedPublicId())
+			.willReturn(admin.getPublicId());
 
-        return savedMember;
-    }
+		return savedMember;
+	}
 
-    protected News createNews(int index, Category category, int count) {
-        News savedNews = newsRepository.save(News.builder()
-                .title("기사타이틀" + index)
-                .category(category)
-                .thumbImg("www.test.com")
-                .postDate(LocalDateTime.now())
-                .source("www.test.com")
-                .content("뉴스본문")
-                .build());
+	protected News createNews(int index, Category category, int count) {
+		News savedNews = newsRepository.save(News.builder()
+			.title("기사타이틀" + index)
+			.category(category)
+			.thumbImg("www.test.com")
+			.postDate(LocalDateTime.now())
+			.source("www.test.com")
+			.content("뉴스본문")
+			.build());
 
-        NewsCount newsCount = NewsCount.builder()
-                .recommendCount(count)
-                .commentCount(count)
-                .viewCount(count)
-                .build();
+		NewsCount newsCount = NewsCount.builder()
+			.recommendCount(count)
+			.commentCount(count)
+			.viewCount(count)
+			.build();
 
-        newsCount.updateNews(savedNews);
+		newsCount.updateNews(savedNews);
 
-        newsCountRepository.save(newsCount);
+		newsCountRepository.save(newsCount);
 
-        return savedNews;
-    }
+		return savedNews;
+	}
 
-    protected News createNewsWithPostDate(int index, Category category, int count, LocalDateTime postTime) {
-        News savedNews = newsRepository.save(News.builder()
-                .title("기사타이틀" + index)
-                .category(category)
-                .thumbImg("www.test.com")
-                .postDate(postTime)
-                .source("www.test.com")
-                .content("뉴스본문")
-                .build());
+	protected News createNewsWithPostDate(int index, Category category, int count, LocalDateTime postTime) {
+		News savedNews = newsRepository.save(News.builder()
+			.title("기사타이틀" + index)
+			.category(category)
+			.thumbImg("www.test.com")
+			.postDate(postTime)
+			.source("www.test.com")
+			.content("뉴스본문")
+			.build());
 
-        NewsCount newsCount = NewsCount.builder()
-                .recommendCount(count)
-                .commentCount(count)
-                .viewCount(count)
-                .build();
+		NewsCount newsCount = NewsCount.builder()
+			.recommendCount(count)
+			.commentCount(count)
+			.viewCount(count)
+			.build();
 
-        newsCount.updateNews(savedNews);
+		newsCount.updateNews(savedNews);
 
-        newsCountRepository.save(newsCount);
+		newsCountRepository.save(newsCount);
 
-        return savedNews;
-    }
+		return savedNews;
+	}
 
-    protected NewsCountMember createNewsCountMember(Member member, News news) {
-        return newsCountMemberRepository.save(
-                NewsCountMember.builder()
-                        .news(news)
-                        .member(member)
-                        .build()
-        );
-    }
+	protected NewsCountMember createNewsCountMember(Member member, News news) {
+		return newsCountMemberRepository.save(
+			NewsCountMember.builder()
+				.news(news)
+				.member(member)
+				.build()
+		);
+	}
 
-    protected Team createTeam(int index, TeamCategory category) {
-        return teamRepository.save(Team.builder()
-                .name("테스트팀" + index)
-                .logo("www.test.com")
-                .category(category)
-                .build());
-    }
+	protected Team createTeam(int index, TeamCategory category) {
+		return teamRepository.save(Team.builder()
+			.name("테스트팀" + index)
+			.logo("www.test.com")
+			.category(category)
+			.build());
+	}
 
-    protected Match createMatch(Team homeTeam, Team awayTeam, MatchCategory category,
-                                LocalDateTime startDate) {
-        return matchRepository.save(Match.builder()
-                .homeTeam(homeTeam)
-                .awayTeam(awayTeam)
-                .category(category)
-                .startTime(startDate)
-                .build());
-    }
+	protected Match createMatch(Team homeTeam, Team awayTeam, MatchCategory category,
+		LocalDateTime startDate) {
+		return matchRepository.save(Match.builder()
+			.homeTeam(homeTeam)
+			.awayTeam(awayTeam)
+			.category(category)
+			.startTime(startDate)
+			.endTime(startDate)
+			.build());
+	}
 
-    protected MatchPrediction createMatchPrediction(Match match, int home, int away) {
-        return matchPredictionRepository.save(MatchPrediction.builder()
-                .match(match)
-                .home(home)
-                .away(away)
-                .build());
-    }
+	protected MatchPrediction createMatchPrediction(Match match, int home, int away) {
+		return matchPredictionRepository.save(MatchPrediction.builder()
+			.match(match)
+			.home(home)
+			.away(away)
+			.build());
+	}
 
-    protected Board createBoard(Member member, Category boardType, CategoryType categoryType, String title,
-                                String content) {
+	protected Board createBoard(Member member, Category boardType, CategoryType categoryType, String title,
+		String content) {
 
-        Board board = Board.builder()
-                .member(member)
-                .boardType(boardType)
-                .categoryType(categoryType)
-                .title(title)
-                .content(content)
-                .link("https://www.naver.com")
-                .createdIp("127.0.0.1")
-                .thumbnail("http://localhost:9000/devbucket/inage/1235.png")
-                .build();
+		Board board = Board.builder()
+			.member(member)
+			.boardType(boardType)
+			.categoryType(categoryType)
+			.title(title)
+			.content(content)
+			.link("https://www.naver.com")
+			.createdIp("127.0.0.1")
+			.thumbnail("http://localhost:9000/devbucket/inage/1235.png")
+			.build();
 
-        boardRepository.save(board);
+		boardRepository.save(board);
 
-        BoardCount boardCount = BoardCount.builder()
-                .board(board)
-                .recommendCount(0)
-                .commentCount(0)
-                .viewCount(0)
-                .build();
+		BoardCount boardCount = BoardCount.builder()
+			.board(board)
+			.recommendCount(0)
+			.commentCount(0)
+			.viewCount(0)
+			.build();
 
-        boardCountRepository.save(boardCount);
+		boardCountRepository.save(boardCount);
 
-        return board;
-    }
+		return board;
+	}
 
-    protected BoardRecommend createBoardRecommend(Board board, Member member) {
-        BoardRecommend recommend = BoardRecommend.builder()
-                .board(board)
-                .member(member)
-                .build();
-        boardRecommendRepository.save(recommend);
+	protected BoardRecommend createBoardRecommend(Board board, Member member) {
+		BoardRecommend recommend = BoardRecommend.builder()
+			.board(board)
+			.member(member)
+			.build();
+		boardRecommendRepository.save(recommend);
 
-        return recommend;
-    }
+		return recommend;
+	}
 
-    protected Notice createNotice(Member member) {
-        Notice notice = Notice.builder()
-                .member(member)
-                .title("공지사하아앙 제목")
-                .content("공지공지공지")
-                .createdIP("0.0.0.1")
-                .imgUrl(null)
-                .build();
+	protected Notice createNotice(Member member) {
+		Notice notice = Notice.builder()
+			.member(member)
+			.title("공지사하아앙 제목")
+			.content("공지공지공지")
+			.createdIP("0.0.0.1")
+			.imgUrl(null)
+			.build();
 
-        noticeRepository.save(notice);
+		noticeRepository.save(notice);
 
-        NoticeCount noticeCount = NoticeCount.builder()
-                .notice(notice)
-                .recommendCount(0)
-                .commentCount(0)
-                .viewCount(0)
-                .build();
+		NoticeCount noticeCount = NoticeCount.builder()
+			.notice(notice)
+			.recommendCount(0)
+			.commentCount(0)
+			.viewCount(0)
+			.build();
 
-        noticeCountRepository.save(noticeCount);
+		noticeCountRepository.save(noticeCount);
 
-        return notice;
-    }
+		return notice;
+	}
 
-    protected Inquiry createInquiry(Member member) {
-        Inquiry inquiry = Inquiry.builder()
-                .content("문의사항ㅇㅇㅇ")
-                .member(member)
-                .clientIp("0.0.0.1")
-                .createdAt(LocalDateTime.now())
-                .isAdminAnswered(false)
-                .build();
+	protected Inquiry createInquiry(Member member) {
+		Inquiry inquiry = Inquiry.builder()
+			.content("문의사항ㅇㅇㅇ")
+			.member(member)
+			.clientIp("0.0.0.1")
+			.createdAt(LocalDateTime.now())
+			.isAdminAnswered(false)
+			.build();
 
-        inquiryRepository.save(inquiry);
+		inquiryRepository.save(inquiry);
 
-        InquiryCount inquiryCount = InquiryCount.createCount(inquiry);
-        inquiryCountRepository.save(inquiryCount);
+		InquiryCount inquiryCount = InquiryCount.createCount(inquiry);
+		inquiryCountRepository.save(inquiryCount);
 
-        return inquiry;
-    }
+		return inquiry;
+	}
 
-    protected Improvement createImprovement(Member member) {
-        Improvement improvement = Improvement.builder()
-                .member(member)
-                .title("개선요처어엉ㅇ 제목")
-                .content("개선개선개선")
-                .createdIP("0.0.0.1")
-                .imgUrl(null)
-                .build();
-        improvementRepository.save(improvement);
+	protected Improvement createImprovement(Member member) {
+		Improvement improvement = Improvement.builder()
+			.member(member)
+			.title("개선요처어엉ㅇ 제목")
+			.content("개선개선개선")
+			.createdIP("0.0.0.1")
+			.imgUrl(null)
+			.build();
+		improvementRepository.save(improvement);
 
-        ImprovementCount improvementCount = ImprovementCount.createImprovementCount(improvement);
-        improvementCountRepository.save(improvementCount);
+		ImprovementCount improvementCount = ImprovementCount.createImprovementCount(improvement);
+		improvementCountRepository.save(improvementCount);
 
-        return improvement;
-    }
+		return improvement;
+	}
 }


### PR DESCRIPTION
## 기능 설명
- 리그명추가, 종료시간 기준으로 경기일정 필터링 추가했습니다.
- 일정 푸시로 인해 머지하겠습니다ㅠ 큰 작업도 아니였습니다
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
