### PR TITLE
feat: 뉴스 댓글, 내용검색 추가

### DIFF
--- a/src/main/java/org/myteam/server/news/news/dto/controller/request/NewsRequest.java
+++ b/src/main/java/org/myteam/server/news/news/dto/controller/request/NewsRequest.java
@@ -1,10 +1,11 @@
 package org.myteam.server.news.news.dto.controller.request;
 
+import org.myteam.server.board.domain.BoardOrderType;
+import org.myteam.server.board.domain.BoardSearchType;
 import org.myteam.server.global.domain.Category;
 import org.myteam.server.global.page.request.PageInfoRequest;
 import org.myteam.server.global.util.domain.TimePeriod;
 import org.myteam.server.news.news.dto.service.request.NewsServiceRequest;
-import org.myteam.server.news.news.repository.OrderType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -21,23 +22,28 @@ public class NewsRequest extends PageInfoRequest {
 	@Schema(description = "뉴스 카테고리", example = "BASEBALL, FOOTBALL, ESPORTS")
 	private Category category;
 
-	@Schema(description = "뉴스 정렬 타입", example = "DATE(날짜순), COMMENT(댓글순), VIEW(조회순)")
+	@Schema(description = "뉴스 정렬 타입", example = "CREATE(최신), RECOMMEND(인기), COMMENT(댓글)")
 	@NotNull(message = "뉴스 정렬 타입은 필수입니다.")
-	private OrderType orderType;
+	private BoardOrderType orderType;
+
+	@Schema(description = "뉴스 검색 타입", example = "TITLE(제목), CONTENT(내용), TITLE_CONTENT(제목 + 내용), COMMENT(댓글)")
+	private BoardSearchType searchType;
 
 	@Schema(description = "검색할 뉴스 내용", example = "검색할 뉴스 제목")
-	private String content;
+	private String search;
 
 	@Schema(description = "날짜 조건", example = "DAILY(일별), WEEKLY(주별), MONTHLY(월별), YEARLY(년별)")
 	private TimePeriod timePeriod;
 
 	@Builder
-	public NewsRequest(Category category, OrderType orderType, String content, TimePeriod timePeriod, int page,
+	public NewsRequest(Category category, BoardOrderType orderType, BoardSearchType SearchType, String search,
+		TimePeriod timePeriod, int page,
 		int size) {
 		super(page, size);
 		this.category = category;
 		this.orderType = orderType;
-		this.content = content;
+		this.searchType = SearchType;
+		this.search = search;
 		this.timePeriod = timePeriod;
 	}
 
@@ -45,7 +51,8 @@ public class NewsRequest extends PageInfoRequest {
 		return NewsServiceRequest.builder()
 			.category(category)
 			.orderType(orderType)
-			.content(content)
+			.searchType(searchType)
+			.search(search)
 			.timePeriod(timePeriod)
 			.size(getSize())
 			.page(getPage())

--- a/src/main/java/org/myteam/server/news/news/dto/service/request/NewsServiceRequest.java
+++ b/src/main/java/org/myteam/server/news/news/dto/service/request/NewsServiceRequest.java
@@ -1,5 +1,7 @@
 package org.myteam.server.news.news.dto.service.request;
 
+import org.myteam.server.board.domain.BoardOrderType;
+import org.myteam.server.board.domain.BoardSearchType;
 import org.myteam.server.global.domain.Category;
 import org.myteam.server.global.page.request.PageInfoServiceRequest;
 import org.myteam.server.global.util.domain.TimePeriod;
@@ -13,16 +15,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NewsServiceRequest extends PageInfoServiceRequest {
 	private Category category;
-	private OrderType orderType;
-	private String content;
+	private BoardOrderType orderType;
+	private BoardSearchType searchType;
+	private String search;
 	private TimePeriod timePeriod;
 
 	@Builder
-	public NewsServiceRequest(Category category, OrderType orderType, String content, TimePeriod timePeriod, int size, int page) {
+	public NewsServiceRequest(Category category, BoardOrderType orderType, BoardSearchType searchType, String search, TimePeriod timePeriod, int size, int page) {
 		super(page, size);
 		this.category = category;
 		this.orderType = orderType;
-		this.content = content;
+		this.searchType = searchType;
+		this.search = search;
 		this.timePeriod = timePeriod;
 	}
 

--- a/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
@@ -1,24 +1,15 @@
 package org.myteam.server.news.news.repository;
 
-import static java.util.Optional.ofNullable;
-import static org.myteam.server.board.domain.QBoard.board;
-import static org.myteam.server.news.news.domain.QNews.news;
-import static org.myteam.server.news.newsCount.domain.QNewsCount.newsCount;
-
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.impl.JPAQueryFactory;
+import static java.util.Optional.*;
+import static org.myteam.server.board.domain.QBoard.*;
+import static org.myteam.server.news.news.domain.QNews.*;
+import static org.myteam.server.news.newsCount.domain.QNewsCount.*;
 
 import java.util.List;
-import java.util.Optional;
 
-import lombok.RequiredArgsConstructor;
 import org.myteam.server.board.domain.BoardOrderType;
 import org.myteam.server.board.domain.BoardSearchType;
 import org.myteam.server.comment.domain.CommentType;
-import org.myteam.server.comment.domain.QBoardComment;
 import org.myteam.server.comment.domain.QComment;
 import org.myteam.server.comment.domain.QNewsComment;
 import org.myteam.server.global.domain.Category;
@@ -30,188 +21,176 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
 @Repository
 @RequiredArgsConstructor
 public class NewsQueryRepository {
 
-    private final JPAQueryFactory queryFactory;
+	private final JPAQueryFactory queryFactory;
 
-    public Page<NewsDto> getNewsList(NewsServiceRequest newsServiceRequest) {
-        Category category = newsServiceRequest.getCategory();
-        OrderType orderType = newsServiceRequest.getOrderType();
-        String content = newsServiceRequest.getContent();
-        TimePeriod timePeriod = newsServiceRequest.getTimePeriod();
-        Pageable pageable = newsServiceRequest.toPageable();
+	public Page<NewsDto> getNewsList(NewsServiceRequest newsServiceRequest) {
+		Category category = newsServiceRequest.getCategory();
+		BoardOrderType orderType = newsServiceRequest.getOrderType();
+		BoardSearchType searchType = newsServiceRequest.getSearchType();
+		String search = newsServiceRequest.getSearch();
+		TimePeriod timePeriod = newsServiceRequest.getTimePeriod();
+		Pageable pageable = newsServiceRequest.toPageable();
 
-        List<NewsDto> contents = queryFactory
-                .select(Projections.constructor(NewsDto.class,
-                        news.id,
-                        news.category,
-                        news.title,
-                        news.thumbImg,
-                        news.content,
-                        newsCount.commentCount,
-                        news.postDate
-                ))
-                .from(news)
-                .join(newsCount).on(newsCount.news.id.eq(news.id))
-                .where(
-                        isCategoryEqualTo(category),
-                        isTitleLikeTo(content),
-                        isPostDateAfter(timePeriod)
-                )
-                .orderBy(isOrderByEqualToOrderType(orderType))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+		List<NewsDto> contents = queryFactory
+			.select(Projections.constructor(NewsDto.class,
+				news.id,
+				news.category,
+				news.title,
+				news.thumbImg,
+				news.content,
+				newsCount.commentCount,
+				news.postDate
+			))
+			.from(news)
+			.join(newsCount).on(newsCount.news.id.eq(news.id))
+			.where(
+				isCategoryEqualTo(category),
+				isSearchTypeLikeTo(searchType, search),
+				isPostDateAfter(timePeriod)
+			)
+			.orderBy(isOrderByEqualToOrderCategory(orderType))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
 
-        long total = getTotalNewsCount(category, content, timePeriod);
+		long total = getTotalNewsCount(category, searchType, search, timePeriod);
 
-        return new PageImpl<>(contents, pageable, total);
-    }
+		return new PageImpl<>(contents, pageable, total);
+	}
 
-    public Page<NewsDto> getTotalList(TimePeriod timePeriod, BoardOrderType orderType,
-                                      BoardSearchType searchType, String search, Pageable pageable) {
-        List<NewsDto> contents = queryFactory
-                .select(Projections.constructor(NewsDto.class,
-                        news.id,
-                        news.category,
-                        news.title,
-                        news.thumbImg,
-                        news.content,
-                        newsCount.commentCount,
-                        news.postDate
-                ))
-                .from(news)
-                .join(newsCount).on(newsCount.news.id.eq(news.id))
-                .where(
-                        isSearchTypeLikeTo(searchType, search),
-                        isPostDateAfter(timePeriod)
-                )
-                .orderBy(isOrderByEqualToOrderCategory(orderType))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+	public Page<NewsDto> getTotalList(TimePeriod timePeriod, BoardOrderType orderType,
+		BoardSearchType searchType, String search, Pageable pageable) {
+		List<NewsDto> contents = queryFactory
+			.select(Projections.constructor(NewsDto.class,
+				news.id,
+				news.category,
+				news.title,
+				news.thumbImg,
+				news.content,
+				newsCount.commentCount,
+				news.postDate
+			))
+			.from(news)
+			.join(newsCount).on(newsCount.news.id.eq(news.id))
+			.where(
+				isSearchTypeLikeTo(searchType, search),
+				isPostDateAfter(timePeriod)
+			)
+			.orderBy(isOrderByEqualToOrderCategory(orderType))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
 
-        long total = getTotalNewsCount(timePeriod, searchType, search);
+		long total = getTotalNewsCount(timePeriod, searchType, search);
 
-        return new PageImpl<>(contents, pageable, total);
-    }
+		return new PageImpl<>(contents, pageable, total);
+	}
 
-    private long getTotalNewsCount(Category category, String content, TimePeriod timePeriod) {
-        return ofNullable(
-                queryFactory
-                        .select(news.count())
-                        .from(news)
-                        .where(
-                                isCategoryEqualTo(category),
-                                isTitleLikeTo(content),
-                                isPostDateAfter(timePeriod)
-                        )
-                        .fetchOne()
-        ).orElse(0L);
-    }
+	private long getTotalNewsCount(Category category, BoardSearchType searchType, String search,
+		TimePeriod timePeriod) {
+		return ofNullable(
+			queryFactory
+				.select(news.count())
+				.from(news)
+				.where(
+					isCategoryEqualTo(category),
+					isSearchTypeLikeTo(searchType, search),
+					isPostDateAfter(timePeriod)
+				)
+				.fetchOne()
+		).orElse(0L);
+	}
 
-    private long getTotalNewsCount(TimePeriod timePeriod, BoardSearchType searchType, String search) {
-        return ofNullable(
-                queryFactory
-                        .select(board.countDistinct())
-                        .from(board)
-                        .where(
-                                isSearchTypeLikeTo(searchType, search),
-                                isPostDateAfter(timePeriod)
-                        )
-                        .fetchOne()
-        ).orElse(0L);
-    }
+	private long getTotalNewsCount(TimePeriod timePeriod, BoardSearchType searchType, String search) {
+		return ofNullable(
+			queryFactory
+				.select(board.countDistinct())
+				.from(board)
+				.where(
+					isSearchTypeLikeTo(searchType, search),
+					isPostDateAfter(timePeriod)
+				)
+				.fetchOne()
+		).orElse(0L);
+	}
 
-    private OrderSpecifier<?> isOrderByEqualToOrderType(OrderType orderType) {
-        return switch (orderType) {
-            case DATE -> news.postDate.desc();
-            case VIEW -> newsCount.viewCount.desc();
-            case COMMENT -> newsCount.commentCount.desc();
-        };
-    }
+	private BooleanExpression isSearchTypeLikeTo(BoardSearchType searchType, String search) {
+		if (searchType == null) {
+			return null;
+		}
 
-    private BooleanExpression isSearchTypeLikeTo(BoardSearchType searchType, String search) {
-        if (searchType == null) {
-            return null;
-        }
+		return switch (searchType) {
+			case TITLE -> news.title.like("%" + search + "%");
+			case CONTENT -> news.content.like("%" + search + "%");
+			case TITLE_CONTENT -> news.title.like("%" + search + "%")
+				.or(news.content.like("%" + search + "%"));
+			case NICKNAME -> null;
+			case COMMENT -> JPAExpressions.selectOne()
+				.from(QComment.comment1)
+				.where(
+					QComment.comment1.comment.like("%" + search + "%")
+						.and(QComment.comment1.commentType.eq(CommentType.NEWS))
+						.and(QComment.comment1.as(QNewsComment.class).news.id.eq(
+							news.id))
+				)
+				.exists();
+		};
+	}
 
-        return switch (searchType) {
-            case TITLE -> news.title.like("%" + search + "%");
-            case CONTENT -> news.content.like("%" + search + "%");
-            case TITLE_CONTENT -> news.title.like("%" + search + "%")
-                    .or(news.content.like("%" + search + "%"));
-            case NICKNAME -> null;
-            case COMMENT -> JPAExpressions.selectOne()
-                    .from(QComment.comment1)
-                    .where(
-                            QComment.comment1.comment.like("%" + search + "%")
-                                    .and(QComment.comment1.commentType.eq(CommentType.NEWS))
-                                    .and(QComment.comment1.as(QNewsComment.class).news.id.eq(
-                                            news.id))
-                    )
-                    .exists();
-            default -> null;
-        };
-    }
+	private OrderSpecifier<?>[] isOrderByEqualToOrderCategory(BoardOrderType orderType) {
+		// default 최신순
+		BoardOrderType boardOrderType = ofNullable(orderType).orElse(BoardOrderType.CREATE);
+		return switch (boardOrderType) {
+			case CREATE -> new OrderSpecifier<?>[] {news.postDate.desc(), news.title.asc(), news.id.desc()};
+			case RECOMMEND -> new OrderSpecifier<?>[] {newsCount.recommendCount.desc(),
+				newsCount.commentCount.add(newsCount.viewCount).desc(), news.title.asc(), news.id.desc()};
+			case COMMENT -> new OrderSpecifier<?>[] {newsCount.commentCount.desc(), news.title.asc(), news.id.desc()};
+		};
+	}
 
-    private OrderSpecifier<?>[] isOrderByEqualToOrderCategory(BoardOrderType orderType) {
-        // default 최신순
-        BoardOrderType boardOrderType = Optional.ofNullable(orderType).orElse(BoardOrderType.CREATE);
-        return switch (boardOrderType) {
-            case CREATE -> new OrderSpecifier<?>[]{news.createDate.desc(), news.title.asc(), news.id.desc()};
-            case RECOMMEND -> new OrderSpecifier<?>[]{newsCount.recommendCount.desc(),
-                    newsCount.commentCount.add(newsCount.viewCount).desc(), news.title.asc(), news.id.desc()};
-            case COMMENT -> new OrderSpecifier<?>[]{newsCount.commentCount.desc(), news.title.asc(), news.id.desc()};
-        };
-    }
+	private BooleanExpression isCategoryEqualTo(Category category) {
+		return category != null ? news.category.eq(category) : null;
+	}
 
-    private long getTotalBoardCount(TimePeriod timePeriod, BoardSearchType searchType, String search) {
-        return ofNullable(
-                queryFactory
-                        .select(board.countDistinct())
-                        .from(board)
-                        .where(
-                                isSearchTypeLikeTo(searchType, search),
-                                isPostDateAfter(timePeriod)
-                        )
-                        .fetchOne()
-        ).orElse(0L);
-    }
+	private BooleanExpression isTitleLikeTo(String content) {
+		return content != null ? news.title.like("%" + content + "%") : null;
+	}
 
-    private BooleanExpression isCategoryEqualTo(Category category) {
-        return category != null ? news.category.eq(category) : null;
-    }
+	private BooleanExpression isPostDateAfter(TimePeriod timePeriod) {
+		return timePeriod != null ? news.postDate.after(timePeriod.getStartDateByTimePeriod(timePeriod)) : null;
+	}
 
-    private BooleanExpression isTitleLikeTo(String content) {
-        return content != null ? news.title.like("%" + content + "%") : null;
-    }
+	public Long findPreviousNewsId(Long newsId, Category category) {
+		return queryFactory
+			.select(news.id)
+			.from(news)
+			.where(news.id.lt(newsId), // 현재 게시글보다 작은 ID
+				news.category.eq(category))
+			.orderBy(news.id.desc()) // 가장 큰 ID (즉, 이전 글)
+			.limit(1)
+			.fetchOne();
+	}
 
-    private BooleanExpression isPostDateAfter(TimePeriod timePeriod) {
-        return timePeriod != null ? news.postDate.after(timePeriod.getStartDateByTimePeriod(timePeriod)) : null;
-    }
-
-    public Long findPreviousNewsId(Long newsId, Category category) {
-        return queryFactory
-                .select(news.id)
-                .from(news)
-                .where(news.id.lt(newsId), // 현재 게시글보다 작은 ID
-                        news.category.eq(category))
-                .orderBy(news.id.desc()) // 가장 큰 ID (즉, 이전 글)
-                .limit(1)
-                .fetchOne();
-    }
-
-    public Long findNextNewsId(Long newsId, Category category) {
-        return queryFactory
-                .select(news.id)
-                .from(news)
-                .where(news.id.gt(newsId), // 현재 게시글보다 큰 ID
-                        news.category.eq(category))
-                .orderBy(news.id.asc()) // 가장 작은 ID (즉, 다음 글)
-                .limit(1)
-                .fetchOne();
-    }
+	public Long findNextNewsId(Long newsId, Category category) {
+		return queryFactory
+			.select(news.id)
+			.from(news)
+			.where(news.id.gt(newsId), // 현재 게시글보다 큰 ID
+				news.category.eq(category))
+			.orderBy(news.id.asc()) // 가장 작은 ID (즉, 다음 글)
+			.limit(1)
+			.fetchOne();
+	}
 }

--- a/src/test/java/org/myteam/server/news/news/controller/NewsControllerTest.java
+++ b/src/test/java/org/myteam/server/news/news/controller/NewsControllerTest.java
@@ -9,9 +9,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.myteam.server.ControllerTestSupport;
+import org.myteam.server.board.domain.BoardOrderType;
+import org.myteam.server.board.domain.BoardSearchType;
 import org.myteam.server.global.domain.Category;
 import org.myteam.server.news.news.dto.controller.request.NewsRequest;
-import org.myteam.server.news.news.repository.OrderType;
 import org.springframework.security.test.context.support.WithMockUser;
 
 class NewsControllerTest extends ControllerTestSupport {
@@ -24,15 +25,16 @@ class NewsControllerTest extends ControllerTestSupport {
 		NewsRequest newsRequest = NewsRequest.builder()
 			.page(1)
 			.size(10)
-			.content("테스트")
-			.orderType(OrderType.DATE)
+			.search("테스트")
+			.SearchType(BoardSearchType.CONTENT)
+			.orderType(BoardOrderType.CREATE)
 			.category(Category.FOOTBALL)
 			.build();
 
 		// when // then
 		mockMvc.perform(
 				get("/api/news")
-					.param("content", "테스트")
+					.param("search", "테스트")
 					.param("orderType", newsRequest.getOrderType().name())
 					.param("category", newsRequest.getCategory().name())
 					.param("page", String.valueOf(newsRequest.getPage()))
@@ -53,7 +55,7 @@ class NewsControllerTest extends ControllerTestSupport {
 		NewsRequest newsRequest = NewsRequest.builder()
 			.page(1)
 			.size(10)
-			.content("테스트")
+			.search("테스트")
 			.category(Category.FOOTBALL)
 			.build();
 
@@ -62,7 +64,7 @@ class NewsControllerTest extends ControllerTestSupport {
 				get("/api/news")
 					.param("page", String.valueOf(newsRequest.getPage()))
 					.param("size", String.valueOf(newsRequest.getSize()))
-					.param("content", newsRequest.getContent())
+					.param("content", newsRequest.getSearch())
 					.param("category", newsRequest.getCategory().name())
 					.with(csrf())
 			)
@@ -72,32 +74,32 @@ class NewsControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("$.message").value("뉴스 정렬 타입은 필수입니다."));
 	}
 
-//	@DisplayName("뉴스목록을 조회시 뉴스 카테고리는 필수입니다.")
-//	@Test
-//	@WithMockUser
-//	void findAllWithoutCategoryTest() throws Exception {
-//		// given
-//		NewsRequest newsRequest = NewsRequest.builder()
-//			.page(1)
-//			.size(10)
-//			.content("테스트")
-//			.orderType(OrderType.DATE)
-//			.build();
-//
-//		// when // then
-//		mockMvc.perform(
-//				get("/api/news")
-//					.param("page", String.valueOf(newsRequest.getPage()))
-//					.param("size", String.valueOf(newsRequest.getSize()))
-//					.param("content", newsRequest.getContent())
-//					.param("orderType", newsRequest.getOrderType().name())
-//					.with(csrf())
-//			)
-//			.andDo(print())
-//			.andExpect(status().isBadRequest())
-//			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
-//			.andExpect(jsonPath("$.message").value("뉴스 카테고리는 필수입니다."));
-//	}
+	//	@DisplayName("뉴스목록을 조회시 뉴스 카테고리는 필수입니다.")
+	//	@Test
+	//	@WithMockUser
+	//	void findAllWithoutCategoryTest() throws Exception {
+	//		// given
+	//		NewsRequest newsRequest = NewsRequest.builder()
+	//			.page(1)
+	//			.size(10)
+	//			.content("테스트")
+	//			.orderType(OrderType.DATE)
+	//			.build();
+	//
+	//		// when // then
+	//		mockMvc.perform(
+	//				get("/api/news")
+	//					.param("page", String.valueOf(newsRequest.getPage()))
+	//					.param("size", String.valueOf(newsRequest.getSize()))
+	//					.param("content", newsRequest.getContent())
+	//					.param("orderType", newsRequest.getOrderType().name())
+	//					.with(csrf())
+	//			)
+	//			.andDo(print())
+	//			.andExpect(status().isBadRequest())
+	//			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+	//			.andExpect(jsonPath("$.message").value("뉴스 카테고리는 필수입니다."));
+	//	}
 
 	@DisplayName("뉴스상세 조회를 한다.")
 	@Test

--- a/src/test/java/org/myteam/server/news/news/service/NewsReadServiceTest.java
+++ b/src/test/java/org/myteam/server/news/news/service/NewsReadServiceTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.board.domain.BoardOrderType;
+import org.myteam.server.board.domain.BoardSearchType;
 import org.myteam.server.global.domain.Category;
 import org.myteam.server.global.page.response.PageableCustomResponse;
 import org.myteam.server.global.util.domain.TimePeriod;
@@ -17,7 +19,6 @@ import org.myteam.server.news.news.dto.repository.NewsDto;
 import org.myteam.server.news.news.dto.service.request.NewsServiceRequest;
 import org.myteam.server.news.news.dto.service.response.NewsListResponse;
 import org.myteam.server.news.news.dto.service.response.NewsResponse;
-import org.myteam.server.news.news.repository.OrderType;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class NewsReadServiceTest extends IntegrationTestSupport {
@@ -35,7 +36,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 
 		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
 			.category(Category.BASEBALL)
-			.orderType(OrderType.DATE)
+			.orderType(BoardOrderType.CREATE)
 			.page(1)
 			.size(10)
 			.build();
@@ -80,7 +81,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 
 		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
 			.category(Category.ESPORTS)
-			.orderType(OrderType.DATE)
+			.orderType(BoardOrderType.CREATE)
 			.page(1)
 			.size(10)
 			.build();
@@ -130,7 +131,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 
 		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
 			.category(Category.FOOTBALL)
-			.orderType(OrderType.DATE)
+			.orderType(BoardOrderType.CREATE)
 			.page(1)
 			.size(10)
 			.build();
@@ -172,7 +173,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 		createNews(4, Category.BASEBALL, 12);
 
 		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
-			.orderType(OrderType.DATE)
+			.orderType(BoardOrderType.CREATE)
 			.page(1)
 			.size(10)
 			.build();
@@ -208,7 +209,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 		createNewsWithPostDate(4, Category.BASEBALL, 12, LocalDateTime.now().minusDays(2));
 
 		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
-			.orderType(OrderType.DATE)
+			.orderType(BoardOrderType.CREATE)
 			.page(1)
 			.size(10)
 			.timePeriod(TimePeriod.DAILY)
@@ -243,7 +244,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 		createNewsWithPostDate(4, Category.BASEBALL, 12, LocalDateTime.now().minusDays(7));
 
 		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
-			.orderType(OrderType.DATE)
+			.orderType(BoardOrderType.CREATE)
 			.page(1)
 			.size(10)
 			.timePeriod(TimePeriod.WEEKLY)
@@ -278,7 +279,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 		createNewsWithPostDate(4, Category.BASEBALL, 12, LocalDateTime.now().minusMonths(7));
 
 		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
-			.orderType(OrderType.DATE)
+			.orderType(BoardOrderType.CREATE)
 			.page(1)
 			.size(10)
 			.timePeriod(TimePeriod.MONTHLY)
@@ -313,7 +314,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 		createNewsWithPostDate(4, Category.BASEBALL, 12, LocalDateTime.now().minusYears(1));
 
 		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
-			.orderType(OrderType.DATE)
+			.orderType(BoardOrderType.CREATE)
 			.page(1)
 			.size(10)
 			.timePeriod(TimePeriod.YEARLY)
@@ -348,8 +349,9 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 		createNews(4, Category.BASEBALL, 12);
 
 		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
-			.orderType(OrderType.DATE)
-			.content("타이틀1")
+			.orderType(BoardOrderType.CREATE)
+			.searchType(BoardSearchType.TITLE)
+			.search("타이틀1")
 			.page(1)
 			.size(10)
 			.build();


### PR DESCRIPTION
## 기능 설명
- 계시판 검색과 같은 포맷으로 뉴스리스트 조회하도록 수정했습니다.
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
