### PR TITLE
feat: 뉴스 댓글 검색 시 댓글 함께 내려주도록 수정

### DIFF
--- a/src/main/java/org/myteam/server/comment/util/CommentFactory.java
+++ b/src/main/java/org/myteam/server/comment/util/CommentFactory.java
@@ -1,9 +1,13 @@
 package org.myteam.server.comment.util;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.board.service.BoardReadService;
-import org.myteam.server.comment.domain.*;
+import org.myteam.server.comment.domain.BoardComment;
+import org.myteam.server.comment.domain.Comment;
+import org.myteam.server.comment.domain.CommentType;
+import org.myteam.server.comment.domain.ImprovementComment;
+import org.myteam.server.comment.domain.InquiryComment;
+import org.myteam.server.comment.domain.NewsComment;
+import org.myteam.server.comment.domain.NoticeComment;
 import org.myteam.server.comment.repository.CommentRepository;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
@@ -13,110 +17,113 @@ import org.myteam.server.inquiry.repository.InquiryRepository;
 import org.myteam.server.inquiry.service.InquiryReadService;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.news.news.service.NewsReadService;
-import org.myteam.server.notice.repository.NoticeRepository;
 import org.myteam.server.notice.service.NoticeReadService;
 import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class CommentFactory {
-    private final CommentRepository commentRepository;
-    private final NoticeReadService noticeReadService;
-    private final BoardReadService boardReadService;
-    private final NewsReadService newsReadService;
-    private final ImprovementReadService improvementReadService;
-    private final InquiryReadService inquiryReadService;
-    private final InquiryRepository inquiryRepository;
+	private final CommentRepository commentRepository;
+	private final NoticeReadService noticeReadService;
+	private final BoardReadService boardReadService;
+	private final NewsReadService newsReadService;
+	private final ImprovementReadService improvementReadService;
+	private final InquiryReadService inquiryReadService;
+	private final InquiryRepository inquiryRepository;
 
-    public Comment createComment(CommentType type, Long contentId, Member member, Member mentionedMember, String comment, String imageUrl, String createdIp, Long parentId) {
-        log.info("댓글 생성 요청 - type: {}, contentId: {}, memberId: {}, mentionedMemberId: {}, parentId: {}",
-                type, contentId, member.getPublicId(),
-                (mentionedMember != null ? mentionedMember.getPublicId() : "N/A"),
-                parentId);
+	public Comment createComment(CommentType type, Long contentId, Member member, Member mentionedMember,
+		String comment, String imageUrl, String createdIp, Long parentId) {
+		log.info("댓글 생성 요청 - type: {}, contentId: {}, memberId: {}, mentionedMemberId: {}, parentId: {}",
+			type, contentId, member.getPublicId(),
+			(mentionedMember != null ? mentionedMember.getPublicId() : "N/A"),
+			parentId);
 
-        Comment parent = null;
+		Comment parent = null;
 
-        if (parentId != null) {
-            // 부모 댓글 조회 (부모 댓글이 존재하면 참조)
-            parent = commentRepository.findById(parentId)
-                    .orElseThrow(() -> {
-                        log.error("댓글 생성 실패 - 부모 댓글({})을 찾을 수 없음", parentId);
-                        return new PlayHiveException(ErrorCode.COMMENT_NOT_FOUND);
-                    });
+		if (parentId != null) {
+			// 부모 댓글 조회 (부모 댓글이 존재하면 참조)
+			parent = commentRepository.findById(parentId)
+				.orElseThrow(() -> {
+					log.error("댓글 생성 실패 - 부모 댓글({})을 찾을 수 없음", parentId);
+					return new PlayHiveException(ErrorCode.COMMENT_NOT_FOUND);
+				});
 
-            if (!parent.canAddReply()) {
-                log.warn("댓글 생성 실패 - 최대 대댓글 깊이 초과 (parentId: {}, depth: {})",
-                        parentId, parent.getDepth());
-                throw new PlayHiveException(ErrorCode.LIMIT_COMMENT_DEPTH);
-            }
-        }
+			if (!parent.canAddReply()) {
+				log.warn("댓글 생성 실패 - 최대 대댓글 깊이 초과 (parentId: {}, depth: {})",
+					parentId, parent.getDepth());
+				throw new PlayHiveException(ErrorCode.LIMIT_COMMENT_DEPTH);
+			}
+		}
 
-        // 댓글 타입에 따라 생성
-        switch (type) {
-            case BOARD:
-                return BoardComment.createComment(
-                        boardReadService.findById(contentId),
-                        member,
-                        mentionedMember,
-                        comment,
-                        imageUrl,
-                        createdIp,
-                        parent
-                );
+		// 댓글 타입에 따라 생성
+		switch (type) {
+			case BOARD:
+				return BoardComment.createComment(
+					boardReadService.findById(contentId),
+					member,
+					mentionedMember,
+					comment,
+					imageUrl,
+					createdIp,
+					parent
+				);
 
-            case NEWS:
-                return NewsComment.createComment(
-                        newsReadService.findById(contentId),
-                        member,
-                        mentionedMember,
-                        comment,
-                        imageUrl,
-                        createdIp,
-                        parent
-                );
+			case NEWS:
+				return NewsComment.createComment(
+					newsReadService.findById(contentId),
+					member,
+					mentionedMember,
+					comment,
+					imageUrl,
+					createdIp,
+					parent
+				);
 
-            case IMPROVEMENT:
-                return ImprovementComment.createComment(
-                        improvementReadService.findById(contentId),
-                        member,
-                        mentionedMember,
-                        comment,
-                        imageUrl,
-                        createdIp,
-                        parent
-                );
+			case IMPROVEMENT:
+				return ImprovementComment.createComment(
+					improvementReadService.findById(contentId),
+					member,
+					mentionedMember,
+					comment,
+					imageUrl,
+					createdIp,
+					parent
+				);
 
-            case INQUIRY:
-                Inquiry inquiry = inquiryReadService.findInquiryById(contentId);
-                if (member.isAdmin()) {
-                    inquiry.updateAdminAnswered();
-                    inquiryRepository.save(inquiry);
-                }
-                return InquiryComment.createComment(
-                        inquiry,
-                        member,
-                        mentionedMember,
-                        comment,
-                        imageUrl,
-                        createdIp,
-                        parent
-                );
+			case INQUIRY:
+				Inquiry inquiry = inquiryReadService.findInquiryById(contentId);
+				if (member.isAdmin()) {
+					inquiry.updateAdminAnswered();
+					inquiryRepository.save(inquiry);
+				}
+				return InquiryComment.createComment(
+					inquiry,
+					member,
+					mentionedMember,
+					comment,
+					imageUrl,
+					createdIp,
+					parent
+				);
 
-            case NOTICE:
-                return NoticeComment.createComment(
-                        noticeReadService.findById(contentId),
-                        member,
-                        mentionedMember,
-                        comment,
-                        imageUrl,
-                        createdIp,
-                        parent
-                );
+			case NOTICE:
+				return NoticeComment.createComment(
+					noticeReadService.findById(contentId),
+					member,
+					mentionedMember,
+					comment,
+					imageUrl,
+					createdIp,
+					parent
+				);
 
-            default:
-                throw new PlayHiveException(ErrorCode.NOT_SUPPORT_COMMENT_TYPE);
-        }
+			default:
+				throw new PlayHiveException(ErrorCode.NOT_SUPPORT_COMMENT_TYPE);
+		}
 
-    }
+	}
 }

--- a/src/main/java/org/myteam/server/news/news/dto/repository/NewsCommentSearchDto.java
+++ b/src/main/java/org/myteam/server/news/news/dto/repository/NewsCommentSearchDto.java
@@ -1,0 +1,14 @@
+package org.myteam.server.news.news.dto.repository;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class NewsCommentSearchDto {
+	private Long commentId;
+	private String comment;
+	private String imageUrl;
+}

--- a/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
+++ b/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
@@ -26,6 +26,8 @@ public class NewsDto {
 	private int commentCount;
 	@Schema(description = "뉴스 계시 날짜")
 	private LocalDateTime postDate;
+	@Schema(description = "댓글 검색 시 최상단 댓글 데이터")
+	private NewsCommentSearchDto newsCommentSearchDto;
 
 	public NewsDto(Long id, Category category, String title, String thumbImg, String content, int commentCount, LocalDateTime postDate) {
 		this.id = id;
@@ -35,5 +37,9 @@ public class NewsDto {
 		this.content = content;
 		this.commentCount = commentCount;
 		this.postDate = postDate;
+	}
+
+	public void updateNewsCommentSearchDto(NewsCommentSearchDto newsCommentSearchDto){
+		this.newsCommentSearchDto = newsCommentSearchDto;
 	}
 }

--- a/src/test/java/org/myteam/server/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/IntegrationTestSupport.java
@@ -1,11 +1,11 @@
 package org.myteam.server;
 
-import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+
 import org.junit.jupiter.api.AfterEach;
-import org.mockito.Mock;
 import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.BoardCount;
 import org.myteam.server.board.domain.BoardRecommend;
@@ -18,11 +18,11 @@ import org.myteam.server.board.service.BoardCountService;
 import org.myteam.server.board.service.BoardReadService;
 import org.myteam.server.board.service.BoardRecommendReadService;
 import org.myteam.server.board.service.BoardService;
+import org.myteam.server.comment.domain.NewsComment;
 import org.myteam.server.comment.repository.CommentRepository;
 import org.myteam.server.comment.service.CommentReadService;
 import org.myteam.server.comment.service.CommentService;
 import org.myteam.server.global.domain.Category;
-import org.myteam.server.global.util.redis.RedisViewCountBulkUpdater;
 import org.myteam.server.global.util.redis.RedisViewCountService;
 import org.myteam.server.improvement.domain.Improvement;
 import org.myteam.server.improvement.domain.ImprovementCount;
@@ -70,6 +70,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
+
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @ActiveProfiles("test")
@@ -165,6 +166,7 @@ public abstract class IntegrationTestSupport {
 
     @AfterEach
     void tearDown() {
+        commentRepository.deleteAllInBatch();
         matchPredictionRepository.deleteAllInBatch();
         matchRepository.deleteAllInBatch();
         teamRepository.deleteAllInBatch();
@@ -246,6 +248,17 @@ public abstract class IntegrationTestSupport {
         newsCountRepository.save(newsCount);
 
         return savedNews;
+    }
+
+    protected void createNewsComment(News news, Member member, String comment) {
+        NewsComment savedNewsComment = commentRepository.save(
+            NewsComment.builder()
+                .news(news)
+                .comment(comment)
+                .imageUrl("www.test.com")
+                .member(member)
+                .build()
+        );
     }
 
     protected News createNewsWithPostDate(int index, Category category, int count, LocalDateTime postTime) {


### PR DESCRIPTION
## 기능 설명
- 계시판과 동일하게 댓글 조회시 댓글도 함께 내려주도록 하였습니다.
- 계시판과 코드 동일하여 바로 머지하게습니다
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
