### PR TITLE
feat: 경기시간 한시간전에 조회시 유튜브 실시간 API 조회하도록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,9 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //openfeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.3'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       JWT_ISSUER: ${JWT_ISSUER}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY}
     restart: always
 
   #  zookeeper:

--- a/src/main/java/org/myteam/server/ServerApplication.java
+++ b/src/main/java/org/myteam/server/ServerApplication.java
@@ -4,26 +4,26 @@ import org.myteam.server.global.config.AuditorAwareImpl;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import java.util.TimeZone;
-
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableFeignClients
 public class ServerApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(ServerApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(ServerApplication.class, args);
+	}
 
-    @Bean
-    public AuditorAware<String> auditorProvider() {
-        return new AuditorAwareImpl();
-    }
+	@Bean
+	public AuditorAware<String> auditorProvider() {
+		return new AuditorAwareImpl();
+	}
 
 }

--- a/src/main/java/org/myteam/server/global/config/FeignConfig.java
+++ b/src/main/java/org/myteam/server/global/config/FeignConfig.java
@@ -1,0 +1,13 @@
+package org.myteam.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+
+import feign.Logger;
+
+public class FeignConfig {
+
+	@Bean
+	Logger.Level feignLoggerLevel() {
+		return Logger.Level.FULL;
+	}
+}

--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -1,12 +1,8 @@
 package org.myteam.server.global.security.config;
 
-import static org.myteam.server.auth.controller.ReIssueController.TOKEN_REISSUE_PATH;
-import static org.myteam.server.global.security.jwt.JwtProvider.HEADER_AUTHORIZATION;
-import static org.myteam.server.global.security.jwt.JwtProvider.REFRESH_TOKEN_KEY;
+import static org.myteam.server.auth.controller.ReIssueController.*;
+import static org.myteam.server.global.security.jwt.JwtProvider.*;
 
-import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.auth.repository.RefreshJpaRepository;
 import org.myteam.server.global.config.WebConfig;
 import org.myteam.server.global.security.filter.AuthenticationEntryPointHandler;
@@ -41,6 +37,10 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Configuration
 @EnableWebSecurity
@@ -48,251 +48,252 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    /* 권한 제외 대상 */
-    private static final String[] PERMIT_ALL_URLS = new String[]{
-            // Test Endpoints
-            /** @brief Exception Test */"/test/exception-test",
-            /** @brief Can Access All */"/test/all/**",
-            /** @brief Test login, create */"/api/test/**",
-            /** @brief Test Slack Integration */"/test/slack",
-            "/api/members/get-token/**", "/api/attachments/**", "/api/posts/**",
-            // Chat
-            "/ws-stomp/**",
-            // Health Check
-            /** @brief health check */
-            "/status",
-            // Swagger Documents
-            /** @brief Swagger Docs */
-            "/v3/api-docs/**", "/swagger-ui/**",
-            // Database console
-            /** @brief database url */
-            "/h2-console",
-            // Business Logic
-            /** @brief about login */"/auth/**",
-            /** @brief Allow static resource access */
-            "/upload/**",
-            /** @brief Allow user permission to change */
-            "/api/members/role",
-            "/api/certification/send",
-            "/api/certification/certify-code",
-            "/api/oauth2/members/email/**",
-            "/api/members/type/**",
-            "/api/me/create",
-            TOKEN_REISSUE_PATH,
+	/* 권한 제외 대상 */
+	private static final String[] PERMIT_ALL_URLS = new String[] {
+		// Test Endpoints
+		/** @brief Exception Test */"/test/exception-test",
+		/** @brief Can Access All */"/test/all/**",
+		/** @brief Test login, create */"/api/test/**",
+		/** @brief Test Slack Integration */"/test/slack",
+		"/api/members/get-token/**", "/api/attachments/**", "/api/posts/**",
+		// Chat
+		"/ws-stomp/**",
+		// Health Check
+		/** @brief health check */
+		"/status",
+		// Swagger Documents
+		/** @brief Swagger Docs */
+		"/v3/api-docs/**", "/swagger-ui/**",
+		// Database console
+		/** @brief database url */
+		"/h2-console",
+		// Business Logic
+		/** @brief about login */"/auth/**",
+		/** @brief Allow static resource access */
+		"/upload/**",
+		/** @brief Allow user permission to change */
+		"/api/members/role",
+		"/api/certification/send",
+		"/api/certification/certify-code",
+		"/api/oauth2/members/email/**",
+		"/api/members/type/**",
+		"/api/me/create",
+		TOKEN_REISSUE_PATH,
 
-            // 문의하기
-            "/api/inquiry",
+		// 문의하기
+		"/api/inquiry",
 
-            // 아이디-비밀번호 찾기
-            "/api/me/find-id/**",
-            "api/me/find-password",
+		// 아이디-비밀번호 찾기
+		"/api/me/find-id/**",
+		"api/me/find-password",
 
-            "/api/notice-comments/**"
-    };
+		"/api/notice-comments/**"
+	};
 
-    /**
-     * @brief Get 요청에서의 모든 사용자 인가
-     */
-    private static final String[] PUBLIC_GET_URLS = {
-            /** @brief 게시판 관련 URL */
-            "/api/board/{boardId}", // 게시글 상세 조회
-            "/api/board", // 게시글 목록 조회
-            "/api/board/comment/{boardCommentId}", // 게시판 댓글 상세 조회
-            "/api/board/{boardId}/comment",
+	/**
+	 * @brief Get 요청에서의 모든 사용자 인가
+	 */
+	private static final String[] PUBLIC_GET_URLS = {
+		/** @brief 게시판 관련 URL */
+		"/api/board/{boardId}", // 게시글 상세 조회
+		"/api/board", // 게시글 목록 조회
+		"/api/board/comment/{boardCommentId}", // 게시판 댓글 상세 조회
+		"/api/board/{boardId}/comment",
 
-            /** @brief 홈 메인*/
-            "api/comments/{contentId}",
-            "api/comments/{commentId}/detail",
-            "/api/comments/{contentId}/best",
+		/** @brief 홈 메인*/
+		"api/comments/{contentId}",
+		"api/comments/{commentId}/detail",
+		"/api/comments/{contentId}/best",
 
-            /** @brief 문의사항 관련 URL */
-            "/api/inquiry/{inquiryId}/comment",
-            "/api/inquiry/comment/{inquiryCommentId}",
-            "/api/inquiry/{inquiryId}/best/comment",
+		/** @brief 문의사항 관련 URL */
+		"/api/inquiry/{inquiryId}/comment",
+		"/api/inquiry/comment/{inquiryCommentId}",
+		"/api/inquiry/{inquiryId}/best/comment",
 
-            /** @brief 공지사항 관련 URL */
-            "/api/notice/{noticeId}",
-            "/api/notice",
-            "/api/notice/comment/{noticeCommentId}",
-            "/api/notice/{noticeId}/comment",
-            "/api/notice/{noticeId}/best/comment",
+		/** @brief 공지사항 관련 URL */
+		"/api/notice/{noticeId}",
+		"/api/notice",
+		"/api/notice/comment/{noticeCommentId}",
+		"/api/notice/{noticeId}/comment",
+		"/api/notice/{noticeId}/best/comment",
 
-            /** @brief 개선요청 관련 URL */
-            "/api/improvement/comment/{improvementCommentId}",
-            "/api/improvement/{improvementId}/comment",
-            "/api/improvement/{improvementId}",
-            "/api/improvement",
-            "/api/improvement/{improvementId}/best/comment",
+		/** @brief 개선요청 관련 URL */
+		"/api/improvement/comment/{improvementCommentId}",
+		"/api/improvement/{improvementId}/comment",
+		"/api/improvement/{improvementId}",
+		"/api/improvement",
+		"/api/improvement/{improvementId}/best/comment",
 
-            //뉴스
-            "/api/news",
-            "/api/news/{newId}",
-            "/api/news/comment",
-            "/api/news/comment/best/{newsId}",
-            "/api/news/comment/{newsCommentId}",
-            "/api/news/reply",
-            "/api/news/reply/{newReplyId}",
+		//뉴스
+		"/api/news",
+		"/api/news/{newId}",
+		"/api/news/comment",
+		"/api/news/comment/best/{newsId}",
+		"/api/news/comment/{newsCommentId}",
+		"/api/news/reply",
+		"/api/news/reply/{newReplyId}",
 
-            //경기일정
-            "/api/match/schedule/{matchCategory}",
-            "/api/match/{matchId}",
-            "/api/match/prediction/{matchId}",
+		//경기일정
+		"/api/match/schedule/{matchCategory}",
+		"/api/match/{matchId}",
+		"/api/match/prediction/{matchId}",
+		"/api/match/esports/youtube",
 
-            /** @brief 게임 할인, 이벤트 관련 URL */
-            "api/game/event",
-            "api/game/discount",
+		/** @brief 게임 할인, 이벤트 관련 URL */
+		"api/game/event",
+		"api/game/discount",
 
-            /** @brief 홈 메인*/
-            "/api/home/new",
-            "/api/home/hot",
+		/** @brief 홈 메인*/
+		"/api/home/new",
+		"/api/home/hot",
 
-            /** @brief 댓글 */
-            "/api/comments/{contentId}",
-    };
+		/** @brief 댓글 */
+		"/api/comments/{contentId}",
+	};
 
-    /* Admin 접근 권한 */
-    private static final String[] PERMIT_ADMIN_URLS = new String[]{
-            // Test Endpoints
-            /** @brief Check Access Admin */"/test/admin/**",
+	/* Admin 접근 권한 */
+	private static final String[] PERMIT_ADMIN_URLS = new String[] {
+		// Test Endpoints
+		/** @brief Check Access Admin */"/test/admin/**",
 
-            "/api/admin/**",
-            "/api/inquiries/answers/**",
-    };
+		"/api/admin/**",
+		"/api/inquiries/answers/**",
+	};
 
-    private static final String[] ADMIN_POST_URLS = {
-            "/api/notice",
-            "/api/improvement/{improvementId}"
-    };
+	private static final String[] ADMIN_POST_URLS = {
+		"/api/notice",
+		"/api/improvement/{improvementId}"
+	};
 
-    private static final String[] ADMIN_PUT_URLS = {
-            "/api/notice/{noticeId}"
-    };
+	private static final String[] ADMIN_PUT_URLS = {
+		"/api/notice/{noticeId}"
+	};
 
-    private static final String[] ADMIN_DELETE_URLS = {
-            "/api/notice/{noticeId}"
-    };
+	private static final String[] ADMIN_DELETE_URLS = {
+		"/api/notice/{noticeId}"
+	};
 
-    /* member 접근 권한 */
-    private static final String[] PERMIT_MEMBER_URLS = new String[]{
-            // Test Endpoints
-            /** @brief Check Access Member */"/test/cert",
-    };
+	/* member 접근 권한 */
+	private static final String[] PERMIT_MEMBER_URLS = new String[] {
+		// Test Endpoints
+		/** @brief Check Access Member */"/test/cert",
+	};
 
-    @Value("${FRONT_URL:http://localhost:3000}")
-    private String frontUrl;
-    private final JwtProvider jwtProvider;
-    private final WebConfig webConfig;
-    private final CustomUserDetailsService customUserDetailsService;
-    private final CustomOAuth2UserService customOAuth2UserService;
-    private final CustomOauth2SuccessHandler customOauth2SuccessHandler;
-    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
-    private final RefreshJpaRepository refreshJpaRepository;
-    private final ApplicationEventPublisher eventPublisher;
+	@Value("${FRONT_URL:http://localhost:3000}")
+	private String frontUrl;
+	private final JwtProvider jwtProvider;
+	private final WebConfig webConfig;
+	private final CustomUserDetailsService customUserDetailsService;
+	private final CustomOAuth2UserService customOAuth2UserService;
+	private final CustomOauth2SuccessHandler customOauth2SuccessHandler;
+	private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+	private final RefreshJpaRepository refreshJpaRepository;
+	private final ApplicationEventPublisher eventPublisher;
 
-    @PostConstruct
-    public void init() {
-        log.debug("init security config");
-        log.debug("frontUrl = {}", frontUrl);
-    }
+	@PostConstruct
+	public void init() {
+		log.debug("init security config");
+		log.debug("frontUrl = {}", frontUrl);
+	}
 
-    @Bean
-    public BCryptPasswordEncoder passwordEncoder() {
-        log.debug("BCryptPasswordEncoder 빈 등록됨");
-        return new BCryptPasswordEncoder();
-    }
+	@Bean
+	public BCryptPasswordEncoder passwordEncoder() {
+		log.debug("BCryptPasswordEncoder 빈 등록됨");
+		return new BCryptPasswordEncoder();
+	}
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        // HTTP 헤더 설정
-        http.headers(headers -> headers
-                .httpStrictTransportSecurity(HstsConfig::disable) // HSTS 비활성화
-                .frameOptions(FrameOptionsConfig::disable)        // FrameOptions 비활성화
-        );
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		// HTTP 헤더 설정
+		http.headers(headers -> headers
+			.httpStrictTransportSecurity(HstsConfig::disable) // HSTS 비활성화
+			.frameOptions(FrameOptionsConfig::disable)        // FrameOptions 비활성화
+		);
 
-        // 기본 보안 설정 비활성화
-        http.logout((auth) -> auth.disable()) // 로그아웃 비활성화
-                .csrf((auth) -> auth.disable()) // csrf disable
-                .formLogin((auth) -> auth.disable()) // From 로그인 방식 disable
-                .httpBasic((auth) -> auth.disable()); // HTTP Basic 인증 방식 disable
+		// 기본 보안 설정 비활성화
+		http.logout((auth) -> auth.disable()) // 로그아웃 비활성화
+			.csrf((auth) -> auth.disable()) // csrf disable
+			.formLogin((auth) -> auth.disable()) // From 로그인 방식 disable
+			.httpBasic((auth) -> auth.disable()); // HTTP Basic 인증 방식 disable
 
-        // 세션 관리: Stateless
-        http.sessionManagement(session -> session
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-        );
+		// 세션 관리: Stateless
+		http.sessionManagement(session -> session
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+		);
 
-        // OAuth2 로그인 설정
-        http.oauth2Login(oauth2 -> oauth2
-                .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
-                .successHandler(customOauth2SuccessHandler)
-                .failureHandler(oAuth2LoginFailureHandler)
-        );
+		// OAuth2 로그인 설정
+		http.oauth2Login(oauth2 -> oauth2
+			.userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+			.successHandler(customOauth2SuccessHandler)
+			.failureHandler(oAuth2LoginFailureHandler)
+		);
 
-        // JWT 인증 및 토큰 검증 필터 추가
-        http.addFilterAt(
-                        new JwtAuthenticationFilter(authenticationManager(), jwtProvider, refreshJpaRepository, eventPublisher),
-                        UsernamePasswordAuthenticationFilter.class
-                )
-                .addFilterAfter(new TokenAuthenticationFilter(jwtProvider), JwtAuthenticationFilter.class);
-        //                .addFilter(webConfig.corsFilter()); // CORS 필터 추가
+		// JWT 인증 및 토큰 검증 필터 추가
+		http.addFilterAt(
+				new JwtAuthenticationFilter(authenticationManager(), jwtProvider, refreshJpaRepository, eventPublisher),
+				UsernamePasswordAuthenticationFilter.class
+			)
+			.addFilterAfter(new TokenAuthenticationFilter(jwtProvider), JwtAuthenticationFilter.class);
+		//                .addFilter(webConfig.corsFilter()); // CORS 필터 추가
 
-        //        // cors 설정
-        http.cors((corsCustomizer) -> corsCustomizer.configurationSource(configurationSource()));
+		//        // cors 설정
+		http.cors((corsCustomizer) -> corsCustomizer.configurationSource(configurationSource()));
 
-        // 예외 처리 핸들러 설정
-        http.exceptionHandling(exceptionHandling -> exceptionHandling
-                .authenticationEntryPoint(new AuthenticationEntryPointHandler())
-                .accessDeniedHandler(new CustomAccessDeniedHandler())
-        );
+		// 예외 처리 핸들러 설정
+		http.exceptionHandling(exceptionHandling -> exceptionHandling
+			.authenticationEntryPoint(new AuthenticationEntryPointHandler())
+			.accessDeniedHandler(new CustomAccessDeniedHandler())
+		);
 
-        // 로그아웃 설정
-        http.logout(logout -> logout
-                .logoutUrl("/logout")
-                .invalidateHttpSession(true)
-                .logoutSuccessHandler(new LogoutSuccessHandler(jwtProvider, refreshJpaRepository))
-                .permitAll()
-        );
+		// 로그아웃 설정
+		http.logout(logout -> logout
+			.logoutUrl("/logout")
+			.invalidateHttpSession(true)
+			.logoutSuccessHandler(new LogoutSuccessHandler(jwtProvider, refreshJpaRepository))
+			.permitAll()
+		);
 
-        // 경로별 인가 작업
-        http.authorizeHttpRequests(authorizeRequests ->
-                authorizeRequests
-                        .requestMatchers(PERMIT_ALL_URLS).permitAll()
-                        .requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll() // 전체 접근 가능한 endpoint
+		// 경로별 인가 작업
+		http.authorizeHttpRequests(authorizeRequests ->
+			authorizeRequests
+				.requestMatchers(PERMIT_ALL_URLS).permitAll()
+				.requestMatchers(HttpMethod.GET, PUBLIC_GET_URLS).permitAll() // 전체 접근 가능한 endpoint
 
-                        .requestMatchers(PERMIT_ADMIN_URLS).hasAnyAuthority(MemberRole.ADMIN.name())
-                        .requestMatchers(HttpMethod.POST, ADMIN_POST_URLS).hasAuthority(MemberRole.ADMIN.name())
-                        .requestMatchers(HttpMethod.PUT, ADMIN_PUT_URLS).hasAuthority(MemberRole.ADMIN.name())
-                        .requestMatchers(HttpMethod.DELETE, ADMIN_DELETE_URLS)
-                        .hasAuthority(MemberRole.ADMIN.name()) // 관리자만 접근 가능한 endpoint
+				.requestMatchers(PERMIT_ADMIN_URLS).hasAnyAuthority(MemberRole.ADMIN.name())
+				.requestMatchers(HttpMethod.POST, ADMIN_POST_URLS).hasAuthority(MemberRole.ADMIN.name())
+				.requestMatchers(HttpMethod.PUT, ADMIN_PUT_URLS).hasAuthority(MemberRole.ADMIN.name())
+				.requestMatchers(HttpMethod.DELETE, ADMIN_DELETE_URLS)
+				.hasAuthority(MemberRole.ADMIN.name()) // 관리자만 접근 가능한 endpoint
 
-                        .anyRequest().authenticated()                   // 나머지 요청은 모두 허용
-        );
+				.anyRequest().authenticated()                   // 나머지 요청은 모두 허용
+		);
 
-        return http.build();
-    }
+		return http.build();
+	}
 
-    @Bean
-    public AuthenticationManager authenticationManager() {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setPasswordEncoder(passwordEncoder());
-        provider.setUserDetailsService(customUserDetailsService);
-        return new ProviderManager(provider);
-    }
+	@Bean
+	public AuthenticationManager authenticationManager() {
+		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+		provider.setPasswordEncoder(passwordEncoder());
+		provider.setUserDetailsService(customUserDetailsService);
+		return new ProviderManager(provider);
+	}
 
-    public CorsConfigurationSource configurationSource() {
-        System.out.println("configurationSource cors 설정이 SecurityFilterChain에 등록됨");
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.addAllowedHeader("*");
-        configuration.addAllowedMethod("*");
-        configuration.addAllowedOriginPattern(frontUrl); // TODO_ 추후 변경 해야함 배포시
-        configuration.addAllowedOriginPattern("http://localhost:3000"); // TODO_ 추후 변경 해야함 배포시
-        configuration.addAllowedOriginPattern("https://main.dbbilwoxps3tu.amplifyapp.com");
-        configuration.addAllowedOriginPattern("https://playhive.co.kr");
-        configuration.setAllowCredentials(true);
-        configuration.addExposedHeader(HEADER_AUTHORIZATION);
-        configuration.addExposedHeader(REFRESH_TOKEN_KEY);
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
+	public CorsConfigurationSource configurationSource() {
+		System.out.println("configurationSource cors 설정이 SecurityFilterChain에 등록됨");
+		CorsConfiguration configuration = new CorsConfiguration();
+		configuration.addAllowedHeader("*");
+		configuration.addAllowedMethod("*");
+		configuration.addAllowedOriginPattern(frontUrl); // TODO_ 추후 변경 해야함 배포시
+		configuration.addAllowedOriginPattern("http://localhost:3000"); // TODO_ 추후 변경 해야함 배포시
+		configuration.addAllowedOriginPattern("https://main.dbbilwoxps3tu.amplifyapp.com");
+		configuration.addAllowedOriginPattern("https://playhive.co.kr");
+		configuration.setAllowCredentials(true);
+		configuration.addExposedHeader(HEADER_AUTHORIZATION);
+		configuration.addExposedHeader(REFRESH_TOKEN_KEY);
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", configuration);
+		return source;
+	}
 
 }

--- a/src/main/java/org/myteam/server/global/util/redis/RedisService.java
+++ b/src/main/java/org/myteam/server/global/util/redis/RedisService.java
@@ -2,6 +2,8 @@ package org.myteam.server.global.util.redis;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.myteam.server.match.match.domain.MatchCategory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import java.time.Duration;
@@ -16,6 +18,8 @@ public class RedisService { // TODO: RedisReportService 로 변경.
 
     private static final int MAX_REQUESTS = 3; // 제한 횟수 (기본값: 5분 동안 3회)
     private static final long EXPIRED_TIME = 5L; // 만료 시간 (5분)
+    private static final long YOUTUBE_EXPIRED_TIME = 5L * 60L * 60L * 1000L;
+    private static final String ESPORTS_YOUTUBE_URL_KEY = "esports:youtube:url";
 
     /**
      * 특정 키(식별자)에 대한 요청이 제한 범위를 초과했는지 확인
@@ -96,5 +100,13 @@ public class RedisService { // TODO: RedisReportService 로 변경.
         } else {
             log.debug("⚠️ [Redis] 초기화 실패 - Key: {} (존재하지 않음)", redisKey);
         }
+    }
+
+    public String getEsportsYoutubeUrl() {
+        return redisTemplate.opsForValue().get(ESPORTS_YOUTUBE_URL_KEY);
+    }
+
+    public void putEsportsYoutubeUrl(String esportsYoutubeUrl) {
+        redisTemplate.opsForValue().set(ESPORTS_YOUTUBE_URL_KEY, esportsYoutubeUrl, Duration.ofMinutes(YOUTUBE_EXPIRED_TIME));
     }
 }

--- a/src/main/java/org/myteam/server/match/match/client/GoogleFeignClient.java
+++ b/src/main/java/org/myteam/server/match/match/client/GoogleFeignClient.java
@@ -1,0 +1,24 @@
+package org.myteam.server.match.match.client;
+
+import org.myteam.server.global.config.FeignConfig;
+import org.myteam.server.match.match.dto.client.reponse.GoogleYoutubeResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Component
+@FeignClient(name = "${google.api.name}", url = "${google.api.url}", configuration = FeignConfig.class)
+public interface GoogleFeignClient {
+
+	@GetMapping(value = "/youtube/v3/search", consumes = MediaType.APPLICATION_JSON_VALUE)
+	GoogleYoutubeResponse searchLiveVideos(
+		@RequestParam("part") String part,
+		@RequestParam("channelId") String channelId,
+		@RequestParam("eventType") String eventType,
+		@RequestParam("type") String type,
+		@RequestParam("key") String apiKey
+	);
+
+}

--- a/src/main/java/org/myteam/server/match/match/controller/MatchController.java
+++ b/src/main/java/org/myteam/server/match/match/controller/MatchController.java
@@ -4,6 +4,7 @@ import static org.myteam.server.global.web.response.ResponseStatus.*;
 
 import org.myteam.server.global.web.response.ResponseDto;
 import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.match.dto.service.response.MatchEsportsYoutubeResponse;
 import org.myteam.server.match.match.dto.service.response.MatchResponse;
 import org.myteam.server.match.match.dto.service.response.MatchScheduleListResponse;
 import org.myteam.server.match.match.service.MatchReadService;
@@ -47,6 +48,16 @@ public class MatchController {
 			SUCCESS.name(),
 			"경기 상세 조회 성공",
 			matchReadService.findOne(matchId))
+		);
+	}
+
+	@Operation(summary = "E스포츠의 유튜브 라이브 여부를 조회 API", description = "E스포츠의 유튜브 라이브 여부를 조회한다.")
+	@GetMapping("/esports/youtube")
+	public ResponseEntity<ResponseDto<MatchEsportsYoutubeResponse>> confirmEsportsYoutube() {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"E스포츠의 유튜브 라이브 여부를 조회 성공",
+			matchReadService.confirmEsportsYoutube())
 		);
 	}
 

--- a/src/main/java/org/myteam/server/match/match/dto/client/reponse/GoogleYoutubeResponse.java
+++ b/src/main/java/org/myteam/server/match/match/dto/client/reponse/GoogleYoutubeResponse.java
@@ -1,0 +1,52 @@
+package org.myteam.server.match.match.dto.client.reponse;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GoogleYoutubeResponse {
+
+	@JsonProperty("kind")
+	private String kind;
+	@JsonProperty("etag")
+	private String etag;
+	@JsonProperty("regionCode")
+	private String regionCode;
+
+	@JsonProperty("items")
+	private List<Item> items;
+
+	public static class Item {
+
+		@JsonProperty("id")
+		private Id id;
+
+		@Builder
+		public Item(Id id) {
+			this.id = id;
+		}
+	}
+
+	public static class Id {
+		private String videoId;
+	}
+
+	@Builder
+	public GoogleYoutubeResponse(List<Item> items) {
+		this.items = items;
+	}
+
+	public boolean isLive() {
+		return !items.isEmpty();
+	}
+
+	public String getVideoId() {
+		return items.get(0).id.videoId;
+	}
+}

--- a/src/main/java/org/myteam/server/match/match/dto/client/request/GoogleYoutubeRequest.java
+++ b/src/main/java/org/myteam/server/match/match/dto/client/request/GoogleYoutubeRequest.java
@@ -1,0 +1,14 @@
+package org.myteam.server.match.match.dto.client.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GoogleYoutubeRequest {
+	private String part;
+	private String channelId;
+	private String eventType;
+	private String type;
+	private String key;
+}

--- a/src/main/java/org/myteam/server/match/match/dto/service/response/MatchEsportsYoutubeResponse.java
+++ b/src/main/java/org/myteam/server/match/match/dto/service/response/MatchEsportsYoutubeResponse.java
@@ -1,0 +1,25 @@
+package org.myteam.server.match.match.dto.service.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchEsportsYoutubeResponse {
+	private boolean isLive;
+	private String url;
+
+	@Builder
+	public MatchEsportsYoutubeResponse(boolean isLive, String url) {
+		this.isLive = isLive;
+		this.url = url;
+	}
+
+	public static MatchEsportsYoutubeResponse createResponse(boolean isLive, String url) {
+		return MatchEsportsYoutubeResponse.builder()
+			.isLive(isLive)
+			.url(url)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/match/repository/MatchRepository.java
+++ b/src/main/java/org/myteam/server/match/match/repository/MatchRepository.java
@@ -1,9 +1,22 @@
 package org.myteam.server.match.match.repository;
 
+import java.time.LocalDateTime;
+
 import org.myteam.server.match.match.domain.Match;
+import org.myteam.server.match.match.domain.MatchCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MatchRepository extends JpaRepository<Match, Long> {
+	@Query("SELECT m.startTime "
+		+ "FROM p_match m "
+		+ "WHERE FUNCTION('DATE', m.startTime) = FUNCTION('DATE', :today) "
+		+ "AND m.category = :category "
+		+ "ORDER BY m.startTime ASC "
+		+ "LIMIT 1")
+	LocalDateTime findMostRecentMatchStartTime(@Param("today") LocalDateTime today,
+		@Param("category") MatchCategory category);
 }

--- a/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
+++ b/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
@@ -8,10 +8,11 @@ import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.match.match.domain.Match;
 import org.myteam.server.match.match.domain.MatchCategory;
-import org.myteam.server.match.match.repository.MatchQueryRepository;
-import org.myteam.server.match.match.repository.MatchRepository;
+import org.myteam.server.match.match.dto.service.response.MatchEsportsYoutubeResponse;
 import org.myteam.server.match.match.dto.service.response.MatchResponse;
 import org.myteam.server.match.match.dto.service.response.MatchScheduleListResponse;
+import org.myteam.server.match.match.repository.MatchQueryRepository;
+import org.myteam.server.match.match.repository.MatchRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ public class MatchReadService {
 
 	private final MatchQueryRepository matchQueryRepository;
 	private final MatchRepository matchRepository;
+	private final MatchYoutubeService matchYoutubeService;
 
 	public Match findById(Long id) {
 		return matchRepository.findById(id)
@@ -44,6 +46,18 @@ public class MatchReadService {
 
 	public MatchResponse findOne(Long id) {
 		return MatchResponse.createResponse(findById(id));
+	}
+
+	public MatchEsportsYoutubeResponse confirmEsportsYoutube() {
+		LocalDateTime today = LocalDateTime.now().toLocalDate().atStartOfDay();
+		LocalDateTime startDate = matchRepository.findMostRecentMatchStartTime(today, MatchCategory.ESPORTS);
+		LocalDateTime todayDate = LocalDateTime.now();
+
+		if (startDate == null || startDate.minusHours(1).isAfter(todayDate)) {
+			return MatchEsportsYoutubeResponse.createResponse(false, null);
+		}
+		String url = matchYoutubeService.getUrl();
+		return MatchEsportsYoutubeResponse.createResponse(url != null, url);
 	}
 
 }

--- a/src/main/java/org/myteam/server/match/match/service/MatchYoutubeService.java
+++ b/src/main/java/org/myteam/server/match/match/service/MatchYoutubeService.java
@@ -1,0 +1,44 @@
+package org.myteam.server.match.match.service;
+
+import org.myteam.server.global.util.redis.RedisService;
+import org.myteam.server.match.match.client.GoogleFeignClient;
+import org.myteam.server.match.match.dto.client.reponse.GoogleYoutubeResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MatchYoutubeService {
+
+	private static final String part = "snippet";
+	private static final String channelId = "UCw1DsweY9b2AKGjV4kGJP1A";
+	private static final String eventType = "live";
+	private static final String type = "video";
+	private static final String videoUrl = "https://www.youtube.com/watch?v=";
+
+	private final GoogleFeignClient googleFeignClient;
+	private final RedisService redisService;
+
+	@Value("${google.api.apiKey}")
+	private String apiKey;
+
+	public String getUrl() {
+		String url = redisService.getEsportsYoutubeUrl();
+		if (url == null) {
+			url = getUrlToGoogleApi();
+			redisService.putEsportsYoutubeUrl(url);
+		}
+		return url;
+	}
+
+	private String getUrlToGoogleApi() {
+		GoogleYoutubeResponse googleYoutubeResponse = googleFeignClient.searchLiveVideos(part,
+			channelId, eventType, type, apiKey);
+		if (googleYoutubeResponse.isLive()) {
+			return videoUrl + googleYoutubeResponse.getVideoId();
+		}
+		return null;
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -61,3 +61,9 @@ playhive:
   control:
     aesSecretKey: ${AES_SECRET_KEY}
     aesIv: ${AES_IV}
+
+google:
+  api:
+    name: googleApi
+    url: https://www.googleapis.com
+    apiKey: ${GOOGLE_API_KEY}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -130,3 +130,9 @@ app:
     url:
       dev: http://localhost:3000
       prod: https://your-production-domain.com
+
+google:
+  api:
+    name: googleApi
+    url: https://www.googleapis.com
+    apiKey: test

--- a/src/test/java/org/myteam/server/match/match/controller/MatchControllerTest.java
+++ b/src/test/java/org/myteam/server/match/match/controller/MatchControllerTest.java
@@ -45,4 +45,20 @@ class MatchControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
 			.andExpect(jsonPath("$.msg").value("경기 상세 조회 성공"));
 	}
+
+	@DisplayName("E스포츠의 유튜브 라이브 여부를 조회한다.")
+	@Test
+	@WithMockUser
+	void confirmEsportsYoutube() throws Exception {
+		// given
+		// when // then
+		mockMvc.perform(
+				get("/api/match/esports/youtube")
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("E스포츠의 유튜브 라이브 여부를 조회 성공"));
+	}
 }

--- a/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
@@ -167,7 +167,7 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		createMatch(team1, team2, MatchCategory.ESPORTS, LocalDateTime.now().plusHours(2));
 
 		assertThat(matchReadService.confirmEsportsYoutube())
-			.extracting("isTrue", "url")
+			.extracting("isLive", "url")
 			.containsExactly(false, null);
 	}
 
@@ -183,7 +183,7 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		createMatch(team1, team2, MatchCategory.ESPORTS, LocalDateTime.now().plusHours(1));
 
 		assertThat(matchReadService.confirmEsportsYoutube())
-			.extracting("isTrue", "url")
+			.extracting("isLive", "url")
 			.containsExactly(true, "www.test.com");
 	}
 


### PR DESCRIPTION
## 기능 설명
- 길표님과 의논 후 당일 제일 최근 경기시작시간 한시간전부터 유튜브 API 조회하도록 했습니다.
- 조회하여 동영상 ID가 내려온경우 Redis에 저장해두고 조회하도록 했습니다. (당일 API 제한 수가 있어 API 호출 최소화 하기위해 사용하였습니다)
- Redis에 url이 없을 시 -> 유튜브 API 조회하여 Redis에 세팅 (5시간 만료기간 설정)
- Redis에 url이 있을시 -> 그래서 응답
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
