### PR TITLE
feat: 뉴스목록조회시 hot 뉴스 표시추가

### DIFF
--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -146,6 +146,7 @@ public class SecurityConfig {
 		/** @brief 홈 메인*/
 		"/api/home/new",
 		"/api/home/hot",
+		"/api/home/search",
 
 		/** @brief 댓글 */
 		"/api/comments/{contentId}",

--- a/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
+++ b/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
@@ -31,12 +31,14 @@ public class NewsDto {
 	private LocalDateTime postDate;
 	@Schema(description = "댓글 검색 시 최상단 댓글 데이터")
 	private NewsCommentSearchDto newsCommentSearchDto;
+	@Schema(description = "Hot 계시물 여부")
+	private boolean isHot;
 
 	@Setter
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private CommentSearchDto commentSearchList;
 
-	public NewsDto(Long id, Category category, String title, String thumbImg, String content, int commentCount, LocalDateTime postDate) {
+	public NewsDto(Long id, Category category, String title, String thumbImg, String content, int commentCount, LocalDateTime postDate, boolean isHot) {
 		this.id = id;
 		this.category = category;
 		this.title = title;
@@ -44,6 +46,7 @@ public class NewsDto {
 		this.content = content;
 		this.commentCount = commentCount;
 		this.postDate = postDate;
+		this.isHot = isHot;
 	}
 
 	public void updateNewsCommentSearchDto(NewsCommentSearchDto newsCommentSearchDto){

--- a/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
@@ -1,11 +1,11 @@
 package org.myteam.server.news.news.repository;
 
 import static java.util.Optional.*;
-import static org.myteam.server.board.domain.QBoard.*;
 import static org.myteam.server.comment.domain.QNewsComment.*;
 import static org.myteam.server.news.news.domain.QNews.*;
 import static org.myteam.server.news.newsCount.domain.QNewsCount.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.myteam.server.board.domain.BoardOrderType;
@@ -93,7 +93,8 @@ public class NewsQueryRepository {
 				news.thumbImg,
 				news.content,
 				newsCount.commentCount,
-				news.postDate
+				news.postDate,
+				news.id.in(getHotNewsIdList())
 			))
 			.from(news)
 			.join(newsCount).on(newsCount.news.id.eq(news.id))
@@ -174,8 +175,8 @@ public class NewsQueryRepository {
 	private long getTotalNewsCount(TimePeriod timePeriod, BoardSearchType searchType, String search) {
 		return ofNullable(
 			queryFactory
-				.select(board.countDistinct())
-				.from(board)
+				.select(news.countDistinct())
+				.from(news)
 				.where(
 					isSearchTypeLikeTo(searchType, search),
 					isPostDateAfter(timePeriod)
@@ -238,7 +239,8 @@ public class NewsQueryRepository {
 	}
 
 	private BooleanExpression isPostDateAfter(TimePeriod timePeriod) {
-		return timePeriod != null ? news.postDate.after(timePeriod.getStartDateByTimePeriod(timePeriod)) : null;
+		LocalDateTime start = timePeriod.getStartDateByTimePeriod(timePeriod);
+		return start != null ? news.postDate.after(start) : null;
 	}
 
 	public Long findPreviousNewsId(Long newsId, Category category) {

--- a/src/test/java/org/myteam/server/news/news/service/NewsReadServiceTest.java
+++ b/src/test/java/org/myteam/server/news/news/service/NewsReadServiceTest.java
@@ -65,11 +65,11 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					1, 1, 3L
 				),
 			() -> assertThat(newsList)
-				.extracting("title", "category", "thumbImg", "content", "commentCount")
+				.extracting("title", "category", "thumbImg", "content", "commentCount", "isHot")
 				.containsExactly(
-					tuple("기사타이틀4", Category.BASEBALL, "www.test.com", "뉴스본문", 12),
-					tuple("기사타이틀2", Category.BASEBALL, "www.test.com", "뉴스본문", 14),
-					tuple("기사타이틀1", Category.BASEBALL, "www.test.com", "뉴스본문", 10)
+					tuple("기사타이틀4", Category.BASEBALL, "www.test.com", "뉴스본문", 12, true),
+					tuple("기사타이틀2", Category.BASEBALL, "www.test.com", "뉴스본문", 14, true),
+					tuple("기사타이틀1", Category.BASEBALL, "www.test.com", "뉴스본문", 10, true)
 				)
 		);
 	}
@@ -202,6 +202,56 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 					tuple("기사타이틀3", Category.ESPORTS, "www.test.com", "뉴스본문", 15),
 					tuple("기사타이틀2", Category.BASEBALL, "www.test.com", "뉴스본문", 14),
 					tuple("기사타이틀1", Category.BASEBALL, "www.test.com", "뉴스본문", 10)
+				)
+		);
+	}
+
+	@DisplayName("추천수와, 조회수가 합해서 상위 10개는 HotNews이다.")
+	@Test
+	void findAllWithHotTest() {
+		createNews(1, Category.BASEBALL, 1);
+		createNews(2, Category.BASEBALL, 2);
+		createNews(3, Category.ESPORTS, 3);
+		createNews(4, Category.BASEBALL, 4);
+		createNews(5, Category.BASEBALL, 5);
+		createNews(6, Category.BASEBALL, 6);
+		createNews(7, Category.BASEBALL, 7);
+		createNews(8, Category.BASEBALL, 8);
+		createNews(9, Category.BASEBALL, 9);
+		createNews(10, Category.BASEBALL, 10);
+		createNews(11, Category.BASEBALL, 11);
+
+		NewsServiceRequest newsServiceRequest = NewsServiceRequest.builder()
+			.orderType(OrderType.DATE)
+			.page(1)
+			.size(11)
+			.build();
+
+		NewsListResponse newsListResponse = newsReadService.findAll(newsServiceRequest);
+
+		List<NewsDto> newsList = newsListResponse.getList().getContent();
+		PageableCustomResponse pageInfo = newsListResponse.getList().getPageInfo();
+
+		assertAll(
+			() -> assertThat(pageInfo)
+				.extracting("currentPage", "totalPage", "totalElement")
+				.containsExactlyInAnyOrder(
+					1, 1, 11L
+				),
+			() -> assertThat(newsList)
+				.extracting("title", "category", "thumbImg", "content", "commentCount", "isHot")
+				.containsExactly(
+					tuple("기사타이틀11", Category.BASEBALL, "www.test.com", "뉴스본문", 11, true),
+					tuple("기사타이틀10", Category.BASEBALL, "www.test.com", "뉴스본문", 10, true),
+					tuple("기사타이틀9", Category.BASEBALL, "www.test.com", "뉴스본문", 9, true),
+					tuple("기사타이틀8", Category.BASEBALL, "www.test.com", "뉴스본문", 8, true),
+					tuple("기사타이틀7", Category.BASEBALL, "www.test.com", "뉴스본문", 7, true),
+					tuple("기사타이틀6", Category.BASEBALL, "www.test.com", "뉴스본문", 6, true),
+					tuple("기사타이틀5", Category.BASEBALL, "www.test.com", "뉴스본문", 5, true),
+					tuple("기사타이틀4", Category.BASEBALL, "www.test.com", "뉴스본문", 4, true),
+					tuple("기사타이틀3", Category.ESPORTS, "www.test.com", "뉴스본문", 3, true),
+					tuple("기사타이틀2", Category.BASEBALL, "www.test.com", "뉴스본문", 2, true),
+					tuple("기사타이틀1", Category.BASEBALL, "www.test.com", "뉴스본문", 1, false)
 				)
 		);
 	}

--- a/src/test/java/org/myteam/server/news/news/service/NewsReadServiceTest.java
+++ b/src/test/java/org/myteam/server/news/news/service/NewsReadServiceTest.java
@@ -45,6 +45,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 			.orderType(OrderType.DATE)
 			.page(1)
 			.size(10)
+			.timePeriod(TimePeriod.ALL)
 			.build();
 
 		NewsListResponse newsListResponse = newsReadService.findAll(newsServiceRequest);
@@ -90,6 +91,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 			.orderType(OrderType.DATE)
 			.page(1)
 			.size(10)
+			.timePeriod(TimePeriod.ALL)
 			.build();
 
 		NewsListResponse newsListResponse = newsReadService.findAll(newsServiceRequest);
@@ -140,6 +142,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 			.orderType(OrderType.DATE)
 			.page(1)
 			.size(10)
+			.timePeriod(TimePeriod.ALL)
 			.build();
 
 		NewsListResponse newsListResponse = newsReadService.findAll(newsServiceRequest);
@@ -182,6 +185,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 			.orderType(OrderType.DATE)
 			.page(1)
 			.size(10)
+			.timePeriod(TimePeriod.ALL)
 			.build();
 
 		NewsListResponse newsListResponse = newsReadService.findAll(newsServiceRequest);
@@ -225,6 +229,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 			.orderType(OrderType.DATE)
 			.page(1)
 			.size(11)
+			.timePeriod(TimePeriod.ALL)
 			.build();
 
 		NewsListResponse newsListResponse = newsReadService.findAll(newsServiceRequest);
@@ -410,6 +415,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 			.search("타이틀1")
 			.page(1)
 			.size(10)
+			.timePeriod(TimePeriod.ALL)
 			.build();
 
 		NewsListResponse newsListResponse = newsReadService.findAll(newsServiceRequest);
@@ -463,6 +469,7 @@ class NewsReadServiceTest extends IntegrationTestSupport {
 			.orderType(OrderType.DATE)
 			.searchType(BoardSearchType.COMMENT)
 			.search("테스트")
+			.timePeriod(TimePeriod.ALL)
 			.page(1)
 			.size(10)
 			.build();


### PR DESCRIPTION
## 기능 설명
- 계시판과 동일하게 hot 뉴스여부 추가했습니다.
- 뉴스 통합검색 버그 발생하여 수정했습니다.
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
