### PR TITLE
feat: esports 경기일정 분리

### DIFF
--- a/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
+++ b/src/main/java/org/myteam/server/global/security/config/SecurityConfig.java
@@ -134,6 +134,7 @@ public class SecurityConfig {
 		"/api/news/reply/{newReplyId}",
 
 		//경기일정
+		"/api/match/esports/schedule",
 		"/api/match/schedule/{matchCategory}",
 		"/api/match/{matchId}",
 		"/api/match/prediction/{matchId}",

--- a/src/main/java/org/myteam/server/match/match/controller/MatchController.java
+++ b/src/main/java/org/myteam/server/match/match/controller/MatchController.java
@@ -2,8 +2,11 @@ package org.myteam.server.match.match.controller;
 
 import static org.myteam.server.global.web.response.ResponseStatus.*;
 
+import java.util.List;
+
 import org.myteam.server.global.web.response.ResponseDto;
 import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.match.dto.service.response.MatchEsportsScheduleResponse;
 import org.myteam.server.match.match.dto.service.response.MatchEsportsYoutubeResponse;
 import org.myteam.server.match.match.dto.service.response.MatchResponse;
 import org.myteam.server.match.match.dto.service.response.MatchScheduleListResponse;
@@ -29,12 +32,22 @@ public class MatchController {
 	@GetMapping("/schedule/{matchCategory}")
 	public ResponseEntity<ResponseDto<MatchScheduleListResponse>> findSchedulesBetweenDate(
 		@PathVariable("matchCategory")
-		@Parameter(description = "경기 유형 FOOTBALL, BASEBALL, ESPORTS")
+		@Parameter(description = "경기 유형 FOOTBALL, BASEBALL")
 		MatchCategory matchCategory) {
 		return ResponseEntity.ok(new ResponseDto<>(
 			SUCCESS.name(),
 			"경기 일정 조회 성공",
 			matchReadService.findSchedulesBetweenDate(matchCategory))
+		);
+	}
+
+	@Operation(summary = "ESPORTS 경기 일정 조회 API", description = "당일과 다음날 새벽6시까지 ESPORTS 경기 일정을 조회한다")
+	@GetMapping("/esports/schedule")
+	public ResponseEntity<ResponseDto<List<MatchEsportsScheduleResponse>>> findEsportsSchedulesBetweenDate() {
+		return ResponseEntity.ok(new ResponseDto<>(
+			SUCCESS.name(),
+			"경기 일정 조회 성공",
+			matchReadService.findEsportsSchedulesBetweenDate())
 		);
 	}
 

--- a/src/main/java/org/myteam/server/match/match/dto/service/response/MatchEsportsScheduleResponse.java
+++ b/src/main/java/org/myteam/server/match/match/dto/service/response/MatchEsportsScheduleResponse.java
@@ -1,0 +1,29 @@
+package org.myteam.server.match.match.dto.service.response;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.myteam.server.match.match.domain.Match;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchEsportsScheduleResponse {
+	private Long matchId;
+	private String startTime;
+	private List<MatchResponse> list;
+
+	public MatchEsportsScheduleResponse(List<Match> matches) {
+		this.matchId = matches.get(matches.size() - 1).getId(); // 마지막 경기 ID를 기준으로 설정
+		this.startTime = matches.get(0).getStartTime().toString(); // 첫번째 경기 시간을 기준
+		this.list = matches.stream().map(MatchResponse::createResponse).toList();
+	}
+
+	public static String formatLocalDateTimeToYearMonth(LocalDateTime dateTime) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+		return dateTime.format(formatter);
+	}
+}

--- a/src/main/java/org/myteam/server/match/match/repository/MatchQueryRepository.java
+++ b/src/main/java/org/myteam/server/match/match/repository/MatchQueryRepository.java
@@ -4,9 +4,12 @@ import static org.myteam.server.match.match.domain.QMatch.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.myteam.server.match.match.domain.Match;
 import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.match.dto.service.response.MatchEsportsScheduleResponse;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -30,11 +33,30 @@ public class MatchQueryRepository {
 			.fetch();
 	}
 
+	public List<MatchEsportsScheduleResponse> findEsportsSchedulesBetweenDate(LocalDateTime startOfDay, LocalDateTime endTime) {
+		List<Match> matches = queryFactory
+			.selectFrom(match)
+			.where(
+				isBetweenDate(startOfDay, endTime),
+				isCategoryEqualTo(MatchCategory.ESPORTS)
+			)
+			.fetch();
+
+		Map<String, List<Match>> groupedByYearMonth = matches.stream()
+			.collect(Collectors.groupingBy(match -> MatchEsportsScheduleResponse.formatLocalDateTimeToYearMonth(match.getStartTime())));
+
+		return groupedByYearMonth.values().stream()
+			.map(MatchEsportsScheduleResponse::new)
+			.collect(Collectors.toList());
+	}
+
 	private BooleanExpression isBetweenDate(LocalDateTime startOfDay, LocalDateTime endTime) {
 		return match.endTime.between(startOfDay, endTime);
 	}
 
 	private BooleanExpression isCategoryEqualTo(MatchCategory matchCategory) {
-		return matchCategory != MatchCategory.ALL ? match.category.eq(matchCategory) : null;
+		return matchCategory != MatchCategory.ALL ? match.category.eq(matchCategory) :
+			match.category.eq(MatchCategory.BASEBALL)
+				.or(match.category.eq(MatchCategory.FOOTBALL));
 	}
 }

--- a/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
+++ b/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
@@ -3,11 +3,13 @@ package org.myteam.server.match.match.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.match.match.domain.Match;
 import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.match.dto.service.response.MatchEsportsScheduleResponse;
 import org.myteam.server.match.match.dto.service.response.MatchEsportsYoutubeResponse;
 import org.myteam.server.match.match.dto.service.response.MatchResponse;
 import org.myteam.server.match.match.dto.service.response.MatchScheduleListResponse;
@@ -34,7 +36,7 @@ public class MatchReadService {
 
 	public MatchScheduleListResponse findSchedulesBetweenDate(MatchCategory matchCategory) {
 		LocalDate today = LocalDate.now();
-		LocalDateTime startOfDay = today.atStartOfDay();
+		LocalDateTime startOfDay = LocalDateTime.now();
 		LocalDateTime endTime = today.plusWeeks(1).atTime(LocalTime.of(6, 0));
 
 		return MatchScheduleListResponse.createResponse(
@@ -42,6 +44,14 @@ public class MatchReadService {
 				.stream()
 				.map(MatchResponse::createResponse)
 				.toList());
+	}
+
+	public List<MatchEsportsScheduleResponse> findEsportsSchedulesBetweenDate() {
+		LocalDate today = LocalDate.now();
+		LocalDateTime startOfDay = today.atStartOfDay();
+		LocalDateTime endTime = today.plusWeeks(1).atTime(LocalTime.of(6, 0));
+
+		return matchQueryRepository.findEsportsSchedulesBetweenDate(startOfDay, endTime);
 	}
 
 	public MatchResponse findOne(Long id) {

--- a/src/main/java/org/myteam/server/news/news/controller/NewsController.java
+++ b/src/main/java/org/myteam/server/news/news/controller/NewsController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class NewsController {
 
     private final NewsReadService newsReadService;
-    private final NewsCountService newsCountService;
 
     @Operation(summary = "뉴스 목록 조회 API", description = "뉴스의 목록을 조회합니다.")
     @GetMapping

--- a/src/main/java/org/myteam/server/news/news/dto/repository/NewsCommentSearchDto.java
+++ b/src/main/java/org/myteam/server/news/news/dto/repository/NewsCommentSearchDto.java
@@ -11,4 +11,10 @@ public class NewsCommentSearchDto {
 	private Long newsCommentId;
 	private String comment;
 	private String imageUrl;
+
+	public NewsCommentSearchDto(Long newsCommentId, String comment, String imageUrl) {
+		this.newsCommentId = newsCommentId;
+		this.comment = comment;
+		this.imageUrl = imageUrl;
+	}
 }

--- a/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
@@ -122,8 +122,8 @@ public class NewsQueryRepository {
 
 	private NewsCommentSearchDto getNewsSearchBoardComment(Long newsId, String search) {
 		JPQLQuery<NewsCommentSearchDto> query = queryFactory
-			.select(Projections.fields(NewsCommentSearchDto.class,
-				newsComment.id.as("commentId"),
+			.select(Projections.constructor(NewsCommentSearchDto.class,
+				newsComment.id,
 				newsComment.comment,
 				newsComment.imageUrl
 			))

--- a/src/test/java/org/myteam/server/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/IntegrationTestSupport.java
@@ -77,340 +77,340 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 @SpringBootTest
 public abstract class IntegrationTestSupport {
 
-    /**
-     * ================== Repository ========================
-     */
-    @Autowired
-    protected TeamRepository teamRepository;
-    @Autowired
-    protected MatchRepository matchRepository;
-    @Autowired
-    protected NewsRepository newsRepository;
-    @Autowired
-    protected NewsCountRepository newsCountRepository;
-    @Autowired
-    protected MemberJpaRepository memberJpaRepository;
-    @Autowired
-    protected MemberActivityRepository memberActivityRepository;
-    @Autowired
-    protected NewsCountMemberRepository newsCountMemberRepository;
-    @Autowired
-    protected InquiryRepository inquiryRepository;
-    @Autowired
-    protected InquiryCountRepository inquiryCountRepository;
-    @Autowired
-    protected MatchPredictionRepository matchPredictionRepository;
-    @Autowired
-    protected BoardRepository boardRepository;
-    @Autowired
-    protected BoardCountRepository boardCountRepository;
-    @Autowired
-    protected BoardRecommendRepository boardRecommendRepository;
-    @Autowired
-    protected NoticeRepository noticeRepository;
-    @Autowired
-    protected NoticeCountRepository noticeCountRepository;
+	/**
+	 * ================== Repository ========================
+	 */
+	@Autowired
+	protected TeamRepository teamRepository;
+	@Autowired
+	protected MatchRepository matchRepository;
+	@Autowired
+	protected NewsRepository newsRepository;
+	@Autowired
+	protected NewsCountRepository newsCountRepository;
+	@Autowired
+	protected MemberJpaRepository memberJpaRepository;
+	@Autowired
+	protected MemberActivityRepository memberActivityRepository;
+	@Autowired
+	protected NewsCountMemberRepository newsCountMemberRepository;
+	@Autowired
+	protected InquiryRepository inquiryRepository;
+	@Autowired
+	protected InquiryCountRepository inquiryCountRepository;
+	@Autowired
+	protected MatchPredictionRepository matchPredictionRepository;
+	@Autowired
+	protected BoardRepository boardRepository;
+	@Autowired
+	protected BoardCountRepository boardCountRepository;
+	@Autowired
+	protected BoardRecommendRepository boardRecommendRepository;
+	@Autowired
+	protected NoticeRepository noticeRepository;
+	@Autowired
+	protected NoticeCountRepository noticeCountRepository;
 
-    @Autowired
-    protected ImprovementRepository improvementRepository;
-    @Autowired
-    protected ImprovementCountRepository improvementCountRepository;
-    @Autowired
-    protected CommentRepository commentRepository;
+	@Autowired
+	protected ImprovementRepository improvementRepository;
+	@Autowired
+	protected ImprovementCountRepository improvementCountRepository;
+	@Autowired
+	protected CommentRepository commentRepository;
 
-    /**
-     * ================== Service ========================
-     */
-    @MockBean
-    protected InquiryReadService inquiryReadService;
-    @MockBean
-    protected SecurityReadService securityReadService;
-    @Autowired
-    protected MemberService memberService;
-    @Autowired
-    protected MyPageReadService myPageReadService;
-    @MockBean
-    protected BoardService boardService;
-    @Autowired
-    protected BoardReadService boardReadService;
-    @MockBean
-    protected MemberReadService memberReadService;
-    @Autowired
-    protected BoardCountReadService boardCountReadService;
-    @Autowired
-    protected BoardRecommendReadService boardRecommendReadService;
-    @Autowired
-    protected BoardCountService boardCountService;
-    @Autowired
-    protected InquiryService inquiryService;
-    @Autowired
-    protected CommentService commentService;
-    @Autowired
-    protected CommentReadService commentReadService;
+	/**
+	 * ================== Service ========================
+	 */
+	@MockBean
+	protected InquiryReadService inquiryReadService;
+	@MockBean
+	protected SecurityReadService securityReadService;
+	@Autowired
+	protected MemberService memberService;
+	@Autowired
+	protected MyPageReadService myPageReadService;
+	@MockBean
+	protected BoardService boardService;
+	@Autowired
+	protected BoardReadService boardReadService;
+	@MockBean
+	protected MemberReadService memberReadService;
+	@Autowired
+	protected BoardCountReadService boardCountReadService;
+	@Autowired
+	protected BoardRecommendReadService boardRecommendReadService;
+	@Autowired
+	protected BoardCountService boardCountService;
+	@Autowired
+	protected InquiryService inquiryService;
+	@Autowired
+	protected CommentService commentService;
+	@Autowired
+	protected CommentReadService commentReadService;
 
-    /**
-     * ================== Config ========================
-     */
-    @MockBean
-    protected S3ConfigLocal s3ConfigLocal;
-    @MockBean
-    protected S3Presigner s3Presigner;
-    @MockBean
-    protected S3Controller s3Controller;
-    @MockBean
-    protected StorageService s3Service;
-    @MockBean
-    protected SlackService slackService;
-    @MockBean
-    protected RedisViewCountService redisViewCountService;
+	/**
+	 * ================== Config ========================
+	 */
+	@MockBean
+	protected S3ConfigLocal s3ConfigLocal;
+	@MockBean
+	protected S3Presigner s3Presigner;
+	@MockBean
+	protected S3Controller s3Controller;
+	@MockBean
+	protected StorageService s3Service;
+	@MockBean
+	protected SlackService slackService;
+	@MockBean
+	protected RedisViewCountService redisViewCountService;
 
-    @AfterEach
-    void tearDown() {
-        commentRepository.deleteAllInBatch();
-        matchPredictionRepository.deleteAllInBatch();
-        matchRepository.deleteAllInBatch();
-        teamRepository.deleteAllInBatch();
-        inquiryRepository.deleteAllInBatch();
-        newsCountMemberRepository.deleteAllInBatch();
-        newsCountRepository.deleteAllInBatch();
-        newsRepository.deleteAllInBatch();
-        boardRecommendRepository.deleteAllInBatch();
-        boardCountRepository.deleteAllInBatch();
-        boardRepository.deleteAllInBatch();
-        memberActivityRepository.deleteAllInBatch();
-        memberJpaRepository.deleteAllInBatch();
-    }
+	@AfterEach
+	void tearDown() {
+		commentRepository.deleteAllInBatch();
+		matchPredictionRepository.deleteAllInBatch();
+		matchRepository.deleteAllInBatch();
+		teamRepository.deleteAllInBatch();
+		inquiryRepository.deleteAllInBatch();
+		newsCountMemberRepository.deleteAllInBatch();
+		newsCountRepository.deleteAllInBatch();
+		newsRepository.deleteAllInBatch();
+		boardRecommendRepository.deleteAllInBatch();
+		boardCountRepository.deleteAllInBatch();
+		boardRepository.deleteAllInBatch();
+		memberActivityRepository.deleteAllInBatch();
+		memberJpaRepository.deleteAllInBatch();
+	}
 
-    protected Member createMember(int index) {
-        Member member = Member.builder()
-                .email("test" + index + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.USER)
-                .type(MemberType.LOCAL)
-                .publicId(UUID.randomUUID())
-                .status(MemberStatus.ACTIVE)
-                .build();
+	protected Member createMember(int index) {
+		Member member = Member.builder()
+			.email("test" + index + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.USER)
+			.type(MemberType.LOCAL)
+			.publicId(UUID.randomUUID())
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-        Member savedMember = memberJpaRepository.save(member);
+		Member savedMember = memberJpaRepository.save(member);
 
-        given(securityReadService.getMember())
-                .willReturn(savedMember);
+		given(securityReadService.getMember())
+			.willReturn(savedMember);
 
-        given(securityReadService.getAuthenticatedPublicId())
-                .willReturn(member.getPublicId());
+		given(securityReadService.getAuthenticatedPublicId())
+			.willReturn(member.getPublicId());
 
-        return savedMember;
-    }
+		return savedMember;
+	}
 
-    protected Member createAdmin(int index) {
-        Member admin = Member.builder()
-                .email("test" + index + "@test.com")
-                .password("1234")
-                .tel("12345")
-                .nickname("test")
-                .role(MemberRole.ADMIN)
-                .type(MemberType.LOCAL)
-                .publicId(UUID.randomUUID())
-                .status(MemberStatus.ACTIVE)
-                .build();
+	protected Member createAdmin(int index) {
+		Member admin = Member.builder()
+			.email("test" + index + "@test.com")
+			.password("1234")
+			.tel("12345")
+			.nickname("test")
+			.role(MemberRole.ADMIN)
+			.type(MemberType.LOCAL)
+			.publicId(UUID.randomUUID())
+			.status(MemberStatus.ACTIVE)
+			.build();
 
-        Member savedMember = memberJpaRepository.save(admin);
+		Member savedMember = memberJpaRepository.save(admin);
 
-        given(securityReadService.getMember())
-                .willReturn(savedMember);
+		given(securityReadService.getMember())
+			.willReturn(savedMember);
 
-        given(securityReadService.getAuthenticatedPublicId())
-                .willReturn(admin.getPublicId());
+		given(securityReadService.getAuthenticatedPublicId())
+			.willReturn(admin.getPublicId());
 
-        return savedMember;
-    }
+		return savedMember;
+	}
 
-    protected News createNews(int index, Category category, int count) {
-        News savedNews = newsRepository.save(News.builder()
-                .title("기사타이틀" + index)
-                .category(category)
-                .thumbImg("www.test.com")
-                .postDate(LocalDateTime.now())
-                .source("www.test.com")
-                .content("뉴스본문")
-                .build());
+	protected News createNews(int index, Category category, int count) {
+		News savedNews = newsRepository.save(News.builder()
+			.title("기사타이틀" + index)
+			.category(category)
+			.thumbImg("www.test.com")
+			.postDate(LocalDateTime.now())
+			.source("www.test.com")
+			.content("뉴스본문")
+			.build());
 
-        NewsCount newsCount = NewsCount.builder()
-                .recommendCount(count)
-                .commentCount(count)
-                .viewCount(count)
-                .build();
+		NewsCount newsCount = NewsCount.builder()
+			.recommendCount(count)
+			.commentCount(count)
+			.viewCount(count)
+			.build();
 
-        newsCount.updateNews(savedNews);
+		newsCount.updateNews(savedNews);
 
-        newsCountRepository.save(newsCount);
+		newsCountRepository.save(newsCount);
 
-        return savedNews;
-    }
+		return savedNews;
+	}
 
-    protected void createNewsComment(News news, Member member, String comment) {
-        NewsComment savedNewsComment = commentRepository.save(
-            NewsComment.builder()
-                .news(news)
-                .comment(comment)
-                .imageUrl("www.test.com")
-                .member(member)
-                .build()
-        );
-    }
+	protected void createNewsComment(News news, Member member, String comment) {
+		NewsComment savedNewsComment = commentRepository.save(
+			NewsComment.builder()
+				.news(news)
+				.comment(comment)
+				.imageUrl("www.test.com")
+				.member(member)
+				.build()
+		);
+	}
 
-    protected News createNewsWithPostDate(int index, Category category, int count, LocalDateTime postTime) {
-        News savedNews = newsRepository.save(News.builder()
-                .title("기사타이틀" + index)
-                .category(category)
-                .thumbImg("www.test.com")
-                .postDate(postTime)
-                .source("www.test.com")
-                .content("뉴스본문")
-                .build());
+	protected News createNewsWithPostDate(int index, Category category, int count, LocalDateTime postTime) {
+		News savedNews = newsRepository.save(News.builder()
+			.title("기사타이틀" + index)
+			.category(category)
+			.thumbImg("www.test.com")
+			.postDate(postTime)
+			.source("www.test.com")
+			.content("뉴스본문")
+			.build());
 
-        NewsCount newsCount = NewsCount.builder()
-                .recommendCount(count)
-                .commentCount(count)
-                .viewCount(count)
-                .build();
+		NewsCount newsCount = NewsCount.builder()
+			.recommendCount(count)
+			.commentCount(count)
+			.viewCount(count)
+			.build();
 
-        newsCount.updateNews(savedNews);
+		newsCount.updateNews(savedNews);
 
-        newsCountRepository.save(newsCount);
+		newsCountRepository.save(newsCount);
 
-        return savedNews;
-    }
+		return savedNews;
+	}
 
-    protected NewsCountMember createNewsCountMember(Member member, News news) {
-        return newsCountMemberRepository.save(
-                NewsCountMember.builder()
-                        .news(news)
-                        .member(member)
-                        .build()
-        );
-    }
+	protected NewsCountMember createNewsCountMember(Member member, News news) {
+		return newsCountMemberRepository.save(
+			NewsCountMember.builder()
+				.news(news)
+				.member(member)
+				.build()
+		);
+	}
 
-    protected Team createTeam(int index, TeamCategory category) {
-        return teamRepository.save(Team.builder()
-                .name("테스트팀" + index)
-                .logo("www.test.com")
-                .category(category)
-                .build());
-    }
+	protected Team createTeam(int index, TeamCategory category) {
+		return teamRepository.save(Team.builder()
+			.name("테스트팀" + index)
+			.logo("www.test.com")
+			.category(category)
+			.build());
+	}
 
-    protected Match createMatch(Team homeTeam, Team awayTeam, MatchCategory category,
-                                LocalDateTime startDate) {
-        return matchRepository.save(Match.builder()
-                .homeTeam(homeTeam)
-                .awayTeam(awayTeam)
-                .category(category)
-                .startTime(startDate)
-                .endTime(startDate)
-                .build());
-    }
+	protected Match createMatch(Team homeTeam, Team awayTeam, MatchCategory category,
+		LocalDateTime startDate) {
+		return matchRepository.save(Match.builder()
+			.homeTeam(homeTeam)
+			.awayTeam(awayTeam)
+			.category(category)
+			.startTime(startDate)
+			.endTime(startDate.plusHours(1))
+			.build());
+	}
 
-    protected MatchPrediction createMatchPrediction(Match match, int home, int away) {
-        return matchPredictionRepository.save(MatchPrediction.builder()
-                .match(match)
-                .home(home)
-                .away(away)
-                .build());
-    }
+	protected MatchPrediction createMatchPrediction(Match match, int home, int away) {
+		return matchPredictionRepository.save(MatchPrediction.builder()
+			.match(match)
+			.home(home)
+			.away(away)
+			.build());
+	}
 
-    protected Board createBoard(Member member, Category boardType, CategoryType categoryType, String title,
-                                String content) {
+	protected Board createBoard(Member member, Category boardType, CategoryType categoryType, String title,
+		String content) {
 
-        Board board = Board.builder()
-                .member(member)
-                .boardType(boardType)
-                .categoryType(categoryType)
-                .title(title)
-                .content(content)
-                .link("https://www.naver.com")
-                .createdIp("127.0.0.1")
-                .thumbnail("http://localhost:9000/devbucket/inage/1235.png")
-                .build();
+		Board board = Board.builder()
+			.member(member)
+			.boardType(boardType)
+			.categoryType(categoryType)
+			.title(title)
+			.content(content)
+			.link("https://www.naver.com")
+			.createdIp("127.0.0.1")
+			.thumbnail("http://localhost:9000/devbucket/inage/1235.png")
+			.build();
 
-        boardRepository.save(board);
+		boardRepository.save(board);
 
-        BoardCount boardCount = BoardCount.builder()
-                .board(board)
-                .recommendCount(0)
-                .commentCount(0)
-                .viewCount(0)
-                .build();
+		BoardCount boardCount = BoardCount.builder()
+			.board(board)
+			.recommendCount(0)
+			.commentCount(0)
+			.viewCount(0)
+			.build();
 
-        boardCountRepository.save(boardCount);
+		boardCountRepository.save(boardCount);
 
-        return board;
-    }
+		return board;
+	}
 
-    protected BoardRecommend createBoardRecommend(Board board, Member member) {
-        BoardRecommend recommend = BoardRecommend.builder()
-                .board(board)
-                .member(member)
-                .build();
-        boardRecommendRepository.save(recommend);
+	protected BoardRecommend createBoardRecommend(Board board, Member member) {
+		BoardRecommend recommend = BoardRecommend.builder()
+			.board(board)
+			.member(member)
+			.build();
+		boardRecommendRepository.save(recommend);
 
-        return recommend;
-    }
+		return recommend;
+	}
 
-    protected Notice createNotice(Member member) {
-        Notice notice = Notice.builder()
-                .member(member)
-                .title("공지사하아앙 제목")
-                .content("공지공지공지")
-                .createdIp("0.0.0.1")
-                .imgUrl(null)
-                .build();
+	protected Notice createNotice(Member member) {
+		Notice notice = Notice.builder()
+			.member(member)
+			.title("공지사하아앙 제목")
+			.content("공지공지공지")
+			.createdIp("0.0.0.1")
+			.imgUrl(null)
+			.build();
 
-        noticeRepository.save(notice);
+		noticeRepository.save(notice);
 
-        NoticeCount noticeCount = NoticeCount.builder()
-                .notice(notice)
-                .recommendCount(0)
-                .commentCount(0)
-                .viewCount(0)
-                .build();
+		NoticeCount noticeCount = NoticeCount.builder()
+			.notice(notice)
+			.recommendCount(0)
+			.commentCount(0)
+			.viewCount(0)
+			.build();
 
-        noticeCountRepository.save(noticeCount);
+		noticeCountRepository.save(noticeCount);
 
-        return notice;
-    }
+		return notice;
+	}
 
-    protected Inquiry createInquiry(Member member) {
-        Inquiry inquiry = Inquiry.builder()
-                .content("문의사항ㅇㅇㅇ")
-                .member(member)
-                .clientIp("0.0.0.1")
-                .createdAt(LocalDateTime.now())
-                .isAdminAnswered(false)
-                .build();
+	protected Inquiry createInquiry(Member member) {
+		Inquiry inquiry = Inquiry.builder()
+			.content("문의사항ㅇㅇㅇ")
+			.member(member)
+			.clientIp("0.0.0.1")
+			.createdAt(LocalDateTime.now())
+			.isAdminAnswered(false)
+			.build();
 
-        inquiryRepository.save(inquiry);
+		inquiryRepository.save(inquiry);
 
-        InquiryCount inquiryCount = InquiryCount.createCount(inquiry);
-        inquiryCountRepository.save(inquiryCount);
+		InquiryCount inquiryCount = InquiryCount.createCount(inquiry);
+		inquiryCountRepository.save(inquiryCount);
 
-        return inquiry;
-    }
+		return inquiry;
+	}
 
-    protected Improvement createImprovement(Member member) {
-        Improvement improvement = Improvement.builder()
-                .member(member)
-                .title("개선요처어엉ㅇ 제목")
-                .content("개선개선개선")
-                .createdIp("0.0.0.1")
-                .imgUrl(null)
-                .build();
-        improvementRepository.save(improvement);
+	protected Improvement createImprovement(Member member) {
+		Improvement improvement = Improvement.builder()
+			.member(member)
+			.title("개선요처어엉ㅇ 제목")
+			.content("개선개선개선")
+			.createdIp("0.0.0.1")
+			.imgUrl(null)
+			.build();
+		improvementRepository.save(improvement);
 
-        ImprovementCount improvementCount = ImprovementCount.createImprovementCount(improvement);
-        improvementCountRepository.save(improvementCount);
+		ImprovementCount improvementCount = ImprovementCount.createImprovementCount(improvement);
+		improvementCountRepository.save(improvementCount);
 
-        return improvement;
-    }
+		return improvement;
+	}
 }

--- a/src/test/java/org/myteam/server/match/match/controller/MatchControllerTest.java
+++ b/src/test/java/org/myteam/server/match/match/controller/MatchControllerTest.java
@@ -61,4 +61,20 @@ class MatchControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
 			.andExpect(jsonPath("$.msg").value("E스포츠의 유튜브 라이브 여부를 조회 성공"));
 	}
+
+	@DisplayName("E스포츠의 경기일정을 조회한다.")
+	@Test
+	@WithMockUser
+	void findEsportsSchedulesBetweenDate() throws Exception {
+		// given
+		// when // then
+		mockMvc.perform(
+				get("/api/match/esports/schedule")
+					.with(csrf())
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.status").value(SUCCESS.name()))
+			.andExpect(jsonPath("$.msg").value("경기 일정 조회 성공"));
+	}
 }

--- a/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
@@ -66,8 +66,8 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
 		Team team3 = createTeam(3, TeamCategory.FOOTBALL);
 
-		createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().minusDays(1).atStartOfDay());
-		createMatch(team2, team3, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+		createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDateTime.now().minusDays(1));
+		createMatch(team2, team3, MatchCategory.FOOTBALL, LocalDateTime.now());
 		createMatch(team3, team1, MatchCategory.FOOTBALL,
 			LocalDate.now().plusWeeks(1).atTime(LocalTime.of(7, 0)));
 
@@ -93,9 +93,9 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		Team team3 = createTeam(3, TeamCategory.ESPORTS);
 		Team team4 = createTeam(4, TeamCategory.ESPORTS);
 
-		createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
-		createMatch(team2, team1, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
-		createMatch(team3, team4, MatchCategory.ESPORTS, LocalDate.now().atStartOfDay());
+		createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDateTime.now());
+		createMatch(team2, team1, MatchCategory.FOOTBALL, LocalDateTime.now());
+		createMatch(team3, team4, MatchCategory.ESPORTS, LocalDateTime.now());
 
 		assertThat(matchReadService.findSchedulesBetweenDate(MatchCategory.FOOTBALL).getList())
 			.extracting(


### PR DESCRIPTION
## 기능 설명
- ESPORTS 경기일정 조회 API를 따로 만들어 프론트에서 따로 조회해서 조합하기로 결정했습니다.
## 작업 내용
- ESPORTS 경기일정 날짜별로 그룹핑하도록 수정
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [x] 단위 테스트 확인(포스트맨 등..)
- [x] 통합 테스트 확인(서버 빌드되는지 확인)
- [x] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
