### PR TITLE
fix: 경기예측 퍼센트 수정

### DIFF
--- a/src/main/java/org/myteam/server/match/util/PercentageUtil.java
+++ b/src/main/java/org/myteam/server/match/util/PercentageUtil.java
@@ -5,6 +5,10 @@ public class PercentageUtil {
 	private static final int STANDARD = 100;
 
 	public static int[] getCalculatedPercentages(int home, int away) {
+		if (home == 0 && away == 0) {
+			return new int[]{0, 0};
+		}
+
 		int homePercentage = getHomePercentage(home, away);
 		int awayPercentage = getAwayPercentage(home, away);
 

--- a/src/test/java/org/myteam/server/match/matchPrediction/dto/MatchPredictionResponseTest.java
+++ b/src/test/java/org/myteam/server/match/matchPrediction/dto/MatchPredictionResponseTest.java
@@ -1,0 +1,37 @@
+package org.myteam.server.match.matchPrediction.dto;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.match.matchPrediction.dto.service.response.MatchPredictionResponse;
+
+public class MatchPredictionResponseTest extends IntegrationTestSupport {
+
+	@DisplayName("경기예측 현황을 퍼센트로 바꾼다.")
+	@Test
+	void percent() {
+		MatchPredictionResponse matchPredictionResponse1 = MatchPredictionResponse.builder()
+			.matchId(1L)
+			.id(1L)
+			.home(1)
+			.away(0)
+			.build();
+
+		MatchPredictionResponse matchPredictionResponse2 = MatchPredictionResponse.builder()
+			.matchId(1L)
+			.id(1L)
+			.home(1)
+			.away(1)
+			.build();
+
+		assertAll(
+			() -> assertThat(matchPredictionResponse1).extracting("matchId", "id", "home", "away")
+				.contains(1L, 1L, 100, 0),
+			() -> assertThat(matchPredictionResponse2).extracting("matchId", "id", "home", "away")
+				.contains(1L, 1L, 50, 50)
+		);
+	}
+}


### PR DESCRIPTION
## 기능 설명
- 경기예측이 아직 진행되지 않아 0, 0일때 그대로 0, 0으로 내려주도록 버그 수정했습니다.
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
