### PR TITLE
fix: 실시간 유튜브 url   video id만

### DIFF
--- a/src/main/java/org/myteam/server/global/util/redis/RedisService.java
+++ b/src/main/java/org/myteam/server/global/util/redis/RedisService.java
@@ -21,7 +21,7 @@ public class RedisService { // TODO: RedisReportService 로 변경.
 	private static final long YOUTUBE_EXPIRED_TIME = 5L * 60L * 60L * 1000L;
 	private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 30;      // 30일
 	private static final String REFRESH_TOKEN_KEY = "refreshToken:";
-	private static final String ESPORTS_YOUTUBE_URL_KEY = "esports:youtube:url";
+	private static final String ESPORTS_YOUTUBE_VIDEOID_KEY = "esports:youtube:videoId";
 
 	/**
 	 * 특정 키(식별자)에 대한 요청이 제한 범위를 초과했는지 확인
@@ -106,13 +106,13 @@ public class RedisService { // TODO: RedisReportService 로 변경.
 		}
 	}
 
-	public String getEsportsYoutubeUrl() {
-		return redisTemplate.opsForValue().get(ESPORTS_YOUTUBE_URL_KEY);
+	public String getEsportsYoutubeVideoId() {
+		return redisTemplate.opsForValue().get(ESPORTS_YOUTUBE_VIDEOID_KEY);
 	}
 
-	public void putEsportsYoutubeUrl(String esportsYoutubeUrl) {
+	public void putEsportsYoutubeVideoId(String esportsYoutubeUrl) {
 		redisTemplate.opsForValue()
-			.set(ESPORTS_YOUTUBE_URL_KEY, esportsYoutubeUrl, Duration.ofMinutes(YOUTUBE_EXPIRED_TIME));
+			.set(ESPORTS_YOUTUBE_VIDEOID_KEY, esportsYoutubeUrl, Duration.ofMinutes(YOUTUBE_EXPIRED_TIME));
 	}
 
 	public void putRefreshToken(UUID publicId, String refreshToken) {

--- a/src/main/java/org/myteam/server/match/match/dto/service/response/MatchEsportsYoutubeResponse.java
+++ b/src/main/java/org/myteam/server/match/match/dto/service/response/MatchEsportsYoutubeResponse.java
@@ -8,18 +8,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MatchEsportsYoutubeResponse {
 	private boolean isLive;
-	private String url;
+	private String videoId;
 
 	@Builder
-	public MatchEsportsYoutubeResponse(boolean isLive, String url) {
+	public MatchEsportsYoutubeResponse(boolean isLive, String videoId) {
 		this.isLive = isLive;
-		this.url = url;
+		this.videoId = videoId;
 	}
 
-	public static MatchEsportsYoutubeResponse createResponse(boolean isLive, String url) {
+	public static MatchEsportsYoutubeResponse createResponse(boolean isLive, String videoId) {
 		return MatchEsportsYoutubeResponse.builder()
 			.isLive(isLive)
-			.url(url)
+			.videoId(videoId)
 			.build();
 	}
 }

--- a/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
+++ b/src/main/java/org/myteam/server/match/match/service/MatchReadService.java
@@ -65,8 +65,8 @@ public class MatchReadService {
 		if (startDate == null || startDate.minusHours(1).isAfter(todayDate)) {
 			return MatchEsportsYoutubeResponse.createResponse(false, null);
 		}
-		String url = matchYoutubeService.getUrl();
-		return MatchEsportsYoutubeResponse.createResponse(url != null, url);
+		String videoId = matchYoutubeService.getVideoId();
+		return MatchEsportsYoutubeResponse.createResponse(videoId != null, videoId);
 	}
 
 }

--- a/src/main/java/org/myteam/server/match/match/service/MatchYoutubeService.java
+++ b/src/main/java/org/myteam/server/match/match/service/MatchYoutubeService.java
@@ -16,7 +16,6 @@ public class MatchYoutubeService {
 	private static final String channelId = "UCw1DsweY9b2AKGjV4kGJP1A";
 	private static final String eventType = "live";
 	private static final String type = "video";
-	private static final String videoUrl = "https://www.youtube.com/watch?v=";
 
 	private final GoogleFeignClient googleFeignClient;
 	private final RedisService redisService;
@@ -24,20 +23,20 @@ public class MatchYoutubeService {
 	@Value("${google.api.apiKey}")
 	private String apiKey;
 
-	public String getUrl() {
-		String url = redisService.getEsportsYoutubeUrl();
-		if (url == null) {
-			url = getUrlToGoogleApi();
-			redisService.putEsportsYoutubeUrl(url);
+	public String getVideoId() {
+		String videoId = redisService.getEsportsYoutubeVideoId();
+		if (videoId == null) {
+			videoId = getUrlToGoogleApi();
+			redisService.putEsportsYoutubeVideoId(videoId);
 		}
-		return url;
+		return videoId;
 	}
 
 	private String getUrlToGoogleApi() {
 		GoogleYoutubeResponse googleYoutubeResponse = googleFeignClient.searchLiveVideos(part,
 			channelId, eventType, type, apiKey);
 		if (googleYoutubeResponse.isLive()) {
-			return videoUrl + googleYoutubeResponse.getVideoId();
+			return googleYoutubeResponse.getVideoId();
 		}
 		return null;
 	}

--- a/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
@@ -160,15 +160,15 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		createMatch(team1, team2, MatchCategory.ESPORTS, LocalDateTime.now().plusHours(2));
 
 		assertThat(matchReadService.confirmEsportsYoutube())
-			.extracting("isLive", "url")
+			.extracting("isLive", " videoId")
 			.containsExactly(false, null);
 	}
 
 	@DisplayName("E스포츠 경기시간이 되었으면 Youtube API를 조회한다.")
 	@Test
 	void confirmEsportsYoutubeAfterStartDate() {
-		given(matchYoutubeService.getUrl())
-			.willReturn("www.test.com");
+		given(matchYoutubeService.getVideoId())
+			.willReturn("wsawcwdwd");
 
 		Team team1 = createTeam(1, TeamCategory.ESPORTS);
 		Team team2 = createTeam(2, TeamCategory.ESPORTS);
@@ -176,8 +176,8 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		createMatch(team1, team2, MatchCategory.ESPORTS, LocalDateTime.now().plusHours(1));
 
 		assertThat(matchReadService.confirmEsportsYoutube())
-			.extracting("isLive", "url")
-			.containsExactly(true, "www.test.com");
+			.extracting("isLive", "videoId")
+			.containsExactly(true, "wsawcwdwd");
 	}
 
 	@DisplayName("ESPORTS 경기일정 목록을 조회한다.")

--- a/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/match/service/MatchReadServiceTest.java
@@ -160,7 +160,7 @@ class MatchReadServiceTest extends IntegrationTestSupport {
 		createMatch(team1, team2, MatchCategory.ESPORTS, LocalDateTime.now().plusHours(2));
 
 		assertThat(matchReadService.confirmEsportsYoutube())
-			.extracting("isLive", " videoId")
+			.extracting("isLive", "videoId")
 			.containsExactly(false, null);
 	}
 


### PR DESCRIPTION
## 기능 설명
- 길표님 요청으로 유튜브 url이 아닌 videoId만 내려주도록 수정하였습니다.
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
