### PR TITLE
feat: 메인화면에서 유연하게 사용가능하도록 startIndex 추가

### DIFF
--- a/src/main/java/org/myteam/server/news/news/dto/controller/request/NewsRequest.java
+++ b/src/main/java/org/myteam/server/news/news/dto/controller/request/NewsRequest.java
@@ -36,16 +36,21 @@ public class NewsRequest extends PageInfoRequest {
 	@Schema(description = "날짜 조건", example = "DAILY(일별), WEEKLY(주별), MONTHLY(월별), YEARLY(년별)")
 	private TimePeriod timePeriod;
 
+	@Schema(description = "시작할 인덱스 번호")
+	private int startIndex;
+
+
 	@Builder
 	public NewsRequest(Category category, OrderType orderType, BoardSearchType SearchType, String search,
 		TimePeriod timePeriod, int page,
-		int size) {
+		int size, int startIndex) {
 		super(page, size);
 		this.category = category;
 		this.orderType = orderType;
 		this.searchType = SearchType;
 		this.search = search;
 		this.timePeriod = timePeriod;
+		this.startIndex = startIndex;
 	}
 
 	public NewsServiceRequest toServiceRequest() {
@@ -57,6 +62,7 @@ public class NewsRequest extends PageInfoRequest {
 			.timePeriod(timePeriod)
 			.size(getSize())
 			.page(getPage())
+			.startIndex(startIndex)
 			.build();
 	}
 }

--- a/src/main/java/org/myteam/server/news/news/dto/service/request/NewsServiceRequest.java
+++ b/src/main/java/org/myteam/server/news/news/dto/service/request/NewsServiceRequest.java
@@ -18,16 +18,18 @@ public class NewsServiceRequest extends PageInfoServiceRequest {
 	private BoardSearchType searchType;
 	private String search;
 	private TimePeriod timePeriod;
+	private int startIndex;
 
 	@Builder
 	public NewsServiceRequest(Category category, OrderType orderType, BoardSearchType searchType, String search,
-		TimePeriod timePeriod, int size, int page) {
+		TimePeriod timePeriod, int size, int page, int startIndex) {
 		super(page, size);
 		this.category = category;
 		this.orderType = orderType;
 		this.searchType = searchType;
 		this.search = search;
 		this.timePeriod = timePeriod;
+		this.startIndex = startIndex;
 	}
 
 }

--- a/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
+++ b/src/main/java/org/myteam/server/news/news/repository/NewsQueryRepository.java
@@ -5,7 +5,6 @@ import static org.myteam.server.comment.domain.QNewsComment.*;
 import static org.myteam.server.news.news.domain.QNews.*;
 import static org.myteam.server.news.newsCount.domain.QNewsCount.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,6 +46,7 @@ public class NewsQueryRepository {
 		String search = newsServiceRequest.getSearch();
 		TimePeriod timePeriod = newsServiceRequest.getTimePeriod();
 		Pageable pageable = newsServiceRequest.toPageable();
+		int startIndex = newsServiceRequest.getStartIndex();
 
 		List<NewsDto> contents = queryFactory
 			.select(Projections.constructor(NewsDto.class,
@@ -67,7 +67,7 @@ public class NewsQueryRepository {
 				isPostDateAfter(timePeriod)
 			)
 			.orderBy(isOrderByEqualToOrderCategory(orderType))
-			.offset(pageable.getOffset())
+			.offset(pageable.getOffset() + startIndex)
 			.limit(pageable.getPageSize())
 			.fetch();
 
@@ -79,7 +79,7 @@ public class NewsQueryRepository {
 			});
 		}
 
-		long total = getTotalNewsCount(category, searchType, search, timePeriod);
+		long total = getTotalNewsCount(category, searchType, search, timePeriod, startIndex);
 
 		return new PageImpl<>(contents, pageable, total);
 	}
@@ -140,7 +140,7 @@ public class NewsQueryRepository {
 	}
 
 	private long getTotalNewsCount(Category category, BoardSearchType searchType, String search,
-		TimePeriod timePeriod) {
+		TimePeriod timePeriod, int startIndex) {
 		return ofNullable(
 			queryFactory
 				.select(news.count())
@@ -151,7 +151,7 @@ public class NewsQueryRepository {
 					isPostDateAfter(timePeriod)
 				)
 				.fetchOne()
-		).orElse(0L);
+		).orElse(0L) - startIndex;
 	}
 
 	/**


### PR DESCRIPTION
## 기능 설명
- 제동님요청으로 메인화면에서는 뉴스 페이징이 3-7, 8-12 이런식으로 앞에 3개를 잘라야해서 startIndex 추가하여 원하는 곳부터 데이터 가져올수있도록 수정하였습니다.
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
