### PR TITLE
fix: 경기예측 사용자 저장

### DIFF
--- a/src/main/java/org/myteam/server/global/exception/ErrorCode.java
+++ b/src/main/java/org/myteam/server/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     ALREADY_MEMBER_RECOMMEND_NEWS(HttpStatus.BAD_REQUEST, "Member Already Recommend News"),
     ALREADY_MEMBER_RECOMMEND_NEWS_COMMENT(HttpStatus.BAD_REQUEST, "Member Already Recommend News Comment"),
     ALREADY_MEMBER_RECOMMEND_NEWS_REPLY(HttpStatus.BAD_REQUEST, "Member Already Recommend News Reply"),
+    ALREADY_MEMBER_MATCH_PREDICTION(HttpStatus.BAD_REQUEST, "Member Already Match Prediction"),
     INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "Phone number is invalid"),
     INVALID_GENDER_TYPE(HttpStatus.BAD_REQUEST, "Gender Type allow M or F"),
     INVALID_BIRTH_DATE(HttpStatus.BAD_REQUEST, "BIRTHDATE length must be 6"),

--- a/src/main/java/org/myteam/server/match/matchPrediction/controller/MatchPredictionController.java
+++ b/src/main/java/org/myteam/server/match/matchPrediction/controller/MatchPredictionController.java
@@ -44,9 +44,10 @@ public class MatchPredictionController {
 	@PatchMapping
 	public ResponseEntity<ResponseDto<Long>> update(@RequestBody MatchPredictionRequest matchPredictionRequest) {
 		return ResponseEntity.ok(new ResponseDto<>(
-			SUCCESS.name(),
-			"경기예측 저장 성공",
-			matchPredictionService.update(matchPredictionRequest.toServiceRequest()))
+				SUCCESS.name(),
+				"경기예측 저장 성공",
+				matchPredictionService.update(matchPredictionRequest.toServiceRequest())
+			)
 		);
 	}
 

--- a/src/main/java/org/myteam/server/match/matchPrediction/dto/service/response/MatchPredictionResponse.java
+++ b/src/main/java/org/myteam/server/match/matchPrediction/dto/service/response/MatchPredictionResponse.java
@@ -1,7 +1,10 @@
 package org.myteam.server.match.matchPrediction.dto.service.response;
 
+import java.time.LocalDateTime;
+
 import org.myteam.server.match.match.dto.service.response.TeamResponse;
 import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
+import org.myteam.server.match.matchPrediction.dto.service.request.Side;
 import org.myteam.server.match.util.PercentageUtil;
 
 import lombok.Builder;
@@ -16,29 +19,38 @@ public class MatchPredictionResponse {
 	private Long matchId;
 	private TeamResponse homeTeam;
 	private TeamResponse awayTeam;
+	private LocalDateTime startTime;
 	private int home;
 	private int away;
+	private boolean isVote;
+	private Side side;
 
 	@Builder
-	public MatchPredictionResponse(Long id, Long matchId, TeamResponse homeTeam, TeamResponse awayTeam, int home,
-		int away) {
+	public MatchPredictionResponse(Long id, Long matchId, TeamResponse homeTeam, TeamResponse awayTeam, LocalDateTime startTime, int home,
+		int away, boolean isVote, Side side) {
 		this.id = id;
 		this.matchId = matchId;
 		this.homeTeam = homeTeam;
 		this.awayTeam = awayTeam;
+		this.startTime = startTime;
 		this.home = home;
 		this.away = away;
+		this.isVote = isVote;
+		this.side = side;
 		updateAsPercentage();
 	}
 
-	public static MatchPredictionResponse createResponse(MatchPrediction matchPrediction) {
+	public static MatchPredictionResponse createResponse(MatchPrediction matchPrediction, boolean isVote, Side side) {
 		return MatchPredictionResponse.builder()
 			.id(matchPrediction.getId())
 			.matchId(matchPrediction.getMatch().getId())
 			.homeTeam(TeamResponse.createResponse(matchPrediction.getMatch().getHomeTeam()))
 			.awayTeam(TeamResponse.createResponse(matchPrediction.getMatch().getAwayTeam()))
+			.startTime(matchPrediction.getMatch().getStartTime())
 			.home(matchPrediction.getHome())
 			.away(matchPrediction.getAway())
+			.isVote(isVote)
+			.side(side)
 			.build();
 	}
 

--- a/src/main/java/org/myteam/server/match/matchPrediction/service/MatchPredictionReadService.java
+++ b/src/main/java/org/myteam/server/match/matchPrediction/service/MatchPredictionReadService.java
@@ -45,7 +45,7 @@ public class MatchPredictionReadService {
 	public MatchPredictionResponse findOne(Long id) {
 		UUID publicId = securityReadService.getAuthenticatedPublicId();
 
-		MatchPrediction matchPrediction = findById(id);
+		MatchPrediction matchPrediction = findByMatchId(id);
 
 		MatchPredictionMember matchPredictionMember = matchPredictionMemberReadService.confirmPredictionMember(
 			matchPrediction.getId(), publicId);

--- a/src/main/java/org/myteam/server/match/matchPrediction/service/MatchPredictionReadService.java
+++ b/src/main/java/org/myteam/server/match/matchPrediction/service/MatchPredictionReadService.java
@@ -1,15 +1,19 @@
 package org.myteam.server.match.matchPrediction.service;
 
+import java.util.UUID;
+
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
+import org.myteam.server.match.matchPrediction.dto.service.request.Side;
 import org.myteam.server.match.matchPrediction.dto.service.response.MatchPredictionResponse;
 import org.myteam.server.match.matchPrediction.repository.MatchPredictionLockRepository;
 import org.myteam.server.match.matchPrediction.repository.MatchPredictionRepository;
-import org.myteam.server.news.newsCount.domain.NewsCount;
+import org.myteam.server.match.matchPredictionMember.domain.MatchPredictionMember;
+import org.myteam.server.match.matchPredictionMember.service.MatchPredictionMemberReadService;
+import org.myteam.server.member.service.SecurityReadService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +24,8 @@ public class MatchPredictionReadService {
 
 	private final MatchPredictionRepository matchPredictionRepository;
 	private final MatchPredictionLockRepository matchPredictionLockRepository;
+	private final MatchPredictionMemberReadService matchPredictionMemberReadService;
+	private final SecurityReadService securityReadService;
 
 	public MatchPrediction findByMatchId(Long id) {
 		return matchPredictionRepository.findByMatchId(id)
@@ -37,7 +43,29 @@ public class MatchPredictionReadService {
 	}
 
 	public MatchPredictionResponse findOne(Long id) {
-		return MatchPredictionResponse.createResponse(findByMatchId(id));
+		UUID publicId = securityReadService.getAuthenticatedPublicId();
+
+		MatchPrediction matchPrediction = findById(id);
+
+		MatchPredictionMember matchPredictionMember = matchPredictionMemberReadService.confirmPredictionMember(
+			matchPrediction.getId(), publicId);
+
+		return MatchPredictionResponse.createResponse(
+			matchPrediction,
+			isRecommendYn(matchPredictionMember, publicId),
+			confirmSide(matchPredictionMember)
+		);
+	}
+
+	private boolean isRecommendYn(MatchPredictionMember matchPredictionMember, UUID publicId) {
+		return publicId != null && matchPredictionMember != null;
+	}
+
+	private Side confirmSide(MatchPredictionMember matchPredictionMember) {
+		if (matchPredictionMember == null) {
+			return null;
+		}
+		return matchPredictionMember.getSide();
 	}
 
 }

--- a/src/main/java/org/myteam/server/match/matchPrediction/service/MatchPredictionService.java
+++ b/src/main/java/org/myteam/server/match/matchPrediction/service/MatchPredictionService.java
@@ -1,7 +1,14 @@
 package org.myteam.server.match.matchPrediction.service;
 
+import java.util.UUID;
+
 import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
 import org.myteam.server.match.matchPrediction.dto.service.request.MatchPredictionServiceRequest;
+import org.myteam.server.match.matchPrediction.dto.service.request.Side;
+import org.myteam.server.match.matchPredictionMember.service.MatchPredictionMemberReadService;
+import org.myteam.server.match.matchPredictionMember.service.MatchPredictionMemberService;
+import org.myteam.server.member.service.SecurityReadService;
+import org.springdoc.core.service.SecurityService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,12 +20,29 @@ import lombok.RequiredArgsConstructor;
 public class MatchPredictionService {
 
 	private final MatchPredictionReadService matchPredictionReadService;
+	private final MatchPredictionMemberService matchPredictionMemberService;
+	private final MatchPredictionMemberReadService matchPredictionMemberReadService;
+	private final SecurityReadService securityReadService;
 
 	public Long update(MatchPredictionServiceRequest matchPredictionServiceRequest) {
-		MatchPrediction prediction = matchPredictionReadService.findByIdLock(
-			matchPredictionServiceRequest.getMatchPredictionId());
-		prediction.addCount(matchPredictionServiceRequest.getSide());
-		return prediction.getId();
+		UUID memberId = securityReadService.getMember().getPublicId();
+
+		Long matchPredictionId = matchPredictionServiceRequest.getMatchPredictionId();
+		Side side = matchPredictionServiceRequest.getSide();
+
+		matchPredictionMemberReadService.confirmExistMember(matchPredictionId, memberId);
+
+		matchPredictionMemberService.save(matchPredictionId, side);
+
+		MatchPrediction matchPrediction = addCount(matchPredictionId, side);
+
+		return matchPrediction.getId();
+	}
+
+	public MatchPrediction addCount(Long matchPredictionId, Side side) {
+		MatchPrediction matchPrediction = matchPredictionReadService.findByIdLock(matchPredictionId);
+		matchPrediction.addCount(side);
+		return matchPrediction;
 	}
 
 }

--- a/src/main/java/org/myteam/server/match/matchPredictionMember/domain/MatchPredictionMember.java
+++ b/src/main/java/org/myteam/server/match/matchPredictionMember/domain/MatchPredictionMember.java
@@ -1,0 +1,53 @@
+package org.myteam.server.match.matchPredictionMember.domain;
+
+import org.myteam.server.global.domain.Base;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
+import org.myteam.server.match.matchPrediction.dto.service.request.Side;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.news.domain.News;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "p_match_prediction_member")
+public class MatchPredictionMember extends Base {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private MatchPrediction matchPrediction;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Member member;
+
+	private Side side;
+
+	@Builder
+	public MatchPredictionMember(Long id, MatchPrediction matchPrediction, Member member, Side side) {
+		this.id = id;
+		this.matchPrediction = matchPrediction;
+		this.member = member;
+		this.side = side;
+	}
+
+	public static MatchPredictionMember createEntity(MatchPrediction matchPrediction, Member member, Side side) {
+		return MatchPredictionMember.builder()
+			.matchPrediction(matchPrediction)
+			.member(member)
+			.side(side)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchPredictionMember/dto/service/response/MatchPredictionMemberDeleteResponse.java
+++ b/src/main/java/org/myteam/server/match/matchPredictionMember/dto/service/response/MatchPredictionMemberDeleteResponse.java
@@ -1,0 +1,28 @@
+package org.myteam.server.match.matchPredictionMember.dto.service.response;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchPredictionMemberDeleteResponse {
+
+	private Long matchPredictionId;
+	private UUID memberId;
+
+	@Builder
+	public MatchPredictionMemberDeleteResponse(Long matchPredictionId, UUID memberId) {
+		this.matchPredictionId = matchPredictionId;
+		this.memberId = memberId;
+	}
+
+	public static MatchPredictionMemberDeleteResponse createResponse(Long matchPredictionId, UUID memberId) {
+		return MatchPredictionMemberDeleteResponse.builder()
+			.matchPredictionId(matchPredictionId)
+			.memberId(memberId)
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchPredictionMember/dto/service/response/MatchPredictionMemberResponse.java
+++ b/src/main/java/org/myteam/server/match/matchPredictionMember/dto/service/response/MatchPredictionMemberResponse.java
@@ -1,0 +1,34 @@
+package org.myteam.server.match.matchPredictionMember.dto.service.response;
+
+import java.util.UUID;
+
+import org.myteam.server.match.matchPredictionMember.domain.MatchPredictionMember;
+import org.myteam.server.news.newsCountMember.domain.NewsCountMember;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MatchPredictionMemberResponse {
+
+	private Long matchPredictionMemberId;
+	private Long matchPredictionId;
+	private UUID memberId;
+
+	@Builder
+	public MatchPredictionMemberResponse(Long matchPredictionMemberId, Long matchPredictionId, UUID memberId) {
+		this.matchPredictionMemberId = matchPredictionMemberId;
+		this.matchPredictionId = matchPredictionId;
+		this.memberId = memberId;
+	}
+
+	public static MatchPredictionMemberResponse createResponse(MatchPredictionMember matchPredictionMember) {
+		return MatchPredictionMemberResponse.builder()
+			.matchPredictionMemberId(matchPredictionMember.getId())
+			.matchPredictionId(matchPredictionMember.getMatchPrediction().getId())
+			.memberId(matchPredictionMember.getMember().getPublicId())
+			.build();
+	}
+}

--- a/src/main/java/org/myteam/server/match/matchPredictionMember/repository/MatchPredictionMemberRepository.java
+++ b/src/main/java/org/myteam/server/match/matchPredictionMember/repository/MatchPredictionMemberRepository.java
@@ -1,0 +1,18 @@
+package org.myteam.server.match.matchPredictionMember.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.myteam.server.match.matchPredictionMember.domain.MatchPredictionMember;
+import org.myteam.server.news.newsCountMember.domain.NewsCountMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MatchPredictionMemberRepository extends JpaRepository<MatchPredictionMember, Long> {
+
+	Optional<MatchPredictionMember> findByMatchPredictionIdAndMemberPublicId(Long matchPredictionId, UUID memberId);
+
+	void deleteByMatchPredictionIdAndMemberPublicId(Long matchPredictionId, UUID memberId);
+
+}

--- a/src/main/java/org/myteam/server/match/matchPredictionMember/service/MatchPredictionMemberReadService.java
+++ b/src/main/java/org/myteam/server/match/matchPredictionMember/service/MatchPredictionMemberReadService.java
@@ -1,0 +1,33 @@
+package org.myteam.server.match.matchPredictionMember.service;
+
+import java.util.UUID;
+
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.match.matchPredictionMember.domain.MatchPredictionMember;
+import org.myteam.server.match.matchPredictionMember.repository.MatchPredictionMemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MatchPredictionMemberReadService {
+
+	private final MatchPredictionMemberRepository matchPredictionMemberRepository;
+
+	public void confirmExistMember(Long newsId, UUID memberId) {
+		matchPredictionMemberRepository.findByMatchPredictionIdAndMemberPublicId(newsId, memberId)
+			.ifPresent(matchPredictionMember -> {
+				throw new PlayHiveException(ErrorCode.ALREADY_MEMBER_MATCH_PREDICTION);
+			});
+	}
+
+	public MatchPredictionMember confirmPredictionMember(Long matchPredictionId, UUID memberId) {
+		return matchPredictionMemberRepository.findByMatchPredictionIdAndMemberPublicId(matchPredictionId, memberId)
+			.orElse(null);
+	}
+
+}

--- a/src/main/java/org/myteam/server/match/matchPredictionMember/service/MatchPredictionMemberService.java
+++ b/src/main/java/org/myteam/server/match/matchPredictionMember/service/MatchPredictionMemberService.java
@@ -1,0 +1,43 @@
+package org.myteam.server.match.matchPredictionMember.service;
+
+import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
+import org.myteam.server.match.matchPrediction.dto.service.request.Side;
+import org.myteam.server.match.matchPrediction.service.MatchPredictionReadService;
+import org.myteam.server.match.matchPredictionMember.domain.MatchPredictionMember;
+import org.myteam.server.match.matchPredictionMember.dto.service.response.MatchPredictionMemberDeleteResponse;
+import org.myteam.server.match.matchPredictionMember.dto.service.response.MatchPredictionMemberResponse;
+import org.myteam.server.match.matchPredictionMember.repository.MatchPredictionMemberRepository;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.service.SecurityReadService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MatchPredictionMemberService {
+
+	private final MatchPredictionMemberRepository matchPredictionMemberRepository;
+	private final SecurityReadService securityReadService;
+	private final MatchPredictionReadService matchPredictionReadService;
+
+	public MatchPredictionMemberResponse save(Long matchPredictionId, Side side) {
+		Member member = securityReadService.getMember();
+		MatchPrediction matchPrediction = matchPredictionReadService.findById(matchPredictionId);
+		return MatchPredictionMemberResponse.createResponse(
+			matchPredictionMemberRepository.save(MatchPredictionMember.createEntity(matchPrediction, member, side))
+		);
+	}
+
+	public MatchPredictionMemberDeleteResponse deleteByMatchPredictionIdMemberId(Long matchPredictionId) {
+		Member member = securityReadService.getMember();
+		MatchPrediction matchPrediction = matchPredictionReadService.findById(matchPredictionId);
+
+		matchPredictionMemberRepository.deleteByMatchPredictionIdAndMemberPublicId(matchPrediction.getId(),
+			member.getPublicId());
+		return MatchPredictionMemberDeleteResponse.createResponse(matchPrediction.getId(), member.getPublicId());
+	}
+
+}

--- a/src/test/java/org/myteam/server/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/IntegrationTestSupport.java
@@ -39,6 +39,8 @@ import org.myteam.server.match.match.domain.MatchCategory;
 import org.myteam.server.match.match.repository.MatchRepository;
 import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
 import org.myteam.server.match.matchPrediction.repository.MatchPredictionRepository;
+import org.myteam.server.match.matchPredictionMember.domain.MatchPredictionMember;
+import org.myteam.server.match.matchPredictionMember.repository.MatchPredictionMemberRepository;
 import org.myteam.server.match.team.domain.Team;
 import org.myteam.server.match.team.domain.TeamCategory;
 import org.myteam.server.match.team.repository.TeamRepository;
@@ -117,6 +119,8 @@ public abstract class IntegrationTestSupport {
 	protected ImprovementCountRepository improvementCountRepository;
 	@Autowired
 	protected CommentRepository commentRepository;
+	@Autowired
+	protected MatchPredictionMemberRepository matchPredictionMemberRepository;
 
 	/**
 	 * ================== Service ========================
@@ -166,6 +170,7 @@ public abstract class IntegrationTestSupport {
 
 	@AfterEach
 	void tearDown() {
+		matchPredictionMemberRepository.deleteAllInBatch();
 		commentRepository.deleteAllInBatch();
 		matchPredictionRepository.deleteAllInBatch();
 		matchRepository.deleteAllInBatch();
@@ -412,5 +417,14 @@ public abstract class IntegrationTestSupport {
 		improvementCountRepository.save(improvementCount);
 
 		return improvement;
+	}
+
+	protected MatchPredictionMember createMatchPredictionMember(Member member, MatchPrediction matchPrediction) {
+		return matchPredictionMemberRepository.save(
+			MatchPredictionMember.builder()
+				.matchPrediction(matchPrediction)
+				.member(member)
+				.build()
+		);
 	}
 }

--- a/src/test/java/org/myteam/server/match/matchPrediction/service/MatchPredictionReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/matchPrediction/service/MatchPredictionReadServiceTest.java
@@ -1,6 +1,7 @@
 package org.myteam.server.match.matchPrediction.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
 

--- a/src/test/java/org/myteam/server/match/matchPrediction/service/MatchPredictionServiceTest.java
+++ b/src/test/java/org/myteam/server/match/matchPrediction/service/MatchPredictionServiceTest.java
@@ -1,6 +1,7 @@
 package org.myteam.server.match.matchPrediction.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
 import java.util.concurrent.CountDownLatch;
@@ -18,6 +19,7 @@ import org.myteam.server.match.matchPrediction.dto.service.request.MatchPredicti
 import org.myteam.server.match.matchPrediction.dto.service.request.Side;
 import org.myteam.server.match.team.domain.Team;
 import org.myteam.server.match.team.domain.TeamCategory;
+import org.myteam.server.member.entity.Member;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class MatchPredictionServiceTest extends IntegrationTestSupport {
@@ -70,12 +72,7 @@ class MatchPredictionServiceTest extends IntegrationTestSupport {
 		for (int i = 0; i < threadCount; i++) {
 			executorService.execute(() -> {
 				try {
-					MatchPredictionServiceRequest request = MatchPredictionServiceRequest.builder()
-						.matchPredictionId(matchPrediction.getId())
-						.side(Side.HOME)
-						.build();
-
-					matchPredictionService.update(request);
+					matchPredictionService.addCount(matchPrediction.getId(), Side.HOME);
 				} finally {
 					countDownLatch.countDown();
 				}

--- a/src/test/java/org/myteam/server/match/matchPredictionMember/service/MatchPredictionMemberReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/matchPredictionMember/service/MatchPredictionMemberReadServiceTest.java
@@ -1,0 +1,47 @@
+package org.myteam.server.match.matchPredictionMember.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.global.domain.Category;
+import org.myteam.server.global.exception.ErrorCode;
+import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.match.match.domain.Match;
+import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
+import org.myteam.server.match.team.domain.Team;
+import org.myteam.server.match.team.domain.TeamCategory;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.news.domain.News;
+import org.myteam.server.news.newsCountMember.service.NewsCountMemberReadService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class MatchPredictionMemberReadServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private MatchPredictionMemberReadService matchPredictionMemberReadService;
+
+	@DisplayName("이미 좋아요를 누른 뉴스면 예외가 발생한다.")
+	@Test
+	void confirmExistMemberTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+		MatchPrediction matchPrediction = createMatchPrediction(match, 1, 2);
+
+		Member member = createMember(1);
+
+		createMatchPredictionMember(member, matchPrediction);
+
+		assertThatThrownBy(() -> matchPredictionMemberReadService.confirmExistMember(matchPrediction.getId(), member.getPublicId()))
+			.isInstanceOf(PlayHiveException.class)
+			.hasMessage(ErrorCode.ALREADY_MEMBER_MATCH_PREDICTION.getMsg());
+
+	}
+
+}

--- a/src/test/java/org/myteam/server/match/matchPredictionMember/service/MatchPredictionMemberServiceTest.java
+++ b/src/test/java/org/myteam/server/match/matchPredictionMember/service/MatchPredictionMemberServiceTest.java
@@ -1,0 +1,67 @@
+package org.myteam.server.match.matchPredictionMember.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.IntegrationTestSupport;
+import org.myteam.server.global.domain.Category;
+import org.myteam.server.match.match.domain.Match;
+import org.myteam.server.match.match.domain.MatchCategory;
+import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
+import org.myteam.server.match.matchPrediction.dto.service.request.Side;
+import org.myteam.server.match.matchPredictionMember.domain.MatchPredictionMember;
+import org.myteam.server.match.team.domain.Team;
+import org.myteam.server.match.team.domain.TeamCategory;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.news.domain.News;
+import org.myteam.server.news.newsCountMember.domain.NewsCountMember;
+import org.myteam.server.news.newsCountMember.service.NewsCountMemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class MatchPredictionMemberServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private MatchPredictionMemberService matchPredictionMemberService;
+
+	@DisplayName("사용자 추천 데이터를 추가한다.")
+	@Test
+	void saveTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+		MatchPrediction matchPrediction = createMatchPrediction(match, 1, 2);
+
+		Member member = createMember(1);
+
+		matchPredictionMemberService.save(matchPrediction.getId(), Side.HOME);
+
+		assertThat(matchPredictionMemberRepository.findByMatchPredictionIdAndMemberPublicId(matchPrediction.getId(), member.getPublicId()).get())
+			.extracting("matchPrediction.id", "member.publicId")
+			.contains(matchPrediction.getId(), member.getPublicId());
+	}
+
+	@DisplayName("사용자 추천 데이터를 삭제한다.")
+	@Test
+	void deleteByNewsIdMemberIdTest() {
+		Team team1 = createTeam(1, TeamCategory.FOOTBALL);
+		Team team2 = createTeam(2, TeamCategory.FOOTBALL);
+
+		Match match = createMatch(team1, team2, MatchCategory.FOOTBALL, LocalDate.now().atStartOfDay());
+		MatchPrediction matchPrediction = createMatchPrediction(match, 1, 2);
+
+		Member member = createMember(1);
+
+		MatchPredictionMember matchPredictionMember = createMatchPredictionMember(member, matchPrediction);
+
+		matchPredictionMemberService.deleteByMatchPredictionIdMemberId(matchPrediction.getId());
+
+		assertThatThrownBy(() -> matchPredictionMemberRepository.findById(matchPredictionMember.getId()).get())
+			.isInstanceOf(NoSuchElementException.class)
+			.hasMessage("No value present");
+	}
+}


### PR DESCRIPTION
## 기능 설명
- 경기예측시 사용자가 어디에 경기예측을 걸었는지 저장하도록 추가
- 경기예측 조회시 로그인한 사용자가 투표했는지 여부도 내려주도록 추가
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
