### PR TITLE
fix: 만료된 accesstoken도 사용자정보 가져올수있는 메소드 추가

### DIFF
--- a/src/main/java/org/myteam/server/auth/service/TokenService.java
+++ b/src/main/java/org/myteam/server/auth/service/TokenService.java
@@ -33,7 +33,7 @@ public class TokenService {
 		String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
 		String accessToken = jwtProvider.getAccessToken(authorizationHeader);
 
-		UUID publicId = jwtProvider.getPublicId(accessToken);
+		UUID publicId = jwtProvider.getPublicIdWithoutExpired(accessToken);
 
 		String refreshToken = redisService.getRefreshToken(publicId);
 		// 리프레시 토큰 검증

--- a/src/main/java/org/myteam/server/global/security/jwt/JwtProvider.java
+++ b/src/main/java/org/myteam/server/global/security/jwt/JwtProvider.java
@@ -108,6 +108,12 @@ public class JwtProvider {
         return UUID.fromString(idString);
     }
 
+    public UUID getPublicIdWithoutExpired(final String token) {
+        Claims claims = getClaimsWithoutExpirationCheck(token);
+        String idString = claims.get("id", String.class);
+        return UUID.fromString(idString);
+    }
+
     /**
      * 토큰으로부터 사용자 권한(Authorities)을 추출
      *
@@ -139,6 +145,20 @@ public class JwtProvider {
     private Claims getClaims(String token) {
         Jws<Claims> claimsJws = Jwts.parser().verifyWith(getSigningKey()).build().parseSignedClaims(token);
         return claimsJws.getPayload();
+    }
+
+    public Claims getClaimsWithoutExpirationCheck(String token) {
+        try {
+            // 기본적으로 만료도 체크됨
+            Jws<Claims> claimsJws = Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token);
+            return claimsJws.getPayload();
+        } catch (ExpiredJwtException e) {
+            // 만료된 토큰이어도 Claims는 여기서 꺼낼 수 있음
+            return e.getClaims();
+        }
     }
 
     /**


### PR DESCRIPTION
## 기능 설명
- 재발급시 만료된 accesstoken도 사용자정보 가져올수있는 메소드 추가
## 작업 내용
- 
## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
