### PR TITLE
fix: 상세 조회 API 호출인 경우 openGraph true로 청하면 카운트 안되도록 수정

### DIFF
--- a/src/main/java/org/myteam/server/aop/CommonCountAspect.java
+++ b/src/main/java/org/myteam/server/aop/CommonCountAspect.java
@@ -1,18 +1,15 @@
 package org.myteam.server.aop;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
-import org.myteam.server.global.util.redis.CommonCountDto;
 import org.myteam.server.global.util.redis.RedisCountService;
 import org.myteam.server.global.util.redis.ServiceType;
-import org.myteam.server.report.domain.DomainType;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Aspect
 @Component
@@ -36,8 +33,11 @@ public class CommonCountAspect {
     @Around("@annotation(countView)")
     public Object handleCommonCount(ProceedingJoinPoint joinPoint, CountView countView) throws Throwable {
         String userAgent = request.getHeader("User-Agent");
-        boolean isBot = userAgent != null && BOT_AGENTS.stream()
-                .anyMatch(bot -> userAgent.toLowerCase().contains(bot.toLowerCase()));
+        String openGraphParam = request.getParameter("openGraph");
+
+        boolean isBot = (userAgent != null && BOT_AGENTS.stream()
+                .anyMatch(bot -> userAgent.toLowerCase().contains(bot.toLowerCase())))
+                || ("true".equalsIgnoreCase(openGraphParam));
 
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         String[] paramNames = signature.getParameterNames();

--- a/src/main/java/org/myteam/server/news/news/controller/NewsController.java
+++ b/src/main/java/org/myteam/server/news/news/controller/NewsController.java
@@ -11,7 +11,6 @@ import org.myteam.server.news.news.dto.controller.request.NewsRequest;
 import org.myteam.server.news.news.dto.service.response.NewsListResponse;
 import org.myteam.server.news.news.dto.service.response.NewsResponse;
 import org.myteam.server.news.news.service.NewsReadService;
-import org.myteam.server.news.newsCount.service.NewsCountService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;


### PR DESCRIPTION
## 기능 설명
- 
## 작업 내용
- 프론트측에서 메타 데이터 때문에 상세 요청 API를 2번 호출하게 되면서 생기는 카운트 증가 문제를 해결했습니다.
- API 요청 시 요청 파라미터에 'openGraph'를 'true'로 요청하면 AOP에서 봇과 oepnGraph이 'true'인 경우는 카운트 증가를 하지 않습니다!

## 수정 사항
- 
## 추가 작업 예정
- 
## 테스트
- [ ] 단위 테스트 확인(포스트맨 등..)
- [ ] 통합 테스트 확인(서버 빌드되는지 확인)
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 or Swagger 확인
