### PR TITLE
refac: Redisson 제거

### DIFF
--- a/src/main/java/org/myteam/server/board/service/BoardService.java
+++ b/src/main/java/org/myteam/server/board/service/BoardService.java
@@ -19,8 +19,8 @@ import org.myteam.server.global.domain.Category;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.util.redis.CommonCountDto;
-import org.myteam.server.global.util.redis.service.RedisCountService;
 import org.myteam.server.global.util.redis.ServiceType;
+import org.myteam.server.global.util.redis.service.RedisCountService;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.member.service.SecurityReadService;
@@ -182,7 +182,7 @@ public class BoardService {
         commentService.deleteCommentByPost(CommentType.BOARD, boardId);
         //게시글 추천 삭제
         boardRecommendRepository.deleteAllByBoardId(board.getId());
-        // 조회수 삭제
+        // Redis 카운트 삭제
         redisCountService.removeCount(DomainType.BOARD, boardId);
         // 게시글 카운트 삭제
         boardCountRepository.deleteByBoardId(board.getId());

--- a/src/main/java/org/myteam/server/global/util/redis/RedisCountBulkUpdater.java
+++ b/src/main/java/org/myteam/server/global/util/redis/RedisCountBulkUpdater.java
@@ -23,7 +23,6 @@ public class RedisCountBulkUpdater {
     }
 
     /**
-     * TODO: println 지우기
      * Redis에 저장된 count 정보 → DB로 벌크 업데이트
      */
     public void bulkUpdate(DomainType type) {

--- a/src/main/java/org/myteam/server/recommend/RecommendService.java
+++ b/src/main/java/org/myteam/server/recommend/RecommendService.java
@@ -40,7 +40,15 @@ public class RecommendService {
         Long updateCount;
 
         if (actionType == RecommendActionType.RECOMMEND) {
+
+            // Redis Set은 중복을 허용하지 않음.
+            // 그래서 userId가 이미 Set안에 존재하면 add()는 아무것도 하지 않고 0을 반환한다.
+
+            // added == 0 -> userId가 이미 존재 (이미 추천함)
+            // added == null -> 비정상 상황(Redis 문제 등...)
+            // added == 1 -> userId가 처음 추가 됨 (추천 성공)
             Long added = redisTemplate.opsForSet().add(recommendSetKey, userId);
+
             if (added == null || added == 0) {
                 throw new PlayHiveException(ErrorCode.ALREADY_MEMBER_RECOMMEND);
             }

--- a/src/main/java/org/myteam/server/recommend/RecommendService.java
+++ b/src/main/java/org/myteam/server/recommend/RecommendService.java
@@ -3,7 +3,6 @@ package org.myteam.server.recommend;
 import static org.myteam.server.util.ClientUtils.toInt;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.global.exception.ErrorCode;
@@ -12,8 +11,7 @@ import org.myteam.server.global.util.redis.CommonCountDto;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.SecurityReadService;
 import org.myteam.server.report.domain.DomainType;
-import org.redisson.api.RLock;
-import org.redisson.api.RedissonClient;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +20,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RecommendService {
     private final List<RecommendHandler> handlers;
-    private final RedissonClient redissonClient;
     private final RedisTemplate<String, Object> redisTemplate;
     private final SecurityReadService securityReadService;
 
@@ -38,55 +35,41 @@ public class RecommendService {
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 콘텐츠 타입"));
 
-        String lockKey = "lock:recommend:" + content + ":" + contentId;
-        RLock lock = redissonClient.getLock(lockKey);
+        String userId = String.valueOf(member.getPublicId());
+        String recommendSetKey = "recommend:users:" + content + ":" + contentId;
+        Long updateCount;
 
-        try {
-            log.info("락 시도");
-            if (!lock.tryLock(3, 10, TimeUnit.SECONDS)) {
-                throw new IllegalStateException("잠시 후 다시 시도해주세요.");
-            }
-
-            boolean already = handler.isAlreadyRecommended(contentId, member.getPublicId());
-
-            if (actionType == RecommendActionType.RECOMMEND && already) {
+        if (actionType == RecommendActionType.RECOMMEND) {
+            Long added = redisTemplate.opsForSet().add(recommendSetKey, userId);
+            if (added == null || added == 0) {
                 throw new PlayHiveException(ErrorCode.ALREADY_MEMBER_RECOMMEND);
             }
 
-            if (actionType == RecommendActionType.CANCEL && !already) {
+            updateCount = redisTemplate.opsForHash().increment(redisKey, "recommend", 1);
+
+            try {
+                handler.saveRecommendation(contentId, member);
+            } catch (DuplicateKeyException e) {
+                log.warn("중복 추천 DB insert 발생 (무시): {}", e.getMessage());
+            }
+
+        } else {
+            Long removed = redisTemplate.opsForSet().remove(recommendSetKey, userId);
+            if (removed == null || removed == 0) {
                 throw new PlayHiveException(ErrorCode.NOT_RECOMMENDED_YET);
             }
 
-            Long updateCount;
-            if (actionType == RecommendActionType.RECOMMEND) {
-                log.info("추천 시도: {}", redisKey);
-                handler.saveRecommendation(contentId, member);
-                updateCount = redisTemplate.opsForHash().increment(redisKey, "recommend", 1);
-                log.info("recommend count: {}", updateCount);
-            } else {
-                log.info("추천 삭제: {}", redisKey);
-                handler.deleteRecommendation(contentId, member.getPublicId());
-                updateCount = redisTemplate.opsForHash().increment(redisKey, "recommend", -1);
-                log.info("recommend count: {}", updateCount);
-            }
-
-            // view/comment 값도 함께 조회하려면 entries() 사용
-            Object view = redisTemplate.opsForHash().get(redisKey, "view");
-            Object comment = redisTemplate.opsForHash().get(redisKey, "comment");
-
-            return new CommonCountDto(
-                    toInt(view),
-                    toInt(comment),
-                    updateCount.intValue()
-            );
-
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("락 인터럽트", e);
-        } finally {
-            if (lock.isHeldByCurrentThread()) {
-                lock.unlock();
-            }
+            updateCount = redisTemplate.opsForHash().increment(redisKey, "recommend", -1);
+            handler.deleteRecommendation(contentId, member.getPublicId());
         }
+
+        Object view = redisTemplate.opsForHash().get(redisKey, "view");
+        Object comment = redisTemplate.opsForHash().get(redisKey, "comment");
+
+        return new CommonCountDto(
+                toInt(view),
+                toInt(comment),
+                updateCount.intValue()
+        );
     }
 }

--- a/src/test/java/org/myteam/server/RedisRedissonTest/RedisAndRedissonRecommendTest.java
+++ b/src/test/java/org/myteam/server/RedisRedissonTest/RedisAndRedissonRecommendTest.java
@@ -128,6 +128,7 @@ public class RedisAndRedissonRecommendTest extends TestContainerSupport {
                 } catch (Exception e) {
                     System.err.println("❗예외 발생: " + e.getMessage());
                 } finally {
+                    SecurityContextHolder.clearContext();
                     latch.countDown();
                 }
             });

--- a/src/test/java/org/myteam/server/RedisRedissonTest/RedisAndRedissonRecommendTest.java
+++ b/src/test/java/org/myteam/server/RedisRedissonTest/RedisAndRedissonRecommendTest.java
@@ -1,0 +1,134 @@
+package org.myteam.server.RedisRedissonTest;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.myteam.server.global.security.dto.CustomUserDetails;
+import org.myteam.server.global.util.redis.service.RedisCountService;
+import org.myteam.server.member.domain.MemberRole;
+import org.myteam.server.member.domain.MemberStatus;
+import org.myteam.server.member.domain.MemberType;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.entity.MemberActivity;
+import org.myteam.server.support.TestContainerSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Redisson을 사용햇을 때와 Redis만 사용했을때 추천 기능의 정합성과 시간을 비교하기 위한 테스트 코드
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+public class RedisAndRedissonRecommendTest extends TestContainerSupport {
+    @Autowired
+    private RedisCountService redisCountService;
+
+    private Member member;
+
+    @BeforeEach
+    public void setUp() {
+        member = Member.builder()
+                .email("test@test.com")
+                .password("1234")
+                .tel("12345")
+                .nickname("test")
+                .role(MemberRole.USER)
+                .type(MemberType.LOCAL)
+                .publicId(UUID.randomUUID())
+                .status(MemberStatus.ACTIVE)
+                .build();
+
+        memberJpaRepository.save(member);
+        MemberActivity memberActivity = new MemberActivity(member);
+        memberActivityRepository.save(memberActivity);
+
+        SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL);
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                new CustomUserDetails(member),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        ));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        commentRepository.deleteAllInBatch();
+        boardRecommendRepository.deleteAllInBatch();
+        boardCountRepository.deleteAllInBatch();
+        boardRepository.deleteAllInBatch();
+    }
+//
+//    @DisplayName("여러 회원이 동시에 추천을 눌렀을 때 정합성을 보장한다.")
+//    @Test
+//    void multiMemberConcurrentRecommendTest() throws InterruptedException {
+//        // given
+//        Board board = createBoard(member, Category.BASEBALL, CategoryType.FREE, "야구 카테고리 제목", "야구 카테고리 내용");
+//
+//        int threadCount = 100;
+//        ExecutorService executor = Executors.newFixedThreadPool(10);
+//        CountDownLatch latch = new CountDownLatch(threadCount);
+//        StopWatch stopWatch = new StopWatch();
+//
+//        List<Member> members = new ArrayList<>();
+//        for (int i = 0; i < threadCount; i++) {
+//            Member newMember = Member.builder()
+//                    .email("user" + i + "@test.com")
+//                    .password("1234")
+//                    .tel("010123456" + i)
+//                    .nickname("user" + i)
+//                    .role(MemberRole.USER)
+//                    .type(MemberType.LOCAL)
+//                    .publicId(UUID.randomUUID())
+//                    .status(MemberStatus.ACTIVE)
+//                    .build();
+//            memberJpaRepository.save(newMember);
+//            memberActivityRepository.save(new MemberActivity(newMember));
+//            members.add(newMember);
+//        }
+//
+//        stopWatch.start();
+//
+//        // when
+//        for (Member m : members) {
+//            executor.execute(() -> {
+//                try {
+//                    // 각 스레드마다 고유한 인증 정보 설정
+//                    SecurityContext context = SecurityContextHolder.createEmptyContext();
+//                    context.setAuthentication(new UsernamePasswordAuthenticationToken(
+//                            new CustomUserDetails(m),
+//                            null,
+//                            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+//                    ));
+//                    SecurityContextHolder.setContext(context);
+//
+//                    redisCountService.getCommonCount(ServiceType.RECOMMEND, DomainType.BOARD, board.getId(), null);
+//                } catch (Exception e) {
+//                    System.err.println("❗예외 발생: " + e.getMessage());
+//                } finally {
+//                    latch.countDown();
+//                }
+//            });
+//        }
+//
+//        latch.await();
+//        stopWatch.stop();
+//
+//        // then
+//        CommonCountDto result = redisCountService.getCommonCount(ServiceType.CHECK, DomainType.BOARD, board.getId(),
+//                null);
+//
+//        System.out.println("✅ 최종 추천 수: " + result.getRecommendCount());
+//        System.out.println("⏱ 총 걸린 시간(ms): " + stopWatch.getTotalTimeMillis());
+//
+//        Assertions.assertThat(result.getRecommendCount()).isEqualTo(threadCount);
+//    }
+}

--- a/src/test/java/org/myteam/server/RedisRedissonTest/RedisAndRedissonRecommendTest.java
+++ b/src/test/java/org/myteam/server/RedisRedissonTest/RedisAndRedissonRecommendTest.java
@@ -1,16 +1,29 @@
 package org.myteam.server.RedisRedissonTest;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.board.domain.Board;
+import org.myteam.server.board.domain.CategoryType;
+import org.myteam.server.global.domain.Category;
 import org.myteam.server.global.security.dto.CustomUserDetails;
+import org.myteam.server.global.util.redis.CommonCountDto;
+import org.myteam.server.global.util.redis.ServiceType;
 import org.myteam.server.global.util.redis.service.RedisCountService;
 import org.myteam.server.member.domain.MemberRole;
 import org.myteam.server.member.domain.MemberStatus;
 import org.myteam.server.member.domain.MemberType;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.entity.MemberActivity;
+import org.myteam.server.report.domain.DomainType;
 import org.myteam.server.support.TestContainerSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,6 +32,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StopWatch;
 
 /**
  * Redisson을 사용햇을 때와 Redis만 사용했을때 추천 기능의 정합성과 시간을 비교하기 위한 테스트 코드
@@ -66,69 +80,69 @@ public class RedisAndRedissonRecommendTest extends TestContainerSupport {
         boardCountRepository.deleteAllInBatch();
         boardRepository.deleteAllInBatch();
     }
-//
-//    @DisplayName("여러 회원이 동시에 추천을 눌렀을 때 정합성을 보장한다.")
-//    @Test
-//    void multiMemberConcurrentRecommendTest() throws InterruptedException {
-//        // given
-//        Board board = createBoard(member, Category.BASEBALL, CategoryType.FREE, "야구 카테고리 제목", "야구 카테고리 내용");
-//
-//        int threadCount = 100;
-//        ExecutorService executor = Executors.newFixedThreadPool(10);
-//        CountDownLatch latch = new CountDownLatch(threadCount);
-//        StopWatch stopWatch = new StopWatch();
-//
-//        List<Member> members = new ArrayList<>();
-//        for (int i = 0; i < threadCount; i++) {
-//            Member newMember = Member.builder()
-//                    .email("user" + i + "@test.com")
-//                    .password("1234")
-//                    .tel("010123456" + i)
-//                    .nickname("user" + i)
-//                    .role(MemberRole.USER)
-//                    .type(MemberType.LOCAL)
-//                    .publicId(UUID.randomUUID())
-//                    .status(MemberStatus.ACTIVE)
-//                    .build();
-//            memberJpaRepository.save(newMember);
-//            memberActivityRepository.save(new MemberActivity(newMember));
-//            members.add(newMember);
-//        }
-//
-//        stopWatch.start();
-//
-//        // when
-//        for (Member m : members) {
-//            executor.execute(() -> {
-//                try {
-//                    // 각 스레드마다 고유한 인증 정보 설정
-//                    SecurityContext context = SecurityContextHolder.createEmptyContext();
-//                    context.setAuthentication(new UsernamePasswordAuthenticationToken(
-//                            new CustomUserDetails(m),
-//                            null,
-//                            List.of(new SimpleGrantedAuthority("ROLE_USER"))
-//                    ));
-//                    SecurityContextHolder.setContext(context);
-//
-//                    redisCountService.getCommonCount(ServiceType.RECOMMEND, DomainType.BOARD, board.getId(), null);
-//                } catch (Exception e) {
-//                    System.err.println("❗예외 발생: " + e.getMessage());
-//                } finally {
-//                    latch.countDown();
-//                }
-//            });
-//        }
-//
-//        latch.await();
-//        stopWatch.stop();
-//
-//        // then
-//        CommonCountDto result = redisCountService.getCommonCount(ServiceType.CHECK, DomainType.BOARD, board.getId(),
-//                null);
-//
-//        System.out.println("✅ 최종 추천 수: " + result.getRecommendCount());
-//        System.out.println("⏱ 총 걸린 시간(ms): " + stopWatch.getTotalTimeMillis());
-//
-//        Assertions.assertThat(result.getRecommendCount()).isEqualTo(threadCount);
-//    }
+
+    @DisplayName("여러 회원이 동시에 추천을 눌렀을 때 정합성을 보장한다.")
+    @Test
+    void multiMemberConcurrentRecommendTest() throws InterruptedException {
+        // given
+        Board board = createBoard(member, Category.BASEBALL, CategoryType.FREE, "야구 카테고리 제목", "야구 카테고리 내용");
+
+        int threadCount = 100;
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        StopWatch stopWatch = new StopWatch();
+
+        List<Member> members = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            Member newMember = Member.builder()
+                    .email("user" + i + "@test.com")
+                    .password("1234")
+                    .tel("010123456" + i)
+                    .nickname("user" + i)
+                    .role(MemberRole.USER)
+                    .type(MemberType.LOCAL)
+                    .publicId(UUID.randomUUID())
+                    .status(MemberStatus.ACTIVE)
+                    .build();
+            memberJpaRepository.save(newMember);
+            memberActivityRepository.save(new MemberActivity(newMember));
+            members.add(newMember);
+        }
+
+        stopWatch.start();
+
+        // when
+        for (Member m : members) {
+            executor.execute(() -> {
+                try {
+                    // 각 스레드마다 고유한 인증 정보 설정
+                    SecurityContext context = SecurityContextHolder.createEmptyContext();
+                    context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                            new CustomUserDetails(m),
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                    ));
+                    SecurityContextHolder.setContext(context);
+
+                    redisCountService.getCommonCount(ServiceType.RECOMMEND, DomainType.BOARD, board.getId(), null);
+                } catch (Exception e) {
+                    System.err.println("❗예외 발생: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        stopWatch.stop();
+
+        // then
+        CommonCountDto result = redisCountService.getCommonCount(ServiceType.CHECK, DomainType.BOARD, board.getId(),
+                null);
+
+        System.out.println("✅ 최종 추천 수: " + result.getRecommendCount());
+        System.out.println("⏱ 총 걸린 시간(ms): " + stopWatch.getTotalTimeMillis());
+
+        Assertions.assertThat(result.getRecommendCount()).isEqualTo(threadCount);
+    }
 }

--- a/src/test/java/org/myteam/server/board/service/BoardCountServiceIntegrationTest.java
+++ b/src/test/java/org/myteam/server/board/service/BoardCountServiceIntegrationTest.java
@@ -32,6 +32,7 @@ import org.myteam.server.member.entity.MemberActivity;
 import org.myteam.server.report.domain.DomainType;
 import org.myteam.server.support.TestContainerSupport;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -42,11 +43,16 @@ public class BoardCountServiceIntegrationTest extends TestContainerSupport {
 
     @Autowired
     private RedisCountService redisCountService;
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
 
     private Member member;
 
     @BeforeEach
     public void setUp() {
+        // Redis Key 초기화
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
+
         commentRepository.deleteAllInBatch();
         boardRecommendRepository.deleteAllInBatch();
         boardCountRepository.deleteAllInBatch();
@@ -397,6 +403,7 @@ public class BoardCountServiceIntegrationTest extends TestContainerSupport {
 
                     commentService.addComment(board.getId(), commentSaveRequest, "0.0.0.1");
                 } finally {
+                    SecurityContextHolder.clearContext();
                     countDownLatch.countDown();
                 }
             });
@@ -490,6 +497,7 @@ public class BoardCountServiceIntegrationTest extends TestContainerSupport {
                             commentSaveRequest, "0.0.0.1");
                     commentMap.put(idx, comment.getCommentId());
                 } finally {
+                    SecurityContextHolder.clearContext();
                     commentLatch.countDown();
                 }
             });
@@ -515,6 +523,7 @@ public class BoardCountServiceIntegrationTest extends TestContainerSupport {
                     System.out.println("commentMap.get(idx) = " + commentMap.get(idx));
                     commentService.deleteComment(board.getId(), commentMap.get(idx), deleteRequest);
                 } finally {
+                    SecurityContextHolder.clearContext();
                     deleteLatch.countDown();
                 }
             });

--- a/src/test/java/org/myteam/server/board/service/BoardCountServiceIntegrationTest.java
+++ b/src/test/java/org/myteam/server/board/service/BoardCountServiceIntegrationTest.java
@@ -127,7 +127,7 @@ public class BoardCountServiceIntegrationTest extends TestContainerSupport {
         CountDownLatch countDownLatch = new CountDownLatch(threadCount);
 
         Member mainMember = Member.builder()
-                .email("main@test.com")
+                .email("TTEESSTT@test.com")
                 .password("1234")
                 .tel("01000000000")
                 .nickname("main")
@@ -169,6 +169,7 @@ public class BoardCountServiceIntegrationTest extends TestContainerSupport {
                             .publicId(UUID.randomUUID())
                             .build();
                     memberJpaRepository.save(threadMember);
+                    memberActivityRepository.save(new MemberActivity(threadMember));
 
                     // ✅ 인증 정보 설정
                     SecurityContext context = SecurityContextHolder.createEmptyContext();

--- a/src/test/java/org/myteam/server/news/newsCount/service/NewsCountServiceTest.java
+++ b/src/test/java/org/myteam/server/news/newsCount/service/NewsCountServiceTest.java
@@ -34,6 +34,7 @@ import org.myteam.server.news.news.domain.News;
 import org.myteam.server.news.newsCount.domain.NewsCount;
 import org.myteam.server.report.domain.DomainType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -46,11 +47,16 @@ public class NewsCountServiceTest extends TestContainerSupport {
     private RedisCountService redisCountService;
     @Autowired
     private NewsCountService newsCountService;
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
 
     private Member member;
 
     @BeforeEach
     public void setUp() {
+        // Redis Key 초기화
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
+
         member = Member.builder()
                 .email("test@test.com")
                 .password("1234")
@@ -128,7 +134,6 @@ public class NewsCountServiceTest extends TestContainerSupport {
         int threadCount = 50;
 
         ExecutorService executorService = Executors.newFixedThreadPool(25);
-
         CountDownLatch countDownLatch = new CountDownLatch(threadCount);
 
         News news = News.builder()
@@ -348,6 +353,7 @@ public class NewsCountServiceTest extends TestContainerSupport {
 
                     commentService.addComment(news.getId(), commentSaveRequest, "0.0.0.1");
                 } finally {
+                    SecurityContextHolder.clearContext();
                     countDownLatch.countDown();
                 }
             });


### PR DESCRIPTION
## 기능 설명
- 
### 작업 내용

**추천 중복 방지 로직 정비**

Redis Set 자료구조를 이용해 추천 중복을 방지합니다.

Key 형식: recommend:users:{콘텐츠타입}:{콘텐츠ID}

추천 시, 해당 Set에 사용자 ID를 추가하고, 이미 존재할 경우 예외를 발생시킵니다.
추천 취소 시, 사용자 ID를 Set에서 제거하고 Hash의 추천 수를 -1 처리합니다.

**게시글 삭제 시 캐시 정리 기능 추가**
게시글 삭제와 동시에 관련 Redis 캐시(Key) 를 명시적으로 삭제합니다.

삭제 대상:
조회수/댓글수/추천수를 담고 있는 Hash: count:{content Type}:{contentId}
추천자 목록을 담고 있는 Set: recommend:users:{content Type}}:{contentId}

비교 Test 코드는 계속 실행될 필요가 없어보여 주석처리 했습니다!

**테스트코드**
100명의 서로 다른 유저가 동시에 추천 요청
결과 측정: 최종 추천 수가 100인지 확인 -> 둘다 추천수 100
전체 처리 시간 측정: Redisson 사용할때 1881 ms -> Redisson 제거 후 733ms

## 수정 사항
- 
## 추가 작업 예정
- 
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인