### PR TITLE
feat:관리자 로그인  시도횟수 제한 및 계정 정지 추가

### DIFF
--- a/src/main/java/org/myteam/server/global/security/dto/AdminBanEvent.java
+++ b/src/main/java/org/myteam/server/global/security/dto/AdminBanEvent.java
@@ -1,0 +1,14 @@
+package org.myteam.server.global.security.dto;
+
+
+import lombok.Getter;
+
+@Getter
+public class AdminBanEvent {
+    private String email;
+
+
+    public AdminBanEvent(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/org/myteam/server/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/myteam/server/global/security/filter/JwtAuthenticationFilter.java
@@ -164,11 +164,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 	protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException failed) throws IOException{
 
-
 		if(request.getRequestURI().equals("/api/admin/login")){
-			if(failed.getClass().isAssignableFrom(BadCredentialsException.class)){
+			if(failed.getClass().getSimpleName().equals("BadCredentialsException")){
 				String username=(String) request.getAttribute("username");
-				if(redisService.isAllowed("LOGIN_ADMIN",username)){
+				if(redisService.isAdminLoginAllowed("LOGIN_ADMIN",username)){
 
 					int count=redisService.getRequestCount("LOGIN_ADMIN",username);
 					sendErrorResponse(response,HttpStatus.UNAUTHORIZED,
@@ -182,6 +181,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 				sendErrorResponse(response,HttpStatus.UNAUTHORIZED,"잠긴 계정입니다.");
 				return;
 			}
+
 		}
 
 
@@ -191,7 +191,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 		log.debug("message : {}", message);
 		System.out.println("fail authentication");
 	}
-
 	/**
 	 * 공통 에러 응답 처리 메서드
 	 *

--- a/src/main/java/org/myteam/server/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/myteam/server/global/security/filter/JwtAuthenticationFilter.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import org.myteam.server.chat.info.domain.UserInfo;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
+import org.myteam.server.global.security.dto.AdminBanEvent;
 import org.myteam.server.global.security.dto.CustomUserDetails;
 import org.myteam.server.global.security.dto.UserLoginEvent;
 import org.myteam.server.global.security.jwt.JwtProvider;
@@ -21,6 +22,7 @@ import org.myteam.server.global.util.redis.service.RedisUserInfoService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -34,6 +36,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
 
 @Slf4j
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
@@ -48,7 +52,13 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 								   ApplicationEventPublisher eventPublisher,
 								   RedisService redisService,
 								   RedisUserInfoService redisUserInfoService) {
-		setFilterProcessesUrl("/login");
+
+		setRequiresAuthenticationRequestMatcher((
+				new OrRequestMatcher(
+						new AntPathRequestMatcher("/login"),
+						new AntPathRequestMatcher("/api/admin/login")
+				)
+		));
 		this.authenticationManager = authenticationManager;
 		this.jwtProvider = jwtProvider;
 		this.eventPublisher = eventPublisher;
@@ -67,10 +77,11 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 			String username = credentials.get("username");
 			String password = credentials.get("password");
 
+			request.setAttribute("username",username);
+
 			log.info("로그인 요청 - username: {}, password: {}", username, password);
 
-			UsernamePasswordAuthenticationToken authToken =
-				new UsernamePasswordAuthenticationToken(username, password);
+			UsernamePasswordAuthenticationToken authToken=new UsernamePasswordAuthenticationToken(username, password);
 
 			return authenticationManager.authenticate(authToken);
 		} catch (IOException e) {
@@ -125,6 +136,15 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 			log.debug("print refreshToken: {}", refreshToken);
 			log.debug("print role: {}", role);
 
+
+			if(request.getRequestURI().equals("/api/admin/login")){
+
+
+				redisService.resetRequestCount("LOGIN_ADMIN",username);
+
+			}
+
+
 			redisService.putRefreshToken(publicId, refreshToken);
 			redisUserInfoService.saveUserInfo(accessToken,
 					new UserInfo(publicId, customUserDetails.getNickname(), customUserDetails.getImg()));
@@ -142,7 +162,36 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
 	@Override
 	protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException failed) {
+		AuthenticationException failed) throws IOException{
+		if(request.getRequestURI().equals("/api/admin/login")){
+			if(failed.getClass().isAssignableFrom(BadCredentialsException.class)){
+
+				String username=(String) request.getAttribute("username");
+
+				if(redisService.isAllowed("LOGIN_ADMIN",username)){
+					int count=redisService.getRequestCount("LOGIN_ADMIN",username);
+					sendErrorResponse(response,HttpStatus.UNAUTHORIZED,"%s".formatted(String.valueOf(10-count)));
+					return;
+
+				}
+				int count=redisService.getRequestCount("LOGIN_ADMIN",username);
+				if(count>=10){
+
+					eventPublisher.publishEvent(new AdminBanEvent(username));
+
+
+				}
+
+				sendErrorResponse(response,HttpStatus.UNAUTHORIZED,"잠긴 계정입니다.");
+				return;
+
+
+			}
+
+
+		}
+
+
 		String message = failed.getMessage();
 		//로그인 실패시 401 응답 코드 반환
 		response.setStatus(401);

--- a/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
+++ b/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
@@ -2,11 +2,6 @@ package org.myteam.server.global.security.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.myteam.server.common.certification.mail.core.MailStrategy;
-import org.myteam.server.common.certification.mail.domain.EmailType;
-import org.myteam.server.common.certification.mail.factory.MailStrategyFactory;
-import org.myteam.server.common.certification.mail.strategy.NotifySuspendStrategy;
-import org.myteam.server.common.certification.service.CertificationService;
 import org.myteam.server.global.security.dto.AdminBanEvent;
 import org.myteam.server.member.domain.MemberStatus;
 import org.myteam.server.member.domain.MemberType;
@@ -15,7 +10,6 @@ import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.member.service.MemberService;
 import org.springframework.context.event.EventListener;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
+++ b/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
@@ -9,6 +9,7 @@ import org.myteam.server.common.certification.mail.strategy.NotifySuspendStrateg
 import org.myteam.server.common.certification.service.CertificationService;
 import org.myteam.server.global.security.dto.AdminBanEvent;
 import org.myteam.server.member.domain.MemberStatus;
+import org.myteam.server.member.domain.MemberType;
 import org.myteam.server.member.dto.MemberStatusUpdateRequest;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.MemberReadService;
@@ -17,6 +18,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.myteam.server.member.dto.MemberStatusUpdateRequest.*;
 
 @Service
 @Slf4j
@@ -30,23 +33,19 @@ public class AdminBanEventListener {
     @EventListener
     @Transactional
     public void BadAdmin(AdminBanEvent adminBanEvent){
-
-
-        Member member=memberReadService.findByEmail(adminBanEvent.getEmail());
+        Member member=memberReadService.
+                findByEmailAndType(adminBanEvent.getEmail(), MemberType.LOCAL);
 
         if(!member.getStatus().equals(MemberStatus.INACTIVE)) {
 
             log.info("관리자:{} 정지처리",member.getEmail());
-            MemberStatusUpdateRequest memberStatusUpdateRequest = MemberStatusUpdateRequest.builder()
-                    .status(MemberStatus.INACTIVE)
-                    .email(adminBanEvent.getEmail())
-                    .build();
+
+           MemberStatusUpdateRequest memberStatusUpdateRequest=
+                   MemberStatusUpdateRequestBuilder(member.getEmail(),MemberStatus.INACTIVE);
+
             memberService.updateStatus(adminBanEvent.getEmail(), memberStatusUpdateRequest);
 
-
-
         }
-
     }
 
 

--- a/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
+++ b/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
@@ -1,0 +1,54 @@
+package org.myteam.server.global.security.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.myteam.server.common.certification.mail.core.MailStrategy;
+import org.myteam.server.common.certification.mail.domain.EmailType;
+import org.myteam.server.common.certification.mail.factory.MailStrategyFactory;
+import org.myteam.server.common.certification.mail.strategy.NotifySuspendStrategy;
+import org.myteam.server.common.certification.service.CertificationService;
+import org.myteam.server.global.security.dto.AdminBanEvent;
+import org.myteam.server.member.domain.MemberStatus;
+import org.myteam.server.member.dto.MemberStatusUpdateRequest;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.service.MemberReadService;
+import org.myteam.server.member.service.MemberService;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AdminBanEventListener {
+
+    private final MemberService memberService;
+    private final MemberReadService memberReadService;
+
+
+    @EventListener
+    @Transactional
+    public void BadAdmin(AdminBanEvent adminBanEvent){
+
+
+        Member member=memberReadService.findByEmail(adminBanEvent.getEmail());
+
+        if(!member.getStatus().equals(MemberStatus.INACTIVE)) {
+
+            log.info("관리자:{} 정지처리",member.getEmail());
+            MemberStatusUpdateRequest memberStatusUpdateRequest = MemberStatusUpdateRequest.builder()
+                    .status(MemberStatus.INACTIVE)
+                    .email(adminBanEvent.getEmail())
+                    .build();
+            memberService.updateStatus(adminBanEvent.getEmail(), memberStatusUpdateRequest);
+
+
+
+        }
+
+    }
+
+
+
+}

--- a/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
+++ b/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
@@ -41,7 +41,7 @@ public class AdminBanEventListener {
             log.info("관리자:{} 정지처리",member.getEmail());
 
            MemberStatusUpdateRequest memberStatusUpdateRequest=
-                   MemberStatusUpdateRequestBuilder(member.getEmail(),MemberStatus.INACTIVE);
+                   memberStatusUpdateRequestBuilder(member.getEmail(),MemberStatus.INACTIVE);
 
             memberService.updateStatus(adminBanEvent.getEmail(), memberStatusUpdateRequest);
 

--- a/src/main/java/org/myteam/server/global/security/service/CustomUserDetailsService.java
+++ b/src/main/java/org/myteam/server/global/security/service/CustomUserDetailsService.java
@@ -28,6 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         log.info("일반 로그인 CustomUserDetailsService 실행됨");
         log.info("username : {}", username);
+
         Optional<Member> memberOP = userRepository.findByEmailAndType(username, LOCAL);
 
         if (memberOP.isPresent()) {

--- a/src/main/java/org/myteam/server/global/util/redis/service/RedisService.java
+++ b/src/main/java/org/myteam/server/global/util/redis/service/RedisService.java
@@ -38,7 +38,7 @@ public class RedisService { // TODO: RedisReportService 로 변경.
 		String requestCountStr = redisTemplate.opsForValue().get(redisKey);
 		int requestCount = requestCountStr == null ? 0 : Integer.parseInt(requestCountStr);
 
-		if(category.equals("LOGIN_ADMIN") & requestCount>=ADMIN_LOGIN_MAX_REQUESTS){
+		if(category.equals("LOGIN_ADMIN") && requestCount>=ADMIN_LOGIN_MAX_REQUESTS){
 			log.warn("🚫 [RateLimit] 요청 차단 - Key: {}, 요청 횟수: {}", redisKey, requestCount);
 			return false;
 		}

--- a/src/main/java/org/myteam/server/global/util/redis/service/RedisService.java
+++ b/src/main/java/org/myteam/server/global/util/redis/service/RedisService.java
@@ -49,9 +49,7 @@ public class RedisService { // TODO: RedisReportService 로 변경.
 
 		// TTL(만료 시간)이 없으면 5분 설정
 		if (newCount == 1) {
-
 			redisTemplate.expire(redisKey, Duration.ofMinutes(EXPIRED_TIME));
-
 		}
 
 		log.info("✅ [RateLimit] 요청 허용 - Key: {}, 요청 횟수: {}", redisKey, newCount);

--- a/src/main/java/org/myteam/server/global/util/redis/service/RedisService.java
+++ b/src/main/java/org/myteam/server/global/util/redis/service/RedisService.java
@@ -38,11 +38,6 @@ public class RedisService { // TODO: RedisReportService 로 변경.
 		String requestCountStr = redisTemplate.opsForValue().get(redisKey);
 		int requestCount = requestCountStr == null ? 0 : Integer.parseInt(requestCountStr);
 
-		if(category.equals("LOGIN_ADMIN") && requestCount>=ADMIN_LOGIN_MAX_REQUESTS){
-			log.warn("🚫 [RateLimit] 요청 차단 - Key: {}, 요청 횟수: {}", redisKey, requestCount);
-			return false;
-		}
-
 		// 요청 초과 여부 확인
 		if (requestCount >= MAX_REQUESTS) {
 			log.warn("🚫 [RateLimit] 요청 차단 - Key: {}, 요청 횟수: {}", redisKey, requestCount);
@@ -54,13 +49,31 @@ public class RedisService { // TODO: RedisReportService 로 변경.
 
 		// TTL(만료 시간)이 없으면 5분 설정
 		if (newCount == 1) {
-			if(!category.equals("LOGIN_ADMIN")){
-				redisTemplate.expire(redisKey, Duration.ofMinutes(EXPIRED_TIME));
-			}
+
+			redisTemplate.expire(redisKey, Duration.ofMinutes(EXPIRED_TIME));
+
 		}
 
 		log.info("✅ [RateLimit] 요청 허용 - Key: {}, 요청 횟수: {}", redisKey, newCount);
 		return true;
+	}
+
+
+	public boolean isAdminLoginAllowed(String category,String identifier){
+		String redisKey = getRateLimitKey(category, identifier);
+		String requestCountStr = redisTemplate.opsForValue().get(redisKey);
+		int requestCount = requestCountStr == null ? 0 : Integer.parseInt(requestCountStr);
+
+		if (requestCount >= ADMIN_LOGIN_MAX_REQUESTS) {
+			log.warn("🚫 [RateLimit] 관리자 요청 차단 - Key: {}, 요청 횟수: {}", redisKey, requestCount);
+			return false;
+		}
+
+		long newCount = redisTemplate.opsForValue().increment(redisKey);
+
+		log.info("✅ [RateLimit] 관리자 요청 허용 - Key: {}, 요청 횟수: {}", redisKey, newCount);
+		return true;
+
 	}
 
 	/**

--- a/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
@@ -14,4 +14,13 @@ public class MemberStatusUpdateRequest {
 
     @NotNull
     private MemberStatus status;
+
+    public static MemberStatusUpdateRequest MemberStatusUpdateRequestBuilder(String email
+            ,MemberStatus memberStatus){
+        return MemberStatusUpdateRequest
+                .builder()
+                .email(email)
+                .status(memberStatus)
+                .build();
+    }
 }

--- a/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
@@ -15,7 +15,7 @@ public class MemberStatusUpdateRequest {
     @NotNull
     private MemberStatus status;
 
-    public static MemberStatusUpdateRequest MemberStatusUpdateRequestBuilder(String email
+    public static MemberStatusUpdateRequest memberStatusUpdateRequestBuilder(String email
             ,MemberStatus memberStatus){
         return MemberStatusUpdateRequest
                 .builder()

--- a/src/main/java/org/myteam/server/member/repository/MemberJpaRepository.java
+++ b/src/main/java/org/myteam/server/member/repository/MemberJpaRepository.java
@@ -1,5 +1,6 @@
 package org.myteam.server.member.repository;
 
+import org.myteam.server.member.domain.MemberRole;
 import org.myteam.server.member.domain.MemberType;
 import org.myteam.server.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/org/myteam/server/member/service/MemberReadService.java
+++ b/src/main/java/org/myteam/server/member/service/MemberReadService.java
@@ -48,6 +48,11 @@ public class MemberReadService {
                 .orElseThrow(() -> new PlayHiveException(USER_NOT_FOUND));
     }
 
+    public Member findByEmailAndType(String email,MemberType type) {
+        return memberJpaRepository.findByEmailAndType(email,type)
+                .orElseThrow(() -> new PlayHiveException(USER_NOT_FOUND));
+    }
+
     public ProfileResponse getProfile() {
         Member member = securityReadService.getMember();
 

--- a/src/main/java/org/myteam/server/member/service/MemberService.java
+++ b/src/main/java/org/myteam/server/member/service/MemberService.java
@@ -196,7 +196,16 @@ public class MemberService {
 		Member targetMember = memberJpaRepository.findByEmail(memberStatusUpdateRequest.getEmail())
 				.orElseThrow(() -> new PlayHiveException(USER_NOT_FOUND));
 
-		// 1. 요청자가 본인의 상태를 변경하려는 경우
+
+		// 1. 관리자가 다른 사용자의 상태를 변경하려는 경우
+		if (requester.isAdmin()) {
+			log.info("관리자가 상태를 변경 중: {}, 대상자: {}", targetEmail, memberStatusUpdateRequest.getEmail());
+			targetMember.updateStatus(memberStatusUpdateRequest.getStatus());
+			return;
+		}
+
+
+		// 2. 요청자가 본인의 상태를 변경하려는 경우
 		if (requester.verifyOwnEmail(memberStatusUpdateRequest.getEmail())) {
 			log.info("사용자가 자신의 상태를 변경 중: {}", targetEmail);
 			if (!requester.getStatus().equals(MemberStatus.PENDING))
@@ -205,12 +214,6 @@ public class MemberService {
 			return;
 		}
 
-		// 2. 관리자가 다른 사용자의 상태를 변경하려는 경우
-		if (requester.isAdmin()) {
-			log.info("관리자가 상태를 변경 중: {}, 대상자: {}", targetEmail, memberStatusUpdateRequest.getEmail());
-			targetMember.updateStatus(memberStatusUpdateRequest.getStatus());
-			return;
-		}
 
 		// 3. 권한 없는 사용자가 다른 사용자의 상태를 변경하려고 시도한 경우
 		log.warn("권한 없는 요청: 요청자 {}, 대상자 {}", targetEmail, memberStatusUpdateRequest.getEmail());

--- a/src/test/java/org/myteam/server/admin/filter/LimitLoginTest.java
+++ b/src/test/java/org/myteam/server/admin/filter/LimitLoginTest.java
@@ -1,0 +1,145 @@
+package org.myteam.server.admin.filter;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.member.domain.MemberRole;
+import org.myteam.server.member.domain.MemberStatus;
+import org.myteam.server.member.domain.MemberType;
+import org.myteam.server.member.dto.MemberSaveRequest;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.repository.MemberJpaRepository;
+import org.myteam.server.member.service.MemberReadService;
+import org.myteam.server.member.service.MemberService;
+import org.myteam.server.support.IntegrationTestSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class LimitLoginTest extends IntegrationTestSupport {
+
+
+    Member admin;
+    Member member;
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    MemberJpaRepository memberJpaRepository;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setting(){
+        admin=createAdmin(1);
+        member=createOAuthMember(3);
+
+        String encode=passwordEncoder.encode(admin.getPassword());
+
+        admin.updatePassword(encode);
+
+        memberJpaRepository.save(admin);
+
+        memberJpaRepository.save(member);
+    }
+
+
+    @Test
+    @DisplayName("관리자 로그인 10회 실패시 계정이 잠기는지 테스트")
+    void testLimitLogin() throws Exception{
+
+        given(redisService.isAllowed("LOGIN_ADMIN","test1@test.com"))
+                .willReturn(false);
+        given(redisService.getRequestCount("LOGIN_ADMIN","test1@test.com"))
+                .willReturn(10);
+
+        String requestBody = """
+            {
+                "username": "test1@test.com",
+                "password": "123"
+            }
+        """;
+
+        String requestBody2 = """
+            {
+                "username": "test1@test.com",
+                "password": "1234"
+            }
+        """;
+
+        mockMvc.perform(post("/api/admin/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+
+
+        Optional<Member> member=memberJpaRepository.findByEmail(admin.getEmail());
+        assertThat(member.get().getStatus()).isEqualTo(MemberStatus.INACTIVE);
+
+
+        mockMvc.perform(post("/api/admin/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody2))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+
+
+
+    }
+
+    @Test
+    @DisplayName("잘못된 계정 즉 없는 회원 이던가 혹은 회원 타입이 local인경우 실패 확인")
+    void testingNoMemberLogin() throws Exception{
+
+        //계정이 없는케이스
+        String requestBody3 = """
+            {
+                "username": "test2@test.com",
+                "password": "1234"
+            }
+        """;
+        //oauth 유저가 로그인 시도시
+        String requestBody4 = """
+            {
+                "username": "test3@test.com",
+                "password": "1234"
+            }
+        """;
+
+        mockMvc.perform(post("/api/admin/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody3))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+
+
+        mockMvc.perform(post("/api/admin/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody4))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+
+    }
+
+
+
+}


### PR DESCRIPTION
## 기능 설명
- 관리자 로그인을 시도할때 시도횟수 카운팅 및 정지 기능의 추가
### 작업 내용
- 관리자 로그인 시도시 비밀번호가 틀릴경우 카운팅 기능 구현
- 10회이상 일때 계정을 정지 처리하도록 구현
## 수정 사항
- memberservice의 updatestatus에서 메서드 순서를 바꿈.
- rediservice에서 관리자 로그인 관련 키의경우 expire없이 저장하도록 설정.
- 필터에서 관리자 로그인용 url도 캐치하도록 추가.
## 추가 작업 예정
- 정지시에 이메일 전송 기능 예정
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인