### PR TITLE
refac: es를 사용한 검색 속도 향상

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,9 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // ElasticSearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'jakarta.json:jakarta.json-api:2.1.1'
 }
 
 test {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
+      - network.host=0.0.0.0
     ports:
       - "9200:9200"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,15 @@ services:
     volumes:
       - redis_data:/data
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.1
+    container_name: es
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+
 networks:
   playhive-net:
     external: true

--- a/src/main/java/org/myteam/server/news/news/domain/News.java
+++ b/src/main/java/org/myteam/server/news/news/domain/News.java
@@ -2,15 +2,9 @@ package org.myteam.server.news.news.domain;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.*;
 import org.myteam.server.global.domain.Base;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/org/myteam/server/news/news/domain/NewsDocument.java
+++ b/src/main/java/org/myteam/server/news/news/domain/NewsDocument.java
@@ -1,0 +1,24 @@
+package org.myteam.server.news.news.domain;
+
+import jakarta.persistence.Id;
+import lombok.*;
+
+import org.springframework.data.elasticsearch.annotations.Document;
+import java.time.LocalDateTime;
+
+@Document(indexName = "news")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewsDocument {
+
+    @Id
+    private String id;
+
+    private String title;
+    private String content;
+    private String category;
+    private Long postDate;
+}

--- a/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
+++ b/src/main/java/org/myteam/server/news/news/dto/repository/NewsDto.java
@@ -50,6 +50,18 @@ public class NewsDto {
         this.isHot = isHot;
     }
 
+    public NewsDto(Long id, String category, String title, String thumbImg, String content,
+                   int commentCount, LocalDateTime postDate) {
+        this.id = id;
+        this.category = Category.valueOf(category); // ✅ 직접 enum으로 변환
+        this.title = title;
+        this.thumbImg = extractCleanThumbImg(thumbImg, this.category);
+        this.content = content;
+        this.commentCount = commentCount;
+        this.postDate = postDate;
+        this.isHot = false; // or your logic
+    }
+
     public void updateNewsCommentSearchDto(NewsCommentSearchDto newsCommentSearchDto) {
         this.newsCommentSearchDto = newsCommentSearchDto;
     }

--- a/src/main/java/org/myteam/server/news/news/repository/NewsSearchRepository.java
+++ b/src/main/java/org/myteam/server/news/news/repository/NewsSearchRepository.java
@@ -1,0 +1,14 @@
+package org.myteam.server.news.news.repository;
+
+import org.myteam.server.news.news.domain.NewsDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface NewsSearchRepository extends ElasticsearchRepository<NewsDocument, String> {
+
+    // 기본 쿼리: 제목 또는 내용에 키워드 포함
+    Page<NewsDocument> findByTitleContainingOrContentContaining(
+            String title, String content, Pageable pageable
+    );
+}

--- a/src/main/resources/application-es.yml
+++ b/src/main/resources/application-es.yml
@@ -1,0 +1,3 @@
+spring:
+  elasticsearch:
+    uris: http://es:9200

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
     active: dev
-    include: auth, mail, swagger
+    include: auth, mail, swagger, es
   application:
     name: myteam-server


### PR DESCRIPTION
## 기능 설명
- 뉴스 검색 속도 향상
### 작업 내용
- Elastic-Search를 사용해서 뉴스 검색 속도를 향상시켰습니다.
- 100만건의 데이터에서 3초 걸리던 것을 200ms로 향상시켰습니다.
- 로컬에서 확인했는데, es가 개발계에 띄워질지 몰라서 이거는 머지할지 팀원들과 논의가 필요합니다.
## 수정 사항
- 
## 추가 작업 예정
- 
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인