### PR TITLE
Epic/restrict login

### DIFF
--- a/src/main/java/org/myteam/server/common/certification/mail/factory/MailStrategyFactory.java
+++ b/src/main/java/org/myteam/server/common/certification/mail/factory/MailStrategyFactory.java
@@ -1,20 +1,12 @@
 package org.myteam.server.common.certification.mail.factory;
 
 import lombok.RequiredArgsConstructor;
-<<<<<<< Updated upstream
-=======
-import org.myteam.server.common.certification.mail.strategy.CertifyMailStrategy;
-import org.myteam.server.common.certification.mail.strategy.NotifySuspendStrategy;
-import org.myteam.server.common.certification.mail.strategy.SignUpStrategy;
-import org.myteam.server.common.certification.mail.strategy.TemporaryPasswordMailStrategy;
->>>>>>> Stashed changes
 import org.myteam.server.common.certification.mail.domain.EmailType;
 import org.myteam.server.common.certification.mail.core.MailStrategy;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/org/myteam/server/common/certification/mail/factory/MailStrategyFactory.java
+++ b/src/main/java/org/myteam/server/common/certification/mail/factory/MailStrategyFactory.java
@@ -1,6 +1,13 @@
 package org.myteam.server.common.certification.mail.factory;
 
 import lombok.RequiredArgsConstructor;
+<<<<<<< Updated upstream
+=======
+import org.myteam.server.common.certification.mail.strategy.CertifyMailStrategy;
+import org.myteam.server.common.certification.mail.strategy.NotifySuspendStrategy;
+import org.myteam.server.common.certification.mail.strategy.SignUpStrategy;
+import org.myteam.server.common.certification.mail.strategy.TemporaryPasswordMailStrategy;
+>>>>>>> Stashed changes
 import org.myteam.server.common.certification.mail.domain.EmailType;
 import org.myteam.server.common.certification.mail.core.MailStrategy;
 import org.myteam.server.global.exception.ErrorCode;

--- a/src/main/java/org/myteam/server/global/security/service/CustomUserDetailsService.java
+++ b/src/main/java/org/myteam/server/global/security/service/CustomUserDetailsService.java
@@ -4,6 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.security.dto.CustomUserDetails;
+import org.myteam.server.member.domain.MemberRole;
+import org.myteam.server.member.domain.MemberType;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.repository.MemberJpaRepository;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -26,23 +28,47 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        log.info("일반 로그인 CustomUserDetailsService 실행됨");
-        log.info("username : {}", username);
 
-        Optional<Member> memberOP = userRepository.findByEmailAndType(username, LOCAL);
+        String [] userData=username.split(">");
 
-        if (memberOP.isPresent()) {
-            // 로컬 회원인지 소셜 회원인지 확인
-            if (memberOP.get().getType() != LOCAL) {
-                log.warn("소셜 회원이 로컬 로그인 시도 중 - 거부됨");
-                return null;
+        if(userData[1].equals("ADMIN")) {
+            log.info("관리자 로그인 CustomUserDetailsService 실행됨");
+            log.info("username : {}", userData[0]);
+            Optional<Member> memberOP = userRepository
+                    .findByEmailAndTypeAndRole(userData[0], LOCAL, MemberRole.ADMIN);
+
+            if (memberOP.isPresent()) {
+                // 로컬 회원인지 소셜 회원인지 확인
+                if (memberOP.get().getType() != LOCAL) {
+                    log.warn("소셜 회원이 로컬 로그인 시도 중 - 거부됨");
+                    return null;
+                }
+                log.info(" 관리자 유저가 존재합니다. 인증 처리 로직을 실행합니다.");
+                return new CustomUserDetails(memberOP.get());
             }
+            log.warn("사용자를 찾을수 없습니다.");
+            throw new PlayHiveException(ErrorCode.USER_NOT_FOUND);
+        }
+        else {
+            log.info("일반 로그인 CustomUserDetailsService 실행됨");
+            log.info("username : {}", userData[0]);
 
-            log.info("유저가 존재합니다. 인증 처리 로직을 실행합니다.");
-            return new CustomUserDetails(memberOP.get());
+            Optional<Member> memberOP = userRepository
+                    .findByEmailAndTypeAndRole(userData[0], LOCAL, MemberRole.USER);
+
+            if (memberOP.isPresent()) {
+                // 로컬 회원인지 소셜 회원인지 확인
+                if (memberOP.get().getType() != LOCAL) {
+                    log.warn("소셜 회원이 로컬 로그인 시도 중 - 거부됨");
+                    return null;
+                }
+                log.info("일반 유저가 존재합니다. 인증 처리 로직을 실행합니다.");
+                return new CustomUserDetails(memberOP.get());
+            }
+            log.warn("사용자를 찾을수 없습니다.");
+            throw new PlayHiveException(ErrorCode.USER_NOT_FOUND);
+
         }
 
-        log.warn("사용자를 찾을수 없습니다.");
-        throw new PlayHiveException(ErrorCode.USER_NOT_FOUND);
     }
 }

--- a/src/main/java/org/myteam/server/member/repository/MemberJpaRepository.java
+++ b/src/main/java/org/myteam/server/member/repository/MemberJpaRepository.java
@@ -18,6 +18,8 @@ public interface MemberJpaRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmailAndType(String email, MemberType type);
 
+    Optional<Member> findByEmailAndTypeAndRole(String email, MemberType type,MemberRole role);
+
     Optional<Member> findByPublicId(UUID publicId);
 
     boolean existsByEmail(String email);

--- a/src/test/java/org/myteam/server/admin/filter/LimitLoginTest.java
+++ b/src/test/java/org/myteam/server/admin/filter/LimitLoginTest.java
@@ -1,12 +1,14 @@
 package org.myteam.server.admin.filter;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.myteam.server.chat.info.domain.UserInfo;
+import org.myteam.server.global.security.jwt.JwtProvider;
+import org.myteam.server.global.util.redis.service.RedisUserInfoService;
 import org.myteam.server.member.domain.MemberRole;
 import org.myteam.server.member.domain.MemberStatus;
 import org.myteam.server.member.domain.MemberType;
@@ -20,13 +22,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.mockito.BDDMockito.*;
+import static org.myteam.server.global.security.jwt.JwtProvider.TOKEN_CATEGORY_ACCESS;
+import static org.myteam.server.global.security.jwt.JwtProvider.TOKEN_CATEGORY_REFRESH;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,7 +45,9 @@ public class LimitLoginTest extends IntegrationTestSupport {
 
 
     Member admin;
-    Member member;
+    Member oauth2Member;
+
+    Member normalMember;
     @Autowired
     MockMvc mockMvc;
 
@@ -46,19 +56,32 @@ public class LimitLoginTest extends IntegrationTestSupport {
 
     @Autowired
     PasswordEncoder passwordEncoder;
-
+    
+    @MockBean
+    RedisUserInfoService redisUserInfoService;
+    
+    @Autowired
+    JwtProvider jwtProvider;
+    
     @BeforeEach
     void setting(){
         admin=createAdmin(1);
-        member=createOAuthMember(3);
+        oauth2Member=createOAuthMember(3);
+        normalMember=createMember(4);
+        String adminEncode=passwordEncoder.encode(admin.getPassword());
+        admin.updatePassword(adminEncode);
 
-        String encode=passwordEncoder.encode(admin.getPassword());
+        String oauth2Encode=passwordEncoder.encode(oauth2Member.getPassword());
+        oauth2Member.updatePassword(oauth2Encode);
 
-        admin.updatePassword(encode);
+        String normalEncode=passwordEncoder.encode(normalMember.getPassword());
+        normalMember.updatePassword(normalEncode);
 
         memberJpaRepository.save(admin);
 
-        memberJpaRepository.save(member);
+        memberJpaRepository.save(oauth2Member);
+
+        memberJpaRepository.save(normalMember);
     }
 
 
@@ -66,7 +89,7 @@ public class LimitLoginTest extends IntegrationTestSupport {
     @DisplayName("관리자 로그인 10회 실패시 계정이 잠기는지 테스트")
     void testLimitLogin() throws Exception{
 
-        given(redisService.isAllowed("LOGIN_ADMIN","test1@test.com"))
+        given(redisService.isAdminLoginAllowed("LOGIN_ADMIN", "test1@test.com"))
                 .willReturn(false);
         given(redisService.getRequestCount("LOGIN_ADMIN","test1@test.com"))
                 .willReturn(10);
@@ -101,42 +124,131 @@ public class LimitLoginTest extends IntegrationTestSupport {
                         .content(requestBody2))
                 .andDo(print())
                 .andExpect(status().isForbidden());
-
-
-
     }
-
     @Test
-    @DisplayName("잘못된 계정 즉 없는 회원 이던가 혹은 회원 타입이 local인경우 실패 확인")
+    @DisplayName("잘못된 계정 즉 없는 회원 이던가 혹은 회원 타입이 local인경우 실패 확인" +
+            "혹은 로그인 경로와 알맞지않는 유저가 로그인 시도시 실패 확인")
     void testingNoMemberLogin() throws Exception{
 
+        String accessToken = jwtProvider.generateToken(TOKEN_CATEGORY_ACCESS, Duration.ofDays(1), admin.getPublicId(), MemberRole.ADMIN.name(),
+                MemberStatus.ACTIVE.name());
+        String refreshToken = jwtProvider.generateToken(TOKEN_CATEGORY_REFRESH, Duration.ofDays(30), admin.getPublicId(), MemberRole.ADMIN.name(),
+                MemberStatus.ACTIVE.name());
+
+
+        String accessToken2 = jwtProvider.generateToken(TOKEN_CATEGORY_ACCESS, Duration.ofDays(1), normalMember.getPublicId(), MemberRole.USER.name(),
+                MemberStatus.ACTIVE.name());
+        String refreshToken2 = jwtProvider.generateToken(TOKEN_CATEGORY_REFRESH, Duration.ofDays(30), normalMember.getPublicId(), MemberRole.USER.name(),
+                MemberStatus.ACTIVE.name());
+
+
+        willDoNothing().given(redisService)
+                .putRefreshToken(admin.getPublicId(),refreshToken);
+        willDoNothing().given(redisService)
+                .putRefreshToken(normalMember.getPublicId(),refreshToken2);
+       willDoNothing().given(redisUserInfoService)
+               .saveUserInfo(accessToken,
+                       new UserInfo(admin.getPublicId(), admin.getNickname(), ""));
+
+        willDoNothing().given(redisUserInfoService)
+                .saveUserInfo(accessToken2,
+                        new UserInfo(normalMember.getPublicId(), normalMember.getNickname(), ""));
+        
+        
+
+
         //계정이 없는케이스
-        String requestBody3 = """
+        String requestBodyNoMemberCase= """
             {
                 "username": "test2@test.com",
                 "password": "1234"
             }
         """;
         //oauth 유저가 로그인 시도시
-        String requestBody4 = """
+        String requestBodyOauth2MemberCase = """
             {
                 "username": "test3@test.com",
                 "password": "1234"
             }
         """;
 
+
+
+        //일반 유저가 로그인 시도시
+        String requestBodyNormalCase = """
+            {
+                "username": "test4@test.com",
+                "password": "1234"
+            }
+        """;
+
+
+        //admin 유저가 로그인 시도시
+        String requestBodyAdminCase = """
+            {
+                "username": "test1@test.com",
+                "password": "1234"
+            }
+        """;
+
+        //관리자 경로로 로그인 시도시
         mockMvc.perform(post("/api/admin/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody3))
+                        .content(requestBodyNoMemberCase))
                 .andDo(print())
                 .andExpect(status().isUnauthorized());
 
 
         mockMvc.perform(post("/api/admin/login")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(requestBody4))
+                        .content(requestBodyOauth2MemberCase))
                 .andDo(print())
                 .andExpect(status().isUnauthorized());
+
+
+        mockMvc.perform(post("/api/admin/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyNormalCase))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+
+
+        mockMvc.perform(post("/api/admin/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyAdminCase))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+
+
+
+
+        //일반유저 경로 로그인 시도시
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyNoMemberCase))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyOauth2MemberCase))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyAdminCase))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyNormalCase))
+                .andDo(print())
+                .andExpect(status().isOk());
+
 
     }
 


### PR DESCRIPTION
## 기능 설명
- 로그인시 사용자 role의 구분기능의 추가
### 작업 내용
- jwtauthenticationfilter에서 request에서 uthenticationManager로 넘기는 인증객체의 데이터를 수정하였습니다.
- customdetailsservice에서 넘겨받은 데이터에 있는 일반,관리자 로그인 표시를 바탕으로 인증을 수행하고 로그도 다르게 남기도록 바꿨습니다.
- memberjparepositroy에 role,type,mail로 멤버를 찾는 메서드를 추가했습니다.
## 수정 사항
- 
## 추가 작업 예정
- 
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인