### PR TITLE
chore: 회원 가입 성공 이메일 전송 시 email -> nickname으로 변경, 이메일 형식 _ 허용 추가, 이메일 템플릿 수정 및 추가

### DIFF
--- a/src/main/java/org/myteam/server/common/certification/dto/CertificationCertifyRequest.java
+++ b/src/main/java/org/myteam/server/common/certification/dto/CertificationCertifyRequest.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 public class CertificationCertifyRequest {
-    @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
+    @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email;
     @NotBlank
     private String code;

--- a/src/main/java/org/myteam/server/common/certification/dto/CertificationEmailRequest.java
+++ b/src/main/java/org/myteam/server/common/certification/dto/CertificationEmailRequest.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @Getter
 public class CertificationEmailRequest {
     @NotNull
-    @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
+    @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email;
 }

--- a/src/main/java/org/myteam/server/common/certification/mail/strategy/SignUpStrategy.java
+++ b/src/main/java/org/myteam/server/common/certification/mail/strategy/SignUpStrategy.java
@@ -1,22 +1,26 @@
 package org.myteam.server.common.certification.mail.strategy;
 
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.myteam.server.common.certification.mail.core.AbstractMailSender;
 import org.myteam.server.common.certification.mail.domain.EmailType;
+import org.myteam.server.member.repository.MemberJpaRepository;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
-import java.util.concurrent.CompletableFuture;
-
 @Slf4j
 @Component
 public class SignUpStrategy extends AbstractMailSender {
 
-    public SignUpStrategy(JavaMailSender javaMailSender, SpringTemplateEngine templateEngine) {
+    private final MemberJpaRepository memberJpaRepository;
+
+    public SignUpStrategy(JavaMailSender javaMailSender, SpringTemplateEngine templateEngine,
+                          MemberJpaRepository memberJpaRepository) {
         super(javaMailSender, templateEngine);
+        this.memberJpaRepository = memberJpaRepository;
     }
 
     @Override
@@ -30,8 +34,10 @@ public class SignUpStrategy extends AbstractMailSender {
     }
 
     private String buildWelcomeContent(String email) {
+        String nickname = memberJpaRepository.findByEmail(email).get().getNickname();
+
         Context context = new Context();
-        context.setVariable("email", email);
+        context.setVariable("nickname", nickname);
 
         return templateEngine.process("mail/signup-complete-template", context);
     }

--- a/src/main/java/org/myteam/server/member/domain/validator/MemberValidator.java
+++ b/src/main/java/org/myteam/server/member/domain/validator/MemberValidator.java
@@ -1,16 +1,15 @@
 package org.myteam.server.member.domain.validator;
 
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
-import java.util.regex.Pattern;
-
 @Component
 public class MemberValidator {
     private static final String TEL_PATTERN = "^010[0-9]{7,8}$";
-    private static final String EMAIL_PATTERN = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$";
+    private static final String EMAIL_PATTERN = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$";
 
     private static final int BIRTH_DATE_LENGTH = 6;
     private static final int MIN_MONTH = 1;
@@ -20,6 +19,20 @@ public class MemberValidator {
     private static final int LEAP_YEAR_DIVISOR = 4;
     private static final int LEAP_YEAR_CENTURY_DIVISOR = 400;
     private static final int[] MONTH_DAYS = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+    public static String validateTel(String tel) {
+        if (tel != null && Pattern.matches(TEL_PATTERN, tel)) {
+            return tel; // 유효한 값 반환
+        }
+        return null; // 유효하지 않으면 null 반환
+    }
+
+    public static String validateEmail(String email) {
+        if (email != null && Pattern.matches(EMAIL_PATTERN, email)) {
+            return email; // 유효한 값 반환
+        }
+        return null; // 유효하지 않으면 null 반환
+    }
 
     public void validateBirthDate(String birthDate) {
         if (!isValidLength(birthDate)) {
@@ -64,20 +77,7 @@ public class MemberValidator {
     }
 
     public boolean isLeapYear(int year) {
-        return (year % LEAP_YEAR_DIVISOR == 0 && year % CENTURY_DIVISOR != 0) || (year % LEAP_YEAR_CENTURY_DIVISOR == 0);
-    }
-
-    public static String validateTel(String tel) {
-        if (tel != null && Pattern.matches(TEL_PATTERN, tel)) {
-            return tel; // 유효한 값 반환
-        }
-        return null; // 유효하지 않으면 null 반환
-    }
-
-    public static String validateEmail(String email) {
-        if (email != null && Pattern.matches(EMAIL_PATTERN, email)) {
-            return email; // 유효한 값 반환
-        }
-        return null; // 유효하지 않으면 null 반환
+        return (year % LEAP_YEAR_DIVISOR == 0 && year % CENTURY_DIVISOR != 0) || (year % LEAP_YEAR_CENTURY_DIVISOR
+                == 0);
     }
 }

--- a/src/main/java/org/myteam/server/member/dto/MemberDeleteRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberDeleteRequest.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 public class MemberDeleteRequest {
     //    @NotBlank
-    @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
+    @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email; // 계정
 
     @NotBlank

--- a/src/main/java/org/myteam/server/member/dto/MemberGetRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberGetRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class MemberGetRequest {
-    @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
+    @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email; // 계정
 
     // _-. 를 포함하는 닉네임 생성 가능

--- a/src/main/java/org/myteam/server/member/dto/MemberRoleUpdateRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberRoleUpdateRequest.java
@@ -1,17 +1,16 @@
 package org.myteam.server.member.dto;
 
 import jakarta.validation.constraints.Pattern;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import org.myteam.server.member.domain.MemberRole;
 import org.myteam.server.member.domain.MemberType;
 
-import java.util.UUID;
-
 @Getter
 @Builder
 public class MemberRoleUpdateRequest {
-    @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
+    @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email; // 계정
     private MemberRole role;
     private UUID publicId;

--- a/src/main/java/org/myteam/server/member/dto/MemberSaveRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberSaveRequest.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 public class MemberSaveRequest {
     @NotBlank
-    @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
+    @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email; // 계정
 
     @NotBlank

--- a/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
@@ -9,14 +9,14 @@ import org.myteam.server.member.domain.MemberStatus;
 @Getter
 @Builder
 public class MemberStatusUpdateRequest {
-    @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
+    @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email; // 계정
 
     @NotNull
     private MemberStatus status;
 
     public static MemberStatusUpdateRequest memberStatusUpdateRequestBuilder(String email
-            ,MemberStatus memberStatus){
+            , MemberStatus memberStatus) {
         return MemberStatusUpdateRequest
                 .builder()
                 .email(email)

--- a/src/main/java/org/myteam/server/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberUpdateRequest.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class MemberUpdateRequest {
-    @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
+    @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email; // 계정
 
     @NotNull(message = "영문 + 숫자 조합 4 ~ 10자 이내로 작성해주세요")

--- a/src/main/java/org/myteam/server/profile/dto/request/ProfileRequestDto.java
+++ b/src/main/java/org/myteam/server/profile/dto/request/ProfileRequestDto.java
@@ -4,7 +4,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 public class ProfileRequestDto {
 
@@ -13,7 +16,7 @@ public class ProfileRequestDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MemberUpdateRequest {
-        @Pattern(regexp = "^[0-9a-zA-Z]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
+        @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
         private String email; // 계정
 
         @NotNull(message = "영문 + 숫자 조합 4 ~ 10자 이내로 작성해주세요")

--- a/src/main/resources/templates/mail/certify-template.html
+++ b/src/main/resources/templates/mail/certify-template.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
+
 <head>
     <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>PlayHive 인증 메일</title>
     <style>
         @font-face {
@@ -13,22 +14,25 @@
         }
     </style>
 </head>
-<body style="margin: 0; padding: 0; font-family: 'SUIT Variable', Arial, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
-<table width="728" align="center" cellpadding="0" cellspacing="0"
-       style="background-color: white; padding: 80px 40px 40px; box-sizing: border-box;">
+
+<body
+        style="margin: 0; padding: 0; font-family: 'SUIT Variable', Arial, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
+<table align="center" cellpadding="0" cellspacing="0" style="background-color: white; padding: 40px; box-sizing: border-box;"
+       width="728">
     <tr>
         <td>
-            <table width="648" cellpadding="0" cellspacing="0" style="margin: 0 auto">
+            <table cellpadding="0" cellspacing="0" style="margin: 0 auto" width="648">
                 <tr>
                     <td style="padding-bottom: 24px">
-                        <table width="100%" cellpadding="0" cellspacing="0">
+                        <table cellpadding="0" cellspacing="0" width="100%">
                             <tr>
                                 <td style="width: 118.49px; height: 32px">
-                                    <img src="https://media.playhive.co.kr/image/Logo.png" alt="PlayHive"
+                                    <img alt="PlayHive" src="https://media.playhive.co.kr/image/Logo.png"
                                          style="width: 100%; height: 100%; object-fit: cover"/>
                                 </td>
                                 <td style="padding-left: 16px">
-                                    <p style="width: 325px; height: 32px; color: #00adee; font-size: 16px; font-weight: 700; margin: 0; letter-spacing: -0.04em; line-height: 32px;">
+                                    <p
+                                            style="width: 325px; height: 32px; color: #00adee; font-size: 16px; font-weight: 700; margin: 0; letter-spacing: -0.04em; line-height: 32px;">
                                         모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
                                     </p>
                                 </td>
@@ -39,7 +43,8 @@
 
                 <tr>
                     <td style="height: 88px; padding-bottom: 24px">
-                        <h5 style="width: 490px; font-size: 28px; font-weight: 700; line-height: 40px; color: #000; margin: 0; letter-spacing: -0.04em; padding-bottom: 8px;">
+                        <h5
+                                style="width: 490px; font-size: 28px; font-weight: 700; line-height: 40px; color: #000; margin: 0; letter-spacing: -0.04em; padding-bottom: 8px;">
                             플레이하이브 회원가입을 위한 이메일 인증번호
                         </h5>
                         <p style="width: 490px; font-size: 14px; font-weight: 500; line-height: 20px; color: #424242; margin: 0;">
@@ -51,18 +56,21 @@
 
                 <tr>
                     <td>
-                        <p style="margin: 0; padding-bottom: 4px; color: #444; font-weight: 700; font-size: 20px; line-height: 36px; letter-spacing: -0.02em;">
+                        <p
+                                style="margin: 0; padding-bottom: 4px; color: #444; font-weight: 700; font-size: 20px; line-height: 36px; letter-spacing: -0.02em;">
                             인증번호
                         </p>
-                        <table width="100%" cellpadding="0" cellspacing="0"
-                               style="background-color: #f8fdff; margin: 0">
+                        <table cellpadding="0" cellspacing="0" style="background-color: #f8fdff; margin: 0"
+                               width="100%">
                             <tr>
-                                <td style="font-size: 42px; font-weight: 900; color: #00adee; letter-spacing: -0.02em; padding: 16px;">
+                                <td
+                                        style="font-size: 42px; font-weight: 900; color: #00adee; letter-spacing: -0.02em; padding: 16px;">
                                     <span th:text="${code}">123456</span>
                                 </td>
                             </tr>
                         </table>
-                        <p style="margin: 0; font-size: 14px; font-weight: 500; line-height: 20px; color: #424242; padding-top: 24px;">
+                        <p
+                                style="margin: 0; font-size: 14px; font-weight: 500; line-height: 20px; color: #424242; padding-top: 24px;">
                             본 메일은 발신전용으로 회신하실 경우 답변이 되지 않습니다. 자세한 사항은
                             <a href="https://playhive.co.kr/customer"
                                style="color: #00aaee; text-decoration: underline; text-underline-offset: 2px;">플레이하이브
@@ -76,56 +84,58 @@
     </tr>
 </table>
 
-<!-- 푸터 -->
-<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #181818;">
-    <tr>
-        <td>
-            <table width="728" align="center" cellpadding="0" cellspacing="0"
-                   style="background-color: #181818; margin: 0 auto; padding: 40px 40px 0; box-sizing: border-box;">
-                <tr>
-                    <td>
-                        <table width="648" cellpadding="0" cellspacing="0">
-                            <tr>
-                                <td style="padding-bottom: 24px; width: 148.62px;">
-                                    <img src="https://media.playhive.co.kr/image/logo_white.png" alt="PlayHive"
-                                         width="148.62" height="40"
-                                         style="width: 148.62px; height: 40px; display: block; max-width: 148.62px;"/>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td style="padding-bottom: 24px;">
-                                    <p style="font-weight: 500; font-size: 24px; line-height: 38px; letter-spacing: -0.04em; color: white; margin: 0;">
-                                        열정적으로 응원하고 서로를 존중하며<br/>
-                                        <strong>모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!</strong>
-                                    </p>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; color: #a6a6a6; margin: 0;">
-                                        서비스명: PlayHive · 대표: 홍길표 · 개인정보 보호책임자: 홍길표<br/>
-                                        콘텐츠 내용에 대한 저작권 및 법적 책임은 자료제공자 또는 글쓴이에 있으며 PlayHive의 입장과 다를 수 있습니다.
-                                    </p>
-                                </td>
-                            </tr>
-                        </table>
+<!-- footer -->
+<div style="width: 100%; background-color: #000;">
+    <table align="center" cellpadding="0" cellspacing="0" style="background-color: #000; padding: 40px 40px 0;"
+           width="728">
+        <tr>
+            <td>
+                <table cellpadding="0" cellspacing="0" width="648">
+                    <tr>
+                        <td style="padding-bottom: 24px;">
+                            <div style="width: 148.62px; height: 40px;">
+                                <img alt="PlayHive" src="https://media.playhive.co.kr/image/logo_white.png"
+                                     style="width: 100%; height: 100%; object-fit: cover;"/>
+                            </div>
+                        </td>
+                    </tr>
 
-                        <table width="648" cellpadding="0" cellspacing="0"
-                               style="margin-top: 24px; border-top: 1px solid #424242;">
-                            <tr>
-                                <td style="height: 80px; color: #a6a6a6;">
-                                    <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; margin: 0;">
-                                        Copyright © PlayHive Co., Ltd All rights reserved.
-                                    </p>
-                                </td>
-                            </tr>
-                        </table>
+                    <tr>
+                        <td>
+                            <p
+                                    style="font-weight: 500; font-size: 24px; line-height: 38px; letter-spacing: -0.04em; color: white; margin: 0;">
+                                열정적으로 응원하고 서로를 존중하며<br/>
+                                <span style="font-weight: 700;">
+                    모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
+                  </span>
+                            </p>
+                        </td>
+                    </tr>
 
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
+                    <tr>
+                        <td style="padding-top: 24px;">
+                            <p
+                                    style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; color: #a6a6a6; margin: 0;">
+                                서비스명: PlayHive · 대표: 홍길표 · 개인정보 보호책임자: 홍길표<br/>
+                                콘텐츠 내용에 대한 저작권 및 법적 책임은 자료제공자 또는 글쓴이에 있으며 PlayHive의 입장과 다를 수 있습니다.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+                <table cellpadding="0" cellspacing="0" style="margin-top: 24px; border-top: 1px solid #424242;"
+                       width="648">
+                    <tr>
+                        <td style="height: 80px; color: #a6a6a6;">
+                            <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; margin: 0;">
+                                Copyright © PlayHive Co., Ltd All rights reserved.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</div>
 </body>
+
 </html>

--- a/src/main/resources/templates/mail/signup-complete-template.html
+++ b/src/main/resources/templates/mail/signup-complete-template.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
+
 <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>PlayHive 회원가입완료</title>
     <style>
         @font-face {
@@ -13,22 +14,25 @@
         }
     </style>
 </head>
-<body style="margin: 0; padding: 0; font-family: 'SUIT Variable', Arial, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
-<table width="728" align="center" cellpadding="0" cellspacing="0" style="background-color: white; padding: 80px 40px 40px; box-sizing: border-box; margin: 0 auto; text-align: left;">
+
+<body
+        style="margin: 0; padding: 0; font-family: 'SUIT Variable', Arial, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
+<table align="center" cellpadding="0" cellspacing="0" style="background-color: white; padding: 40px; box-sizing: border-box;"
+       width="728">
     <tr>
         <td>
-            <table width="648" align="center" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+            <table align="center" cellpadding="0" cellspacing="0" style="margin: 0 auto;" width="648">
                 <tr>
                     <td style="padding-bottom: 24px;">
-                        <table width="100%" cellpadding="0" cellspacing="0">
+                        <table cellpadding="0" cellspacing="0" width="100%">
                             <tr>
                                 <td style="width: 118.49px; height: 32px;">
-                                    <img src="https://media.playhive.co.kr/image/Logo.png"
-                                         alt="PlayHive"
+                                    <img alt="PlayHive" src="https://media.playhive.co.kr/image/Logo.png"
                                          style="width: 100%; height: 100%; object-fit: contain;"/>
                                 </td>
                                 <td style="padding-left: 16px;">
-                                    <p style="width: 325px; height: 32px; color: #00adee; font-size: 16px; font-weight: 700; margin: 0; letter-spacing: -0.04em; line-height: 32px;">
+                                    <p
+                                            style="width: 325px; height: 32px; color: #00adee; font-size: 16px; font-weight: 700; margin: 0; letter-spacing: -0.04em; line-height: 32px;">
                                         모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
                                     </p>
                                 </td>
@@ -39,23 +43,26 @@
 
                 <tr>
                     <td>
-                        <h5 style="font-size: 28px; font-weight: 700; line-height: 40px; color: #000; margin: 0; letter-spacing: -0.04em; padding-bottom: 8px;">
-                            <span th:text="${email}">example@email.com</span>님
+                        <h5
+                                style="font-size: 28px; font-weight: 700; line-height: 40px; color: #000; margin: 0; letter-spacing: -0.04em; padding-bottom: 8px;">
+                            <!-- 닉네임 -->
+                            <span th:text="${nickname}">익명의 유저</span>&nbsp;회원님
                         </h5>
-                        <p style="font-size: 14px; font-weight: 500; line-height: 20px; color: #424242; margin: 0; padding-bottom: 20px;">
-                            안녕하세요? 플레이 하이브 입니다.<br />
-                            플레이 하이브 회원이 되신 것을 진심으로 환영합니다!<br />
-                            E스포츠, 축구, 야구의 커뮤니티를 통해 다양한 소통과 정보를 얻어보세요!<br />
-                            뉴스, 경기일정 등을 확인하며 건전하고 클린한 응원문화에 참여하시어 즐거운 커뮤니티 생활을 권장합니다.<br />
-                            E스포츠의 리그오브레전드 게임의 실시간 경기들을 플레이 하이브에서 시청하며 채팅을 나눌 수 있습니다.<br />
-                            <span style="display: block; padding-top: 20px;">많은 이용 부탁드리며 다시 한번 감사합니다.</span>
+                        <p style="font-size: 14px; font-weight: 500; line-height: 20px; color: #424242; margin: 0;">
+                            안녕하세요? 플레이 하이브 입니다.<br/>
+                            플레이 하이브 회원이 되신 것을 진심으로 환영합니다!<br/>
+                            E스포츠, 축구, 야구의 커뮤니티를 통해 다양한 소통과 정보를 얻어보세요!<br/>
+                            뉴스, 경기일정 등을 확인하며 건전하고 클린한 응원문화에 참여하시어 즐거운 커뮤니티 생활을 권장합니다.<br/>
+                            E스포츠의 리그오브레전드 게임의 실시간 경기들을 플레이 하이브에서 시청하며 채팅을 나눌 수 있습니다.<br/><br/>
+                            많은 이용 부탁드리며 다시 한번 감사합니다.
                         </p>
                     </td>
                 </tr>
 
                 <tr>
-                    <td style="width: 648px; padding-bottom: 24px;">
-                        <a href="https://playhive.co.kr/sign" style="display: inline-block; width: 184px; height: 48px; background-color: #00adee; color: #ffffff; font-size: 16px; font-weight: 700; text-decoration: none; text-align: center; line-height: 48px; border-radius: 5px;">
+                    <td style="min-width: 184px; padding: 24px 0;">
+                        <a href="https://playhive.co.kr/sign"
+                           style="width: 184px; height: 48px; background-color: #00adee; color: #ffffff; font-size: 16px; font-weight: 700; text-decoration: none; text-align: center; line-height: 48px; border-radius: 5px; padding: 14px 20px;">
                             플레이하이브 보러가기
                         </a>
                     </td>
@@ -64,7 +71,8 @@
                 <tr>
                     <td style="width: 648px; font-size: 14px; font-weight: 500; line-height: 20px; color: #424242;">
                         본 메일은 발신전용으로 회신하실 경우 답변이 되지 않습니다. 자세한 사항은
-                        <a href="https://playhive.co.kr/customer" style="color: #00aaee; text-decoration: underline; text-underline-offset: 2px;">
+                        <a href="https://playhive.co.kr/customer"
+                           style="color: #00aaee; text-decoration: underline; text-underline-offset: 2px;">
                             플레이하이브 고객센터
                         </a>
                         를 이용하세요.
@@ -75,52 +83,58 @@
     </tr>
 </table>
 
-<!-- Footer -->
-<table width="100%" cellpadding="0" cellspacing="0" style="background-color: #181818;">
-    <tr>
-        <td>
-            <table width="728" align="center" cellpadding="0" cellspacing="0" style="background-color: #181818; margin: 0 auto; padding: 40px 40px 0; box-sizing: border-box;">
-                <tr>
-                    <td>
-                        <table width="648" cellpadding="0" cellspacing="0">
-                            <tr>
-                                <td style="padding-bottom: 24px;">
-                                    <img src="https://media.playhive.co.kr/image/logo_white.png" alt="PlayHive" style="width: 148.62px; height: 40px; display: block; max-width: 148.62px;"/>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td style="padding-bottom: 24px;">
-                                    <p style="font-weight: 500; font-size: 24px; line-height: 38px; letter-spacing: -0.04em; color: white; margin: 0;">
-                                        열정적으로 응원하고 서로를 존중하며<br />
-                                        <strong>모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!</strong>
-                                    </p>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; color: #a6a6a6; margin: 0;">
-                                        서비스명: PlayHive · 대표: 홍길표 · 개인정보 보호책임자: 홍길표<br />
-                                        콘텐츠 내용에 대한 저작권 및 법적 책임은 자료제공자 또는 글쓴이에 있으며 PlayHive의 입장과 다를 수 있습니다.
-                                    </p>
-                                </td>
-                            </tr>
-                        </table>
+<!-- footer -->
+<div style="width: 100%; background-color: #000;">
+    <table align="center" cellpadding="0" cellspacing="0" style="background-color: #000; padding: 40px 40px 0;"
+           width="728">
+        <tr>
+            <td>
+                <table cellpadding="0" cellspacing="0" width="648">
+                    <tr>
+                        <td style="padding-bottom: 24px;">
+                            <div style="width: 148.62px; height: 40px;">
+                                <img alt="PlayHive" src="https://media.playhive.co.kr/image/logo_white.png"
+                                     style="width: 100%; height: 100%; object-fit: cover;"/>
+                            </div>
+                        </td>
+                    </tr>
 
-                        <table width="648" cellpadding="0" cellspacing="0" style="margin-top: 24px; border-top: 1px solid #424242;">
-                            <tr>
-                                <td style="height: 80px; color: #a6a6a6;">
-                                    <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; margin: 0;">
-                                        Copyright © PlayHive Co., Ltd All rights reserved.
-                                    </p>
-                                </td>
-                            </tr>
-                        </table>
+                    <tr>
+                        <td>
+                            <p
+                                    style="font-weight: 500; font-size: 24px; line-height: 38px; letter-spacing: -0.04em; color: white; margin: 0;">
+                                열정적으로 응원하고 서로를 존중하며<br/>
+                                <span style="font-weight: 700;">
+                    모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
+                  </span>
+                            </p>
+                        </td>
+                    </tr>
 
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
+                    <tr>
+                        <td style="padding-top: 24px;">
+                            <p
+                                    style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; color: #a6a6a6; margin: 0;">
+                                서비스명: PlayHive · 대표: 홍길표 · 개인정보 보호책임자: 홍길표<br/>
+                                콘텐츠 내용에 대한 저작권 및 법적 책임은 자료제공자 또는 글쓴이에 있으며 PlayHive의 입장과 다를 수 있습니다.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+                <table cellpadding="0" cellspacing="0" style="margin-top: 24px; border-top: 1px solid #424242;"
+                       width="648">
+                    <tr>
+                        <td style="height: 80px; color: #a6a6a6;">
+                            <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; margin: 0;">
+                                Copyright © PlayHive Co., Ltd All rights reserved.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</div>
 </body>
+
 </html>

--- a/src/main/resources/templates/mail/temporary-password-template.html
+++ b/src/main/resources/templates/mail/temporary-password-template.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
+
 <head>
     <meta charset="UTF-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>PlayHive 임시비밀번호</title>
     <style>
         @font-face {
@@ -14,33 +15,37 @@
     </style>
 </head>
 
-<body style="margin: 0; padding: 0; font-family: 'SUIT Variable', Arial, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
-<table width="728" align="center" cellpadding="0" cellspacing="0"
-       style="background-color: white; padding: 80px 40px 40px; box-sizing: border-box;">
+<body
+        style="margin: 0; padding: 0; font-family: 'SUIT Variable', Arial, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
+<table align="center" cellpadding="0" cellspacing="0" style="background-color: white; padding: 40px; box-sizing: border-box;"
+       width="728">
     <tr>
         <td>
-            <table width="648" align="center" cellpadding="0" cellspacing="0" style="margin: 0 auto;">
+            <table align="center" cellpadding="0" cellspacing="0" style="margin: 0 auto;" width="648">
                 <tr>
-                    <td style="padding-bottom: 24px;">
-                        <div style="width: 100%;">
-                            <div style="float: left; width: 118.49px; height: 32px;">
-                                <img src="https://media.playhive.co.kr/image/Logo.png" alt="PlayHive"
-                                     style="width: 148.62px; height: 40px; display: block; max-width: 148.62px;"/>
-                            </div>
-                            <div style="margin-left: 140px;">
-                                <p style="color: #00adee; font-size: 16px; font-weight: 700; margin: 0; letter-spacing: -0.06em; line-height: 32px;">
-                                    모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
-                                </p>
-                            </div>
-                            <div style="clear: both;"></div>
-                        </div>
+                    <td style="padding-bottom: 24px">
+                        <table cellpadding="0" cellspacing="0" width="100%">
+                            <tr>
+                                <td style="width: 118.49px; height: 32px">
+                                    <img alt="PlayHive 로고 이미지" src="https://media.playhive.co.kr/image/Logo.png"
+                                         style="width: 100%; height: 100%; object-fit: cover"/>
+                                </td>
+                                <td style="padding-left: 16px">
+                                    <p
+                                            style="width: 325px; height: 32px; color: #00adee; font-size: 16px; font-weight: 700; margin: 0; letter-spacing: -0.04em; line-height: 32px;">
+                                        모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
+                                    </p>
+                                </td>
+                            </tr>
+                        </table>
                     </td>
                 </tr>
 
                 <tr>
                     <td style="padding-bottom: 24px;">
-                        <h5 style="font-size: 28px; font-weight: 700; line-height: 40px; color: #000; margin: 0; letter-spacing: -0.04em;">
-                            <span th:text="${email}">example@email.com</span>님
+                        <h5
+                                style="font-size: 28px; font-weight: 700; line-height: 40px; color: #000; margin: 0; letter-spacing: -0.04em;">
+                            <span th:text="${nickname}">익명의 유저</span>&nbsp;회원님
                         </h5>
                         <p style="font-size: 14px; font-weight: 500; line-height: 20px; color: #424242; margin: 8px 0 0;">
                             안녕하세요? 플레이 하이브 입니다. 회원님의 임시 비밀번호를 확인해주세요.<br/>
@@ -53,11 +58,12 @@
                 <tr>
                     <td style="width: 648px; padding: 8px 16px; background-color: #fafafa; color: #424242;">
                         <p style="margin: 0; font-size: 20px; font-weight: 700; line-height: 36px; letter-spacing: -0.02em;">
-                <span style="margin: 0 16px 4px 0; font-size: 20px; font-weight: 500; line-height: 36px; letter-spacing: -0.02em; color: #444;">
+                <span
+                        style="margin: 0 16px 4px 0; font-size: 20px; font-weight: 500; line-height: 36px; letter-spacing: -0.02em; color: #444;">
                   임시 비밀번호
                 </span>
-                            <span th:text="${password}"
-                                  style="font-weight: 700; font-size: 20px; line-height: 36px; letter-spacing: -0.02em;">
+                            <span style="font-weight: 700; font-size: 20px; line-height: 36px; letter-spacing: -0.02em;"
+                                  th:text="${password}">
                   tempPassword123
                 </span>
                         </p>
@@ -83,7 +89,8 @@
     </tr>
 
     <tr>
-        <td style="width: 648px; font-size: 14px; font-weight: 500; line-height: 20px; color: #424242; letter-spacing: -0.02em;">
+        <td
+                style="width: 648px; font-size: 14px; font-weight: 500; line-height: 20px; color: #424242; letter-spacing: -0.02em;">
             본 메일은 발신전용으로 회신하실 경우 답변이 되지 않습니다. 자세한 사항은
             <a href="https://playhive.co.kr/customer" style="color: #00aaee; text-decoration: underline;">
                 플레이하이브 고객센터
@@ -92,16 +99,17 @@
     </tr>
 </table>
 
+<!-- footer -->
 <div style="width: 100%; background-color: #000;">
-    <table width="728" align="center" cellpadding="0" cellspacing="0"
-           style="background-color: #000; padding: 40px 40px 0;">
+    <table align="center" cellpadding="0" cellspacing="0" style="background-color: #000; padding: 40px 40px 0;"
+           width="728">
         <tr>
             <td>
-                <table width="648" cellpadding="0" cellspacing="0">
+                <table cellpadding="0" cellspacing="0" width="648">
                     <tr>
                         <td style="padding-bottom: 24px;">
                             <div style="width: 148.62px; height: 40px;">
-                                <img src="https://media.playhive.co.kr/image/logo_white.png" alt="PlayHive"
+                                <img alt="PlayHive" src="https://media.playhive.co.kr/image/logo_white.png"
                                      style="width: 100%; height: 100%; object-fit: cover;"/>
                             </div>
                         </td>
@@ -109,7 +117,8 @@
 
                     <tr>
                         <td>
-                            <p style="font-weight: 500; font-size: 24px; line-height: 38px; letter-spacing: -0.04em; color: white; margin: 0;">
+                            <p
+                                    style="font-weight: 500; font-size: 24px; line-height: 38px; letter-spacing: -0.04em; color: white; margin: 0;">
                                 열정적으로 응원하고 서로를 존중하며<br/>
                                 <span style="font-weight: 700;">
                     모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
@@ -120,16 +129,16 @@
 
                     <tr>
                         <td style="padding-top: 24px;">
-                            <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; color: #a6a6a6; margin: 0;">
+                            <p
+                                    style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; color: #a6a6a6; margin: 0;">
                                 서비스명: PlayHive · 대표: 홍길표 · 개인정보 보호책임자: 홍길표<br/>
                                 콘텐츠 내용에 대한 저작권 및 법적 책임은 자료제공자 또는 글쓴이에 있으며 PlayHive의 입장과 다를 수 있습니다.
                             </p>
                         </td>
                     </tr>
                 </table>
-
-                <table width="648" cellpadding="0" cellspacing="0"
-                       style="margin-top: 24px; border-top: 1px solid #424242;">
+                <table cellpadding="0" cellspacing="0" style="margin-top: 24px; border-top: 1px solid #424242;"
+                       width="648">
                     <tr>
                         <td style="height: 80px; color: #a6a6a6;">
                             <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; margin: 0;">
@@ -138,10 +147,10 @@
                         </td>
                     </tr>
                 </table>
-
             </td>
         </tr>
     </table>
 </div>
 </body>
+
 </html>

--- a/src/main/resources/templates/mail/user-account-banned.html
+++ b/src/main/resources/templates/mail/user-account-banned.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="x-apple-disable-message-reformatting" />
+  <title>PlayHive 계정 정지 메일</title>
+</head>
+
+<style>
+  @font-face {
+    font-family: "SUIT Variable";
+    font-style: normal;
+    font-weight: 100 900;
+    src: url("https://cdn.jsdelivr.net/gh/sun-typeface/SUIT/fonts/variable/woff2/SUIT-Variable.woff2") format("woff2");
+  }
+</style>
+
+<body
+  style="margin: 0; padding: 0; font-family: 'SUIT Variable', Arial, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
+  <table width="728" align="center" cellpadding="0" cellspacing="0"
+    style="background-color: white; padding: 40px; box-sizing: border-box;">
+    <tr>
+      <td>
+        <table width="648" cellpadding="0" cellspacing="0" style="margin: 0 auto">
+          <!-- header -->
+          <tr>
+            <td style="padding-bottom: 24px">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="width: 118.49px; height: 32px">
+                    <img src="https://media.playhive.co.kr/image/Logo.png" alt="PlayHive 로고 이미지"
+                      style="width: 100%; height: 100%; object-fit: cover" />
+                  </td>
+                  <td style="padding-left: 16px">
+                    <p
+                      style="width: 325px; height: 32px; color: #00adee; font-size: 16px; font-weight: 700; margin: 0; letter-spacing: -0.04em; line-height: 32px;">
+                      모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- body -->
+          <tr>
+            <td style="height: 88px; padding-bottom: 8px">
+              <h5
+                style="width: 648px; font-size: 28px; font-weight: 700; line-height: 40px; color: #000; margin: 0; letter-spacing: -0.04em;">
+                <span th:text="${nickname}">익명의 유저</span>&nbsp;회원님
+              </h5>
+              <h6
+                style="width: 648px; font-size: 28px; font-weight: 700; line-height: 40px; color: #D1504B; margin: 0; letter-spacing: -0.04em;">
+                이용약관에 위배되는 행위로 인해 계정이 정지되었습니다.
+              </h6>
+            </td>
+          </tr>
+
+          <td style="font-weight: 500; font-size: 14px; line-height: 20px; color: #424242; margin: 0;">
+            <p style="margin: 0;">
+              안녕하세요? 플레이 하이브 입니다.<br />
+              이용자님의 게시글, 댓글, 채팅 등 활동 중 다수의 신고 혹은 자체 시스템을 바탕으로 한 검토로 인하여
+              이용약관에 위배되는 행위로 간주되어 계정이 정지되었습니다.<br /><br />
+              관련 문의사항이 있다면, 플레이하이브 고객센터 또는 플레이하이브팀에 문의 주시기 바랍니다.<br /><br />
+              감사합니다.
+            </p>
+          </td>
+    </tr>
+
+    <tr>
+      <td style="min-width: 184px; padding: 24px 0;">
+        <a href="https://playhive.co.kr/?guest-modal=true"
+          style="width: 184px; height: 48px; background-color: #00adee; color: #ffffff; font-size: 16px; font-weight: 700; text-decoration: none; text-align: center; line-height: 48px; border-radius: 5px; padding: 14px 20px;">
+          플레이하이브 고객센터 문의하기
+        </a>
+      </td>
+    </tr>
+
+    <tr>
+      <td style="width: 648px; font-size: 14px; font-weight: 500; line-height: 20px; color: #424242;">
+        본 메일은 발신전용으로 회신하실 경우 답변이 되지 않습니다. 자세한 사항은
+        <a href="https://playhive.co.kr/"
+          style="color: #00aaee; text-decoration: underline; text-underline-offset: 2px;">
+          플레이하이브 고객센터
+        </a>
+        를 이용하세요.
+      </td>
+    </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+
+  <!-- footer -->
+  <div style="width: 100%; background-color: #000;">
+    <table width="728" align="center" cellpadding="0" cellspacing="0"
+      style="background-color: #000; padding: 40px 40px 0;">
+      <tr>
+        <td>
+          <table width="648" cellpadding="0" cellspacing="0">
+            <tr>
+              <td style="padding-bottom: 24px;">
+                <div style="width: 148.62px; height: 40px;">
+                  <img src="https://media.playhive.co.kr/image/logo_white.png" alt="PlayHive"
+                    style="width: 100%; height: 100%; object-fit: cover;" />
+                </div>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <p
+                  style="font-weight: 500; font-size: 24px; line-height: 38px; letter-spacing: -0.04em; color: white; margin: 0;">
+                  열정적으로 응원하고 서로를 존중하며<br />
+                  <span style="font-weight: 700;">
+                    모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
+                  </span>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding-top: 24px;">
+                <p
+                  style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; color: #a6a6a6; margin: 0;">
+                  서비스명: PlayHive · 대표: 홍길표 · 개인정보 보호책임자: 홍길표<br />
+                  콘텐츠 내용에 대한 저작권 및 법적 책임은 자료제공자 또는 글쓴이에 있으며 PlayHive의 입장과 다를 수 있습니다.
+                </p>
+              </td>
+            </tr>
+          </table>
+          <table width="648" cellpadding="0" cellspacing="0" style="margin-top: 24px; border-top: 1px solid #424242;">
+            <tr>
+              <td style="height: 80px; color: #a6a6a6;">
+                <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; margin: 0;">
+                  Copyright © PlayHive Co., Ltd All rights reserved.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/mail/user-account-warning.html
+++ b/src/main/resources/templates/mail/user-account-warning.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns="http://www.w3.org/1999/xhtml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="x-apple-disable-message-reformatting" />
+  <title>PlayHive 계정 경고 메일</title>
+</head>
+
+<style>
+  @font-face {
+    font-family: "SUIT Variable";
+    font-style: normal;
+    font-weight: 100 900;
+    src: url("https://cdn.jsdelivr.net/gh/sun-typeface/SUIT/fonts/variable/woff2/SUIT-Variable.woff2") format("woff2");
+  }
+</style>
+
+<body
+  style="margin: 0; padding: 0; font-family: 'SUIT Variable', Arial, 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;">
+  <table width="728" align="center" cellpadding="0" cellspacing="0"
+    style="background-color: white; padding: 40px; box-sizing: border-box;">
+    <tr>
+      <td>
+        <table width="648" cellpadding="0" cellspacing="0" style="margin: 0 auto">
+          <!-- header -->
+          <tr>
+            <td style="padding-bottom: 24px">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="width: 118.49px; height: 32px">
+                    <img src="https://media.playhive.co.kr/image/Logo.png" alt="PlayHive 로고 이미지"
+                      style="width: 100%; height: 100%; object-fit: cover" />
+                  </td>
+                  <td style="padding-left: 16px">
+                    <p
+                      style="width: 325px; height: 32px; color: #00adee; font-size: 16px; font-weight: 700; margin: 0; letter-spacing: -0.04em; line-height: 32px;">
+                      모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- body -->
+          <tr>
+            <td style="height: 88px; padding-bottom: 8px">
+              <h5
+                style="width: 648px; font-size: 28px; font-weight: 700; line-height: 40px; color: #000; margin: 0; letter-spacing: -0.04em;">
+                <span th:text="${nickname}">익명의 유저</span>&nbsp;회원님
+              </h5>
+              <h6
+                style="width: 648px; font-size: 28px; font-weight: 700; line-height: 40px; color: #D1504B; margin: 0; letter-spacing: -0.04em;">
+                이용약관에 위배되는 행위로 인해 계정이 경고되었습니다.
+              </h6>
+            </td>
+          </tr>
+
+          <td style="font-weight: 500; font-size: 14px; line-height: 20px; color: #424242; margin: 0;">
+            <p style="margin: 0;">
+              안녕하세요? 플레이 하이브 입니다.<br />
+              이용자님의 게시글, 댓글, 채팅 등 활동 중 다수의 신고 혹은 자체 시스템을 바탕으로 한 검토로 인하여
+              이용약관에 위배되는 행위로 간주되어 계정이 경고되었습니다.<br /><br />
+              이에 따라 조금 더 클린한 커뮤니티 조성에 협조해주시기를 진심으로 부탁드리며, 추후 관련 행위가 반복적발시에는
+              계정 정지 조치가 이루어지오니, 이 점 참고하시어 매너채팅과 클린한 커뮤니티 활동 부탁드립니다.
+              관련 문의사항이 있다면, 플레이하이브 고객센터 또는 플레이하이브팀에 문의 주시기 바랍니다.<br /><br />
+              감사합니다.
+            </p>
+          </td>
+    </tr>
+
+    <tr>
+      <td style="min-width: 184px; padding: 24px 0;">
+        <a href="https://playhive.co.kr/sign"
+          style="width: 184px; height: 48px; background-color: #00adee; color: #ffffff; font-size: 16px; font-weight: 700; text-decoration: none; text-align: center; line-height: 48px; border-radius: 5px; padding: 14px 20px;">
+          플레이하이브 보러가기
+        </a>
+      </td>
+    </tr>
+
+    <tr>
+      <td style="width: 648px; font-size: 14px; font-weight: 500; line-height: 20px; color: #424242;">
+        본 메일은 발신전용으로 회신하실 경우 답변이 되지 않습니다. 자세한 사항은
+        <a href="https://playhive.co.kr/customer"
+          style="color: #00aaee; text-decoration: underline; text-underline-offset: 2px;">
+          플레이하이브 고객센터
+        </a>
+        를 이용하세요.
+      </td>
+    </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+
+  <!-- footer -->
+  <div style="width: 100%; background-color: #000;">
+    <table width="728" align="center" cellpadding="0" cellspacing="0"
+      style="background-color: #000; padding: 40px 40px 0;">
+      <tr>
+        <td>
+          <table width="648" cellpadding="0" cellspacing="0">
+            <tr>
+              <td style="padding-bottom: 24px;">
+                <div style="width: 148.62px; height: 40px;">
+                  <img src="https://media.playhive.co.kr/image/logo_white.png" alt="PlayHive"
+                    style="width: 100%; height: 100%; object-fit: cover;" />
+                </div>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+                <p
+                  style="font-weight: 500; font-size: 24px; line-height: 38px; letter-spacing: -0.04em; color: white; margin: 0;">
+                  열정적으로 응원하고 서로를 존중하며<br />
+                  <span style="font-weight: 700;">
+                    모두 함께 즐기는 클린 스포츠 커뮤니티, 플레이 하이브!
+                  </span>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding-top: 24px;">
+                <p
+                  style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; color: #a6a6a6; margin: 0;">
+                  서비스명: PlayHive · 대표: 홍길표 · 개인정보 보호책임자: 홍길표<br />
+                  콘텐츠 내용에 대한 저작권 및 법적 책임은 자료제공자 또는 글쓴이에 있으며 PlayHive의 입장과 다를 수 있습니다.
+                </p>
+              </td>
+            </tr>
+          </table>
+          <table width="648" cellpadding="0" cellspacing="0" style="margin-top: 24px; border-top: 1px solid #424242;">
+            <tr>
+              <td style="height: 80px; color: #a6a6a6;">
+                <p style="font-weight: 500; font-size: 16px; line-height: 24px; letter-spacing: -0.02em; margin: 0;">
+                  Copyright © PlayHive Co., Ltd All rights reserved.
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
## 기능 설명
- 회원 가입 성공 이메일 전송 시 email -> nickname으로 변경, 이메일 형식 _ 허용 추가, 이메일 템플릿 수정 및 추가

### 작업 내용
- 회원 가입 성공 이메일 전송시에 email 말고 nickname으로 변경 요청 들어온 작업 진행하였습니다.
- 제 이메일은 언더바(_)가 들어가는데 막혀있어서 허용 추가했습니다.
- 프론트측에서 새로 받은 이메일 템플릿 수정 및 추가하였습니다.
- memberService에서 이메일 전송이 주석처리 되어있어서 해제 하였습니다.

## 수정 사항
- 
## 추가 작업 예정
- 
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인