### PR TITLE
feat: add admin member controll

### DIFF
--- a/src/main/java/org/myteam/server/admin/dto/ctes/BoardCountCte.java
+++ b/src/main/java/org/myteam/server/admin/dto/ctes/BoardCountCte.java
@@ -1,0 +1,19 @@
+package org.myteam.server.admin.dto.ctes;
+
+import com.blazebit.persistence.CTE;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+import java.util.UUID;
+
+
+@Entity
+@Getter
+@CTE
+public class BoardCountCte {
+    @Id
+    private UUID publicId;
+    private Long count;
+    private Integer recommendCount;
+}

--- a/src/main/java/org/myteam/server/admin/dto/ctes/CommentCountCte.java
+++ b/src/main/java/org/myteam/server/admin/dto/ctes/CommentCountCte.java
@@ -1,0 +1,18 @@
+package org.myteam.server.admin.dto.ctes;
+
+import com.blazebit.persistence.CTE;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@CTE
+public class CommentCountCte {
+    @Id
+    private UUID publicID;
+    private Long count;
+    private Integer recommendCount;
+}

--- a/src/main/java/org/myteam/server/admin/dto/ctes/MemberReportCte.java
+++ b/src/main/java/org/myteam/server/admin/dto/ctes/MemberReportCte.java
@@ -18,5 +18,6 @@ public class MemberReportCte {
     private Long reportedId;
     @Enumerated(EnumType.STRING)
     private ReportType reportType;
+    private Long reportCount;
 
 }

--- a/src/main/java/org/myteam/server/admin/dto/ctes/ReportCountCte.java
+++ b/src/main/java/org/myteam/server/admin/dto/ctes/ReportCountCte.java
@@ -1,0 +1,18 @@
+package org.myteam.server.admin.dto.ctes;
+
+
+import com.blazebit.persistence.CTE;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@CTE
+public class ReportCountCte {
+    @Id
+    private UUID publicId;
+    private Long count;
+}

--- a/src/main/java/org/myteam/server/admin/dto/ctes/SimpleReportCte.java
+++ b/src/main/java/org/myteam/server/admin/dto/ctes/SimpleReportCte.java
@@ -1,0 +1,19 @@
+package org.myteam.server.admin.dto.ctes;
+
+
+import com.blazebit.persistence.CTE;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import org.myteam.server.report.domain.ReportType;
+
+@CTE
+@Entity
+public class SimpleReportCte {
+
+    @Id
+    private Long reportedId;
+    @Enumerated(EnumType.STRING)
+    private ReportType reportType;
+}

--- a/src/main/java/org/myteam/server/admin/dto/request/MemberSearchRequestDto.java
+++ b/src/main/java/org/myteam/server/admin/dto/request/MemberSearchRequestDto.java
@@ -1,0 +1,105 @@
+package org.myteam.server.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.global.util.date.DateFormatUtil;
+import org.myteam.server.member.domain.GenderType;
+import org.myteam.server.member.domain.MemberStatus;
+import org.myteam.server.member.domain.MemberType;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MemberSearchRequestDto() {
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "RequestMemberSearch", description = "조건에 따른 회원들의 정보를 가져올떄 사용합니다")
+    public static class RequestMemberSearch {
+        private String nickName;
+        private String email;
+        @Size(max = 11)
+        private String tel;
+        private GenderType genderType;
+        @Schema(description = "회원의 가입경로 구글,디스코드 등등을 말합니다.")
+        private MemberType memberType;
+        private MemberStatus status;
+        @Schema(description = "회원의 생년월일에 해당됩니다.")
+        @Size(max = 6, min = 6)
+        private String birthDate;
+        @Schema(example = "2025.06.06")
+        private String signInStart;
+        @Schema(example = "2025.06.06")
+        private String signInEnd;
+        @NotNull(message = "offset은 비면 안됩니다.")
+        @Schema(description = "필수값입니다")
+        private int offset;
+        @Builder
+        public RequestMemberSearch(String nickName, String email, String tel
+                , GenderType genderType, MemberType memberType, String birthDate,
+                                   String signInStart, String signInEnd, int offset) {
+            this.nickName = nickName;
+            this.email = email;
+            this.tel = tel;
+            this.genderType = genderType;
+            this.memberType = memberType;
+            this.birthDate = birthDate;
+            this.signInStart = signInStart;
+            this.signInEnd = signInEnd;
+            this.offset = offset;
+        }
+
+
+        public int getOffset() {
+            return this.offset - 1;
+        }
+
+        public LocalDateTime provideStartTime() {
+            if (signInStart == null) {
+                return null;
+            }
+            LocalDate localDate = LocalDate.parse(signInStart, DateFormatUtil.formatByDot);
+            return localDate.atStartOfDay();
+        }
+
+        public LocalDateTime provideEndTime() {
+            if (signInEnd == null) {
+                return null;
+            }
+            LocalDate localDate = LocalDate.parse(signInEnd, DateFormatUtil.formatByDot);
+            return localDate.atStartOfDay();
+        }
+
+
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "RequestMemberDetail", description = "회원의 상세정보를 요구시에 사용합니다 혹은" +
+            "회원을 대상으로한 신고 목록을 조회시에 사용하면 됩니다.")
+    public static class RequestMemberDetail {
+        @NotNull(message = "유저 식별값은 비면 안됩니다")
+        @Schema(description = "필수값입니다.")
+        private UUID publicId;
+
+        @Schema(description = "이 객체는 회원 한명에 대한 데이터와 회원에 대해 발생한 신고에대해서" +
+                "쓰이기에 offset을 넣주었고 회원 한명에대한 데이터를 볼때에는 offset에 아무값이나 넣어줘도" +
+                "알아서 걸러줍니다.")
+        @NotNull
+        private int offset;
+
+        @Builder
+        public RequestMemberDetail(UUID publicId, int offset) {
+            this.publicId = publicId;
+            this.offset = offset;
+
+        }
+
+        public int getOffset() {
+            return this.offset - 1;
+        }
+    }
+}

--- a/src/main/java/org/myteam/server/admin/dto/response/MemberSearchResponseDto.java
+++ b/src/main/java/org/myteam/server/admin/dto/response/MemberSearchResponseDto.java
@@ -1,0 +1,121 @@
+package org.myteam.server.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static org.myteam.server.admin.dto.response.CommonResponseDto.*;
+
+public record MemberSearchResponseDto() {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ResponseMemberSearch {
+        private String status;
+        private String nickName;
+        private Long boardCount;
+        private Long commentCount;
+        private Long reportCount;
+        private Integer recommendCount;
+        private String genderType;
+        private String memberType;
+        private String email;
+        private String tel;
+        private String createDate;
+
+        public void updateCreateDate(String date) {
+            this.createDate = date;
+        }
+    }
+
+    @Getter
+    public static class ResponseReportList {
+        private Long contentId;
+        private String reportedDate;
+        private Long reportedCount;
+        private String reportType;
+        private String content;
+
+        public ResponseReportList(Long contentId, String reportedDate, Long reportedCount,
+                                  String reportType, String content) {
+            this.contentId = contentId;
+            this.reportedDate = reportedDate;
+            this.reportedCount = reportedCount;
+            this.reportType = reportType;
+            this.content = content;
+        }
+
+        public void updateReportDate(String date) {
+            this.reportedDate = date;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ResponseMemberDetail {
+        private String nickName;
+        private String email;
+        private String tel;
+        private String genderType;
+        private String memberType;
+        private int birthYear;
+        private int birthMonth;
+        private int birthDay;
+        private String createDate;
+        @Schema(description = "최근 접속 일자")
+        private String accessTime;
+        @Schema(description = "최근 접속 ip")
+        private String ip;
+        private int countVisit;
+        private Integer recommendCount;
+        private Long countImprovement;
+        private Long countBoard;
+        private Long countComment;
+        private Long reportedCount;
+        private Long reportCount;
+        private String status;
+        @Schema(description = "관리자 들이 해당 회원에 대해서 작성한 메모입니다. 작성일 기준으로 오름차순입니다.")
+        private List<AdminMemoResponse> adminMemoResponses;
+
+        public ResponseMemberDetail(String nickName, String email, String tel, String genderType, String memberType, int birthYear, int birthMonth, int birthDay, String createDate, String accessTime, String ip, int countVisit,
+                                    Integer recommendCount, Long countImprovement,
+                                    Long countBoard, Long countComment, Long reportedCount,
+                                    Long reportCount, String status) {
+            this.nickName = nickName;
+            this.email = email;
+            this.tel = tel;
+            this.genderType = genderType;
+            this.memberType = memberType;
+            this.birthYear = birthYear;
+            this.birthMonth = birthMonth;
+            this.birthDay = birthDay;
+            this.createDate = createDate;
+            this.accessTime = accessTime;
+            this.ip = ip;
+            this.countVisit = countVisit;
+            this.recommendCount = recommendCount;
+            this.countImprovement = countImprovement;
+            this.countBoard = countBoard;
+            this.countComment = countComment;
+            this.reportedCount = reportedCount;
+            this.reportCount = reportCount;
+            this.status = status;
+        }
+
+        public void updateAdminMemoResponse(List<AdminMemoResponse> adminMemoResponses) {
+            this.adminMemoResponses = adminMemoResponses;
+        }
+
+        public void updateAccessDate(String date) {
+            this.accessTime = date;
+        }
+
+        public void updateCreateDate(String date) {
+            this.createDate = date;
+        }
+    }
+
+}

--- a/src/main/java/org/myteam/server/admin/repository/AdminMemberRepository.java
+++ b/src/main/java/org/myteam/server/admin/repository/AdminMemberRepository.java
@@ -1,0 +1,441 @@
+package org.myteam.server.admin.repository;
+
+import com.blazebit.persistence.querydsl.BlazeJPAQuery;
+import com.blazebit.persistence.querydsl.BlazeJPAQueryFactory;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.admin.dto.ctes.QBoardCountCte;
+import org.myteam.server.admin.dto.ctes.QCommentCountCte;
+import org.myteam.server.admin.dto.ctes.QMemberReportCte;
+import org.myteam.server.admin.dto.ctes.QReportCountCte;
+import org.myteam.server.admin.entity.AdminChangeLog;
+import org.myteam.server.admin.entity.AdminMemo;
+import org.myteam.server.admin.repository.simpleRepo.AdminChangeLogRepo;
+import org.myteam.server.admin.repository.simpleRepo.AdminMemoRepository;
+import org.myteam.server.admin.utill.CreateAdminMemo;
+import org.myteam.server.global.util.date.DateFormatUtil;
+import org.myteam.server.member.domain.GenderType;
+import org.myteam.server.member.domain.MemberRole;
+import org.myteam.server.member.domain.MemberStatus;
+import org.myteam.server.member.domain.MemberType;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.entity.QMember;
+import org.myteam.server.report.domain.ReportType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import static org.myteam.server.admin.dto.request.MemberSearchRequestDto.*;
+import static org.myteam.server.admin.dto.response.CommonResponseDto.*;
+import static org.myteam.server.admin.dto.response.MemberSearchResponseDto.*;
+import static org.myteam.server.board.domain.QBoard.board;
+import static org.myteam.server.board.domain.QBoardCount.boardCount;
+import static org.myteam.server.comment.domain.QComment.comment1;
+import static org.myteam.server.improvement.domain.QImprovement.improvement;
+import static org.myteam.server.member.entity.QMember.member;
+import static org.myteam.server.member.entity.QMemberActivity.memberActivity;
+import static org.myteam.server.report.domain.QReport.report;
+
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class AdminMemberRepository {
+    private final AdminChangeLogRepo adminChangeLogRepo;
+    private final JPAQueryFactory queryFactory;
+    private final BlazeJPAQueryFactory blazeJPAQueryFactory;
+    private final CreateAdminMemo createAdminMemo;
+
+
+    public Page<ResponseMemberSearch> getMemberDataList(RequestMemberSearch requestMemberSearch) {
+        Pageable pageable = PageRequest.of(requestMemberSearch.getOffset(), 10);
+        QBoardCountCte boardCounting = new QBoardCountCte("boardCounting");
+        QCommentCountCte commentCount = new QCommentCountCte("commentCount");
+        QReportCountCte reportCount = new QReportCountCte("reportCount");
+
+        BlazeJPAQuery blazeJPAQuery = blazeJPAQueryFactory
+                .from(board)
+                .join(member)
+                .on(member.eq(board.member))
+                .join(boardCount)
+                .on(boardCount.board.eq(board))
+                .groupBy(member.publicId)
+                .bind(boardCounting.publicId, member.publicId)
+                .bind(boardCounting.count, board.id.count().coalesce(0L))
+                .bind(boardCounting.recommendCount, boardCount.recommendCount.sum().coalesce(0));
+
+        BlazeJPAQuery blazeJPAQuery1 = blazeJPAQueryFactory
+                .from(comment1)
+                .join(member)
+                .on(member.eq(comment1.member))
+                .groupBy(member.publicId)
+                .bind(commentCount.publicID, member.publicId)
+                .bind(commentCount.count, comment1.id.count().coalesce(0L))
+                .bind(commentCount.recommendCount, comment1.recommendCount.sum().coalesce(0));
+
+        BlazeJPAQuery blazeJPAQuery2 = blazeJPAQueryFactory
+                .from(report)
+                .join(member)
+                .on(member.eq(report.reported))
+                .groupBy(member.publicId)
+                .bind(reportCount.publicId, member.publicId)
+                .bind(reportCount.count, report.id.count().coalesce(0L));
+
+        List<ResponseMemberSearch> responseSearchUserLists = blazeJPAQueryFactory
+                .with(
+                        boardCounting, blazeJPAQuery
+
+                )
+                .with(
+                        commentCount, blazeJPAQuery1
+                )
+                .with(reportCount, blazeJPAQuery2
+                )
+                .select(
+                        Projections.constructor(ResponseMemberSearch.class,
+                                new CaseBuilder()
+                                        .when(member.status.eq(MemberStatus.ACTIVE))
+                                        .then("정상")
+                                        .when(member.status.eq(MemberStatus.INACTIVE))
+                                        .then("정지")
+                                        .otherwise("경고"),
+                                member.nickname,
+                                new CaseBuilder()
+                                        .when(boardCounting.isNull())
+                                        .then(0L)
+                                        .otherwise(boardCounting.count),
+                                new CaseBuilder()
+                                        .when(commentCount.isNull())
+                                        .then(0L)
+                                        .otherwise(commentCount.count),
+                                new CaseBuilder()
+                                        .when(reportCount.isNull())
+                                        .then(0L)
+                                        .otherwise(reportCount.count),
+                                new CaseBuilder()
+                                        .when(boardCounting.recommendCount.coalesce(0).gt(0)
+                                                .and(commentCount.recommendCount.coalesce(0).gt(0)))
+                                        .then(boardCounting.recommendCount.add(commentCount.recommendCount))
+                                        .when(boardCounting.recommendCount.coalesce(0).eq(0)
+                                                .and(commentCount.recommendCount.coalesce(0).gt(0)))
+                                        .then(commentCount.recommendCount)
+                                        .when(boardCounting.recommendCount.coalesce(0).gt(0)
+                                                .and(commentCount.recommendCount.coalesce(0).eq(0)))
+                                        .then(boardCounting.recommendCount)
+                                        .otherwise(0),
+                                new CaseBuilder()
+                                        .when(member.genderType.eq(GenderType.F))
+                                        .then("여성")
+                                        .when(member.genderType.eq(GenderType.M))
+                                        .then("남자")
+                                        .otherwise("-"),
+                                new CaseBuilder()
+                                        .when(member.type.eq(MemberType.DISCORD))
+                                        .then("디스코드")
+                                        .when(member.type.eq(MemberType.GOOGLE))
+                                        .then("구글")
+                                        .when(member.type.eq(MemberType.KAKAO))
+                                        .then("카카오")
+                                        .when(member.type.eq(MemberType.NAVER))
+                                        .then("네이버")
+                                        .otherwise("일반"),
+                                member.email,
+                                member.tel,
+                                member.createDate.stringValue()
+                        )
+                )
+                .from(member)
+                .leftJoin(boardCounting)
+                .on(boardCounting.publicId.eq(member.publicId))
+                .leftJoin(commentCount)
+                .on(commentCount.publicID.eq(member.publicId))
+                .leftJoin(reportCount)
+                .on(reportCount.publicId.eq(member.publicId))
+                .where(userListSearchCond(requestMemberSearch), member.role.notIn(MemberRole.ADMIN))
+                .orderBy(member.createDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        responseSearchUserLists.stream().forEach(
+                x -> {
+                    x.updateCreateDate(
+                            DateFormatUtil.formatByDot
+                                    .format(LocalDateTime.parse(x.getCreateDate(), DateFormatUtil
+                                            .FLEXIBLE_NANO_FORMATTER)));
+                }
+        );
+
+        Long userTot = Optional.ofNullable(queryFactory.select(member.count())
+                        .from(member)
+                        .where(userListSearchCond(requestMemberSearch))
+                        .fetchOne())
+                .orElse(0L);
+        return new PageImpl<>(responseSearchUserLists, pageable, userTot);
+
+    }
+
+    public ResponseMemberDetail getMemberDetail(UUID publicId) {
+
+        QBoardCountCte boardCounting = new QBoardCountCte("boardCounting");
+        QCommentCountCte commentCount = new QCommentCountCte("commentCount");
+        QMember subQueryImprovementMember = new QMember("subQueryImprovementMember");
+        QMember subQueryReportedMember = new QMember("subQueryReportedMember");
+        QMember subQueryReporterMember = new QMember("subQueryReporterMember");
+
+
+        BlazeJPAQuery blazeJPAQuery = blazeJPAQueryFactory
+                .from(board)
+                .join(member)
+                .on(member.eq(board.member))
+                .join(boardCount)
+                .on(boardCount.board.eq(board))
+                .where(member.publicId.eq(publicId))
+                .groupBy(member.publicId)
+                .bind(boardCounting.publicId, member.publicId)
+                .bind(boardCounting.count, board.id.count().coalesce(0L))
+                .bind(boardCounting.recommendCount, boardCount.recommendCount.sum().coalesce(0));
+
+        BlazeJPAQuery blazeJPAQuery1 = blazeJPAQueryFactory
+                .from(comment1)
+                .join(member)
+                .on(member.eq(comment1.member))
+                .where(member.publicId.eq(publicId))
+                .groupBy(member.publicId)
+                .bind(commentCount.publicID, member.publicId)
+                .bind(commentCount.count, comment1.id.count().coalesce(0L))
+                .bind(commentCount.recommendCount, comment1.recommendCount.sum().coalesce(0));
+
+        ResponseMemberDetail responseMemberDetail = blazeJPAQueryFactory
+                .with(
+                        boardCounting, blazeJPAQuery
+
+                )
+                .with(
+                        commentCount, blazeJPAQuery1
+                )
+                .select(Projections.constructor(ResponseMemberDetail.class,
+                        member.nickname,
+                        member.email,
+                        member.tel,
+                        new CaseBuilder()
+                                .when(member.genderType.eq(GenderType.M))
+                                .then("남성")
+                                .when(member.genderType.eq(GenderType.F))
+                                .then("여성")
+                                .otherwise("-"),
+                        new CaseBuilder()
+                                .when(member.type.eq(MemberType.DISCORD))
+                                .then("디스코드")
+                                .when(member.type.eq(MemberType.GOOGLE))
+                                .then("구글")
+                                .when(member.type.eq(MemberType.KAKAO))
+                                .then("카카오")
+                                .when(member.type.eq(MemberType.NAVER))
+                                .then("네이버")
+                                .otherwise("일반"),
+                        member.birthYear,
+                        member.birthMonth,
+                        member.birthDay,
+                        member.createDate.stringValue(),
+                        Expressions.constant("hello"),
+                        /*memberActivity.latestAccessTime,
+                        memberActivity.latestIp,
+                        추후에 memberaccess객체를 가져와서 작업해야되는걸로 생각됨.
+                        */
+                        Expressions.constant("hello"),
+                        memberActivity.visitCount,
+                        boardCounting.recommendCount.add(commentCount.recommendCount),
+                        JPAExpressions.select(improvement.count())
+                                .from(improvement)
+                                .join(subQueryImprovementMember)
+                                .on(subQueryImprovementMember.eq(improvement.member))
+                                .where(subQueryImprovementMember.publicId.eq(publicId)),
+                        boardCounting.count,
+                        commentCount.count,
+                        JPAExpressions
+                                .select(
+                                        report.reported.count()
+                                )
+                                .from(report)
+                                .join(subQueryReportedMember)
+                                .on(subQueryReportedMember.eq(report.reported))
+                                .where(subQueryReportedMember.publicId.eq(publicId)),
+                        JPAExpressions
+                                .select(
+                                        report.reporter.count()
+                                )
+                                .from(report)
+                                .join(subQueryReporterMember)
+                                .on(subQueryReporterMember.eq(report.reporter))
+                                .where(subQueryReporterMember.publicId.eq(publicId)),
+                        new CaseBuilder()
+                                .when(member.status.eq(MemberStatus.ACTIVE))
+                                .then("정상")
+                                .when(member.status.eq(MemberStatus.INACTIVE))
+                                .then("정지")
+                                .otherwise("경고")
+                ))
+                .from(member)
+                .join(boardCounting)
+                .on(boardCounting.publicId.eq(member.publicId))
+                .join(commentCount)
+                .on(commentCount.publicID.eq(member.publicId))
+                .join(memberActivity)
+                .on(memberActivity.member.eq(member))
+                .where(member.publicId.eq(publicId))
+                .fetch()
+                .get(0);
+
+        editTime(publicId, responseMemberDetail);
+
+        return responseMemberDetail;
+
+    }
+
+    public void updateMemberStatus(Member writer, UUID publicId, String content, MemberStatus targetStatus,
+                                   MemberStatus memberStatus) {
+        createAdminMemo.createMemberMemo(writer,
+               publicId,content,targetStatus,memberStatus);
+    }
+
+
+    public Page<ResponseReportList> getMemberReportedList(RequestMemberDetail requestMemberDetail) {
+
+        UUID publicId = requestMemberDetail.getPublicId();
+        Pageable pageable = PageRequest.of(requestMemberDetail.getOffset(), 10);
+        QMemberReportCte cte = new QMemberReportCte("cte");
+        List<ResponseReportList> responseReportLists = blazeJPAQueryFactory
+                .with(cte, blazeJPAQueryFactory
+                        .from(report)
+                        .groupBy(report.reportedContentId, report.reportType)
+                        .bind(cte.reportedId, report.reportedContentId)
+                        .bind(cte.reportType, report.reportType)
+                        .bind(cte.reportCount, report.count())
+                )
+                .select(
+                        Projections.constructor(ResponseReportList.class,
+                                new CaseBuilder()
+                                        .when(board.isNotNull())
+                                        .then(board.id)
+                                        .otherwise(comment1.id),
+                                report.createDate.stringValue(),
+                                cte.reportCount,
+                                new CaseBuilder()
+                                        .when(report.reportType.eq(ReportType.COMMENT))
+                                        .then("댓글")
+                                        .when(report.reportType.eq(ReportType.BOARD))
+                                        .then("게시글")
+                                        .otherwise("기타"),
+                                new CaseBuilder()
+                                        .when(board.isNotNull())
+                                        .then(board.title)
+                                        .when(comment1.isNotNull())
+                                        .then(comment1.comment.substring(0, 20))
+                                        .otherwise("기타"))
+                )
+                .from(report)
+                .join(member)
+                .on(report.reported.eq(member))
+                .join(cte)
+                .on(cte.reportedId.eq(report.reportedContentId)
+                        .and(report.reportType.eq(cte.reportType)))
+                .leftJoin(board)
+                .on(board.id.eq(report.reportedContentId)
+                        .and(report.reportType.eq(ReportType.BOARD)))
+                .leftJoin(comment1)
+                .on(comment1.id.eq(report.reportedContentId)
+                        .and(report.reportType.eq(ReportType.COMMENT)))
+                .where(report.reported.publicId.eq(publicId))
+                .orderBy(report.createDate.desc())
+                .limit(10)
+                .offset(pageable.getOffset())
+                .fetch();
+
+
+        Long totCount = Optional.ofNullable(queryFactory
+                        .select(report.count())
+                        .from(report)
+                        .join(member)
+                        .on(report.reported.publicId.eq(publicId))
+                        .fetchOne())
+                .orElse(0L);
+
+
+        responseReportLists.stream().forEach(x -> {
+            x.updateReportDate(DateFormatUtil.formatByDot.
+                    format(LocalDateTime.
+                            parse(x.getReportedDate(), DateFormatUtil.FLEXIBLE_NANO_FORMATTER)));
+        });
+
+        return new PageImpl<>(responseReportLists, pageable, totCount);
+
+    }
+
+
+    private BooleanBuilder userListSearchCond(RequestMemberSearch requestMemberSearch) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+        if (requestMemberSearch.getNickName() != null) {
+
+            booleanBuilder.and(member.nickname.like("%" + requestMemberSearch.getNickName() + "%"));
+        }
+        if (requestMemberSearch.getEmail() != null) {
+
+            booleanBuilder.and(member.email.like("%" + requestMemberSearch.getEmail() + "%"));
+        }
+        if (requestMemberSearch.getTel() != null) {
+
+            booleanBuilder.and(member.tel.like("%" + requestMemberSearch.getTel() + "%"));
+        }
+        if (requestMemberSearch.getSignInStart() != null) {
+
+            booleanBuilder.and(member.createDate.goe(requestMemberSearch.provideStartTime()));
+        }
+        if (requestMemberSearch.getSignInEnd() != null) {
+
+            booleanBuilder.and(member.createDate.loe(requestMemberSearch.provideEndTime()));
+        }
+        if (requestMemberSearch.getMemberType() != null) {
+            booleanBuilder.and(member.type.eq(requestMemberSearch.getMemberType()));
+        }
+        if (requestMemberSearch.getGenderType() != null) {
+            booleanBuilder.and(member.genderType.eq(requestMemberSearch.getGenderType()));
+        }
+
+        if (requestMemberSearch.getStatus() != null) {
+            booleanBuilder.and(member.status.eq(requestMemberSearch.getStatus()));
+        }
+
+        if (requestMemberSearch.getBirthDate() != null) {
+            int birthYear = Integer.parseInt(requestMemberSearch.getBirthDate().substring(0, 2));
+            int birthMonth = Integer.parseInt(requestMemberSearch.getBirthDate().substring(2, 4));
+            int birthDay = Integer.parseInt(requestMemberSearch.getBirthDate().substring(4));
+            booleanBuilder.and(member.birthYear.eq(birthYear));
+            booleanBuilder.and(member.birthMonth.eq(birthMonth));
+            booleanBuilder.and(member.birthDay.eq(birthDay));
+        }
+
+
+        return booleanBuilder;
+    }
+
+    private void editTime(UUID publicId
+            , ResponseMemberDetail responseMemberDetail) {
+        List<AdminMemoResponse> adminMemoResponses=
+                createAdminMemo.getMemberAdminMemo(publicId,queryFactory);
+        responseMemberDetail.updateAdminMemoResponse(adminMemoResponses);
+    }
+}

--- a/src/main/java/org/myteam/server/admin/repository/ContentSearchRepository.java
+++ b/src/main/java/org/myteam/server/admin/repository/ContentSearchRepository.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.myteam.server.admin.dto.ctes.QContentCountCte;
 import org.myteam.server.admin.dto.ctes.QContentCte;
 import org.myteam.server.admin.dto.ctes.QMemberReportCte;
+import org.myteam.server.admin.dto.ctes.QSimpleReportCte;
 import org.myteam.server.admin.dto.response.CommonResponseDto;
 import org.myteam.server.admin.utill.AdminControlType;
 import org.myteam.server.admin.utill.CreateAdminMemo;
@@ -239,7 +240,7 @@ public class ContentSearchRepository {
         LocalDateTime endTime = adminContentResearch.provideEndTime();
 
         Pageable pageable = PageRequest.of(adminContentResearch.getOffset(), 10);
-        QMemberReportCte reportCte = new QMemberReportCte("reportCte");
+        QSimpleReportCte reportCte = new QSimpleReportCte("reportCte");
         QContentCte cte = new QContentCte("cte");
 
 
@@ -600,7 +601,7 @@ public class ContentSearchRepository {
 
     }
 
-    private Predicate totReportCond(Boolean reported, QMemberReportCte cte) {
+    private Predicate totReportCond(Boolean reported, QSimpleReportCte cte) {
         if (reported == null) {
             return null;
         }

--- a/src/main/java/org/myteam/server/admin/service/AdminMemberSearchService.java
+++ b/src/main/java/org/myteam/server/admin/service/AdminMemberSearchService.java
@@ -1,0 +1,29 @@
+package org.myteam.server.admin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.admin.dto.request.MemberSearchRequestDto;
+import org.myteam.server.admin.dto.response.MemberSearchResponseDto;
+import org.myteam.server.admin.repository.AdminMemberRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+import static org.myteam.server.admin.dto.request.MemberSearchRequestDto.*;
+import static org.myteam.server.admin.dto.response.MemberSearchResponseDto.*;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberSearchService {
+    private final AdminMemberRepository adminMemberRepository;
+    public Page<ResponseMemberSearch> getMemberDataList(RequestMemberSearch requestMemberSearch) {
+
+        return adminMemberRepository.getMemberDataList(requestMemberSearch);
+    }
+    public ResponseMemberDetail getMemberDetailData(RequestMemberDetail requestMemberDetail) {
+
+        return adminMemberRepository.getMemberDetail(requestMemberDetail.getPublicId());
+    }
+    public Page<ResponseReportList> getMemberReportedList(RequestMemberDetail requestMemberDetail) {
+
+        return adminMemberRepository.getMemberReportedList(requestMemberDetail);
+    }
+}

--- a/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
+++ b/src/main/java/org/myteam/server/global/security/service/AdminBanEventListener.java
@@ -37,12 +37,15 @@ public class AdminBanEventListener {
             log.info("관리자:{} 정지처리",member.getEmail());
 
            MemberStatusUpdateRequest memberStatusUpdateRequest=
-                   memberStatusUpdateRequestBuilder(member.getEmail(),MemberStatus.INACTIVE);
-
+                   MemberStatusUpdateRequest
+                           .builder()
+                           .email(member.getEmail())
+                           .status(MemberStatus.INACTIVE)
+                           .content("관리자 로그인 초과 시도로인한 자동 잠금처리")
+                           .build();
             memberService.updateStatus(adminBanEvent.getEmail(), memberStatusUpdateRequest);
 
             suspendMailSendService.sendAdminSuspendMail(member.getEmail(),adminBanEvent.getIp());
-
         }
     }
 

--- a/src/main/java/org/myteam/server/member/controller/AdminController.java
+++ b/src/main/java/org/myteam/server/member/controller/AdminController.java
@@ -6,17 +6,24 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.myteam.server.admin.dto.request.MemberSearchRequestDto;
+import org.myteam.server.admin.dto.response.MemberSearchResponseDto;
+import org.myteam.server.admin.service.AdminMemberSearchService;
 import org.myteam.server.global.exception.ErrorResponse;
 import org.myteam.server.global.web.response.ResponseDto;
+import org.myteam.server.global.web.response.ResponseStatus;
 import org.myteam.server.member.dto.MemberDeleteRequest;
 import org.myteam.server.member.dto.MemberGetRequest;
 import org.myteam.server.member.controller.response.MemberResponse;
+import org.myteam.server.member.dto.MemberStatusUpdateRequest;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.member.service.MemberService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -25,6 +32,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static org.myteam.server.admin.dto.request.MemberSearchRequestDto.*;
+import static org.myteam.server.admin.dto.response.MemberSearchResponseDto.*;
+import static org.myteam.server.global.security.jwt.JwtProvider.HEADER_AUTHORIZATION;
 import static org.myteam.server.global.web.response.ResponseStatus.SUCCESS;
 
 @Slf4j
@@ -37,6 +47,7 @@ public class AdminController {
 
     private final MemberReadService memberReadService;
     private final MemberService memberService;
+    private final AdminMemberSearchService adminMemberSearchService;
 
     @Operation(summary = "이메일로 회원 조회", description = "관리자가 특정 이메일을 가진 회원을 조회합니다.")
     @ApiResponses(value = {
@@ -89,4 +100,80 @@ public class AdminController {
                 null
         ));
     }
+
+    @Operation(summary = "회원 정보들을 조회", description = "각종 조건을 바탕으로 회원 정보들을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/list")
+    public ResponseEntity<ResponseDto<Page<ResponseMemberSearch>>>
+    getMemberDataList(@RequestBody @Valid RequestMemberSearch requestMemberSearch, BindingResult bindingResult) {
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(org.myteam.server.global.web.response.ResponseStatus.SUCCESS.name(), "성공",
+                        adminMemberSearchService.getMemberDataList(requestMemberSearch)));
+
+    }
+    @Operation(summary = "한 회원의 정보 조회", description = "관리자가 publicId로 특정 회원의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/publicId")
+    public ResponseEntity<ResponseDto<ResponseMemberDetail>>
+    getMemberDataList(@RequestBody @Valid RequestMemberDetail requestMemberDetail, BindingResult bindingResult) {
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(org.myteam.server.global.web.response.ResponseStatus.SUCCESS.name(), "성공",
+                        adminMemberSearchService.getMemberDetailData(requestMemberDetail))
+        );
+
+    }
+
+    @Operation(summary = "회원의 신고 사항 불러오기", description = "관리자가 특정 회원에 대해서 접수된 신고들을 불러옵니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/reports")
+    public ResponseEntity<ResponseDto<Page<ResponseReportList>>>
+    getMemberReportedList(@RequestBody @Valid RequestMemberDetail requestMemberDetail, BindingResult bindingResult) {
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(ResponseStatus.SUCCESS.name(), "성공"
+                        , adminMemberSearchService.getMemberReportedList(requestMemberDetail))
+        );
+    }
+
+    @Operation(summary = "회원의 상태 업데이트 및 메모추가",
+            description = "관리자가 특정 회원의 상태를 업데이트 및 메모를 추가합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공", useReturnTypeSchema = true),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PutMapping("/status")
+    public ResponseEntity<?> updateStatus(@RequestBody @Valid MemberStatusUpdateRequest memberStatusUpdateRequest,
+                                          BindingResult bindingResult,
+                                          HttpServletRequest httpServletRequest) {
+        log.info("AdminController updateStatus 메서드 실행");
+        String authorizationHeader = httpServletRequest.getHeader(HEADER_AUTHORIZATION);
+
+        // accessToken 으로 부터 유저 정보 반환
+        MemberResponse response = memberReadService.getAuthenticatedMember(authorizationHeader);
+
+        log.info("email : {}", response.getEmail());
+
+        // 서비스 호출
+        String targetEmail = response.getEmail(); // 변경을 시도하는 유저의 이메일 (본인 또는 관리자)
+
+        memberService.updateStatus(targetEmail, memberStatusUpdateRequest);
+
+        return ResponseEntity.ok(new ResponseDto<>(SUCCESS.name(), "회원 상태가 성공적으로 변경되었습니다.", null));
+    }
+
 }

--- a/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
+++ b/src/main/java/org/myteam/server/member/dto/MemberStatusUpdateRequest.java
@@ -1,26 +1,32 @@
 package org.myteam.server.member.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.myteam.server.member.domain.MemberStatus;
 
 @Getter
-@Builder
+@NoArgsConstructor
 public class MemberStatusUpdateRequest {
     @Pattern(regexp = "^[0-9a-zA-Z_]+@[0-9a-zA-Z]+(\\.[a-zA-Z]{2,3}){1,2}$", message = "이메일 형식으로 작성해주세요")
     private String email; // 계정
 
-    @NotNull
+    @NotNull(message = "memberstatus는 필수값입니다.")
+    @Schema(description = "필수값입니다. 같다면 이전과 같은값을 다르다면 바뀐값을 넣어주세요.")
     private MemberStatus status;
 
-    public static MemberStatusUpdateRequest memberStatusUpdateRequestBuilder(String email
-            , MemberStatus memberStatus) {
-        return MemberStatusUpdateRequest
-                .builder()
-                .email(email)
-                .status(memberStatus)
-                .build();
-    }
+    @Schema(description = "관리자가 회원의 상태를 업데이트 할때 따로 넣을게 없다면은 그냥 null로 해주세요")
+    private String content;
+
+    @Builder
+    public MemberStatusUpdateRequest (String email
+            , MemberStatus status, String content) {
+        this.status=status;
+        this.email=email;
+        this.content=content;
+    };
 }

--- a/src/test/java/org/myteam/server/admin/AdminMemberSearchTest.java
+++ b/src/test/java/org/myteam/server/admin/AdminMemberSearchTest.java
@@ -1,0 +1,227 @@
+package org.myteam.server.admin;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.myteam.server.admin.repository.AdminMemberRepository;
+import org.myteam.server.board.domain.Board;
+import org.myteam.server.board.domain.CategoryType;
+import org.myteam.server.board.repository.BoardRepository;
+import org.myteam.server.chat.block.domain.BanReason;
+import org.myteam.server.comment.domain.Comment;
+import org.myteam.server.comment.repository.CommentRepository;
+import org.myteam.server.global.domain.Category;
+import org.myteam.server.global.security.jwt.JwtProvider;
+import org.myteam.server.member.domain.MemberStatus;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.news.news.domain.News;
+import org.myteam.server.report.domain.ReportType;
+import org.myteam.server.support.IntegrationTestSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import java.time.Duration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.myteam.server.admin.dto.request.MemberSearchRequestDto.*;
+import static org.myteam.server.admin.dto.response.MemberSearchResponseDto.*;
+import static org.myteam.server.global.security.jwt.JwtProvider.TOKEN_CATEGORY_ACCESS;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AdminMemberSearchTest extends IntegrationTestSupport {
+    @Autowired
+    AdminMemberRepository adminMemberRepository;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    Member m;
+
+
+    Member admin;
+
+
+    @Autowired
+    JwtProvider jwtProvider;
+
+
+    String accessToken;
+
+    @BeforeEach
+    void settingBeforeTest() {
+
+        admin = createAdmin(0);
+
+        m = createMember(1);
+        Member m2 = createOAuthMember(2);
+        Member m3 = createOAuthMemberNonPending(3);
+
+        News news = createNews(0, Category.BASEBALL, 0);
+
+        Board b = createBoard(m, Category.ESPORTS, CategoryType.FREE, "z", "z");
+        Comment c = createNewsComment(news, m, "Z");
+        createReport(m, m2, BanReason.ETC, ReportType.COMMENT, c.getId());
+        createReport(m, m2, BanReason.ETC, ReportType.BOARD, b.getId());
+        c.addRecommendCount();
+
+
+        Board b2 = createBoard(m2, Category.ESPORTS, CategoryType.FREE, "z", "z");
+        Comment c2 = createNewsComment(news, m2, "Z");
+        createReport(m2, m3, BanReason.ETC, ReportType.COMMENT, c2.getId());
+        createReport(m2, m3, BanReason.ETC, ReportType.BOARD, b2.getId());
+        c2.addRecommendCount();
+
+        Board b3 = createBoard(m3, Category.ESPORTS, CategoryType.FREE, "z", "z");
+        Comment c3 = createNewsComment(news, m3, "Z");
+        createReport(m3, m, BanReason.ETC, ReportType.COMMENT, c3.getId());
+        createReport(m3, m, BanReason.ETC, ReportType.BOARD, b3.getId());
+        c3.addRecommendCount();
+
+        commentRepository.save(c);
+        commentRepository.save(c2);
+        commentRepository.save(c3);
+
+
+    }
+
+
+    @Test
+    void repoTest() {
+
+        RequestMemberSearch memberSearch = RequestMemberSearch
+                .builder()
+                .offset(1)
+                .build();
+
+        Page<ResponseMemberSearch> requestMemberSearchList = adminMemberRepository.getMemberDataList(memberSearch);
+
+        assertThat(requestMemberSearchList.getContent().size()).isEqualTo(3);
+
+        requestMemberSearchList.get()
+                .forEach(x -> {
+                    assertThat(x.getBoardCount()).isEqualTo(1);
+                    assertThat(x.getCommentCount()).isEqualTo(1);
+                    assertThat(x.getRecommendCount()).isEqualTo(1);
+                    assertThat(x.getReportCount()).isEqualTo(2);
+
+                });
+    }
+
+    @Test
+    void testingReportedList() {
+
+        RequestMemberDetail requestMemberDetail = RequestMemberDetail
+                .builder()
+                .publicId(m.getPublicId())
+                .offset(1)
+                .build();
+
+        Page<ResponseReportList> data = adminMemberRepository.getMemberReportedList(requestMemberDetail);
+
+        assertThat(data.getContent().size()).isEqualTo(2);
+        assertThat(data.getContent().get(0).getReportedCount()).isEqualTo(1);
+
+        assertThat(data.getContent().get(0).getReportType()).isEqualTo("게시글");
+        assertThat(data.getContent().get(1).getReportType()).isEqualTo("댓글");
+    }
+
+    @Test
+    void testingMemberDetail() {
+
+        RequestMemberDetail requestMemberDetail = RequestMemberDetail
+                .builder()
+                .publicId(m.getPublicId())
+                .offset(1)
+                .build();
+
+        ResponseMemberDetail responseMemberDetail = adminMemberRepository.getMemberDetail(m.getPublicId());
+
+        assertThat(responseMemberDetail.getCountBoard()).isEqualTo(1);
+        assertThat(responseMemberDetail.getCountBoard()).isEqualTo(1);
+        assertThat(responseMemberDetail.getReportedCount()).isEqualTo(2);
+        assertThat(responseMemberDetail.getReportCount()).isEqualTo(2);
+        assertThat(responseMemberDetail.getAdminMemoResponses().size()).isEqualTo(0);
+    }
+
+    @Test
+    void updateUserStatus(){
+        adminMemberRepository.updateMemberStatus(m,m.getPublicId(),"테스팅"
+        ,m.getStatus(),MemberStatus.INACTIVE);
+        ResponseMemberDetail responseMemberDetail = adminMemberRepository.getMemberDetail(m.getPublicId());
+        assertThat(responseMemberDetail.getAdminMemoResponses().size()).isEqualTo(1);
+    }
+
+    @Test
+    void apiParameterTest() throws Exception {
+
+
+        String telError = """
+                    {
+                      "tel":"0105000000000"
+                    }
+                """;
+
+
+        String publicId = """
+                    {
+                      
+                    }
+                """;
+        String email = """
+                    {
+                      "email":"test0@test.com"       
+                    }
+                """;
+
+
+        accessToken = jwtProvider.generateToken(TOKEN_CATEGORY_ACCESS, Duration.ofDays(1),
+                admin.getPublicId(), admin.getRole().name(),
+                admin.getStatus().name());
+
+
+        mockMvc.perform(post("/api/admin/members/list")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(telError)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+
+        mockMvc.perform(post("/api/admin/members/publicId")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(publicId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+
+        mockMvc.perform(post("/api/admin/members/reports")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(publicId)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+
+        mockMvc.perform(put("/api/admin/members/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(email)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+    }
+}

--- a/src/test/java/org/myteam/server/admin/filter/LimitLoginTest.java
+++ b/src/test/java/org/myteam/server/admin/filter/LimitLoginTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.myteam.server.admin.entity.AdminMemo;
 import org.myteam.server.chat.info.domain.UserInfo;
 import org.myteam.server.common.certification.mail.core.MailStrategy;
 import org.myteam.server.common.certification.mail.domain.EmailType;
@@ -37,6 +38,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -58,7 +60,6 @@ public class LimitLoginTest extends IntegrationTestSupport {
     Member normalMember;
     @Autowired
     MockMvc mockMvc;
-
     @Autowired
     MemberJpaRepository memberJpaRepository;
 
@@ -139,6 +140,10 @@ public class LimitLoginTest extends IntegrationTestSupport {
 
         Optional<Member> member=memberJpaRepository.findByEmail(admin.getEmail());
         assertThat(member.get().getStatus()).isEqualTo(MemberStatus.INACTIVE);
+
+        List<AdminMemo> adminMemo=adminMemoRepository.findAll();
+        assertThat(adminMemo.size()).isEqualTo(1);
+        assertThat(adminMemo.get(0).getMemberId()).isEqualTo(admin.getPublicId());
 
         mockMvc.perform(post("/api/admin/login")
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 기능 설명
- 관리자 회원기능 오류 수정해서 재업로드
### 작업 내용
- 관리자의 회원 관리기능 추가.
## 수정 사항
- 
## 추가 작업 예정
- 
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인