### PR TITLE
epic: add auto contenthide and fix changelog logic

### DIFF
--- a/src/main/java/org/myteam/server/admin/dto/request/AdminMemoRequestDto.java
+++ b/src/main/java/org/myteam/server/admin/dto/request/AdminMemoRequestDto.java
@@ -1,6 +1,7 @@
 package org.myteam.server.admin.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,8 +10,31 @@ import org.myteam.server.admin.utill.AdminControlType;
 import org.myteam.server.admin.utill.StaticDataType;
 import org.myteam.server.improvement.domain.ImportantStatus;
 import org.myteam.server.improvement.domain.ImprovementStatus;
+import org.myteam.server.member.domain.MemberStatus;
+
+import java.util.UUID;
 
 public record AdminMemoRequestDto() {
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "회원에 대한 메모 작성을 요청시에 쓰이는 값입니다")
+    public static class AdminMemoMemberRequest{
+        @NotNull(message = "memberId는 비어있으면 안됩니다")
+        private UUID memberId;
+        @NotNull(message = "회원 상태값이 비어있습니다.")
+        @Schema(description = "수정이 없다면 기존값을 수정했다면 수정값을 주세요", example = "INACTIVE, ACTIVE, PENDING,WARNED")
+        private MemberStatus memberStatus;
+        @Schema(description = "내용이 없다면 null로 주세요")
+        private String content;
+        @Builder
+        public AdminMemoMemberRequest(UUID memberId,MemberStatus memberStatus, String content){
+            this.memberId=memberId;
+            this.memberStatus=memberStatus;
+            this.content = content;
+        }
+
+    }
 
     @Getter
     @NoArgsConstructor
@@ -26,14 +50,16 @@ public record AdminMemoRequestDto() {
         private ImportantStatus importantStatus;
         @Schema(description = "내용이 없다면 null로 주세요")
         private String content;
-
+        @Schema(description ="생성시 로그 남기기 여부를 결정하는 값입니다. 무시하셔도됩니다." )
+        private String auto;
         @Builder
         public AdminMemoImprovementRequest(Long contentId, String content
-                , ImprovementStatus improvementStatus, ImportantStatus importantStatus) {
+                , ImprovementStatus improvementStatus, ImportantStatus importantStatus,String auto) {
             this.contentId = contentId;
             this.importantStatus = importantStatus;
             this.improvementStatus = improvementStatus;
             this.content = content;
+            this.auto=auto;
         }
     }
 
@@ -44,18 +70,23 @@ public record AdminMemoRequestDto() {
         @NotNull(message = "contentid는 비어있으면 안됩니다.")
         @Schema(description = "필수값 입니다.")
         private Long contentId;
-        @Schema(description = "내용이 없다면 null로 주세요")
+        @Schema(description = "필수값. 공백이면안됨.")
+        @NotBlank(message = "문의는 빈값이 즉 공백이아닙니다.")
+        @NotNull(message = "문의메모는 답변이 존재해야만합니다.")
         private String content;
         @NotNull(message ="이메일은 비어있으면 안됩니다.")
         @Schema(description = "문의 작성자의 이메일 입니다.")
         private String email;
+        @Schema(description = "문의 생성시 로그 남기기용입니다 무시해주세요.")
+        private Boolean isMember;
 
         @Builder
         public AdminMemoInquiryRequest(Long contentId
-                , String content, String email) {
+                , String content, String email,String auto,Boolean isMember) {
             this.contentId = contentId;
             this.content = content;
             this.email = email;
+            this.isMember=isMember;
         }
     }
 
@@ -74,14 +105,17 @@ public record AdminMemoRequestDto() {
         private AdminControlType adminControlType;
         @Schema(description = "내용이 없다면 null로 주세요")
         private String content;
+        @Schema(description ="자동 숨김 처리 여부를 결정하는 값입니다. 무시하셔도됩니다." )
+        private String auto;
 
         @Builder
         public AdminMemoContentRequest(Long contentId, StaticDataType staticDataType, String content
-                , AdminControlType adminControlType) {
+                , AdminControlType adminControlType,String auto) {
             this.contentId = contentId;
             this.staticDataType = staticDataType;
             this.adminControlType = adminControlType;
             this.content = content;
+            this.auto=auto;
         }
     }
 }

--- a/src/main/java/org/myteam/server/admin/dto/request/InquiryRequestDto.java
+++ b/src/main/java/org/myteam/server/admin/dto/request/InquiryRequestDto.java
@@ -20,16 +20,16 @@ public record InquiryRequestDto() {
     @NoArgsConstructor
     @Getter
     public final static class RequestInquiryList {
-        @NotNull(message = "public id는 필수입니다.")
+        @NotNull(message = "email은 필수입니다.")
         @Schema(description = "회원 식별 아이디값,필수입니다.")
-        private UUID publicId;
+        private String email;
         @NotNull(message = "offset은 필수입니다.")
         @Schema(description = "필수입니다.")
         private int offset;
 
         @Builder
-        public RequestInquiryList(UUID publicId, int offset) {
-            this.publicId = publicId;
+        public RequestInquiryList(String email, int offset) {
+            this.email = email;
             this.offset = offset;
         }
 

--- a/src/main/java/org/myteam/server/admin/entity/AdminContentChangeLog.java
+++ b/src/main/java/org/myteam/server/admin/entity/AdminContentChangeLog.java
@@ -7,39 +7,31 @@ import lombok.NoArgsConstructor;
 import org.myteam.server.admin.utill.AdminControlType;
 import org.myteam.server.admin.utill.StaticDataType;
 import org.myteam.server.global.domain.BaseTime;
-import org.myteam.server.member.domain.MemberStatus;
 import org.myteam.server.member.entity.Member;
-
-import java.util.UUID;
-
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class AdminChangeLog extends BaseTime {
+public class AdminContentChangeLog extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne(fetch = FetchType.LAZY)
     private Member admin;
-    private UUID memberId;
     private Long contentId;
-    @Enumerated(EnumType.STRING)
-    private MemberStatus memberStatus;
     @Enumerated(EnumType.STRING)
     private StaticDataType staticDataType;
     @Enumerated(EnumType.STRING)
     private AdminControlType adminControlType;
 
     @Builder
-    public AdminChangeLog(MemberStatus memberStatus, StaticDataType staticDataType
-            , AdminControlType adminControlType, Member admin, UUID memberId, Long contentId) {
-        this.memberStatus = memberStatus;
+    public AdminContentChangeLog(StaticDataType staticDataType
+            , AdminControlType adminControlType, Member admin,Long contentId) {
         this.staticDataType = staticDataType;
         this.adminControlType = adminControlType;
         this.admin = admin;
-        this.memberId = memberId;
         this.contentId = contentId;
     }
+
 }

--- a/src/main/java/org/myteam/server/admin/entity/AdminContentMemo.java
+++ b/src/main/java/org/myteam/server/admin/entity/AdminContentMemo.java
@@ -1,0 +1,33 @@
+package org.myteam.server.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.admin.utill.StaticDataType;
+import org.myteam.server.global.domain.BaseTime;
+import org.myteam.server.member.entity.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class AdminContentMemo extends BaseTime {
+    @Id
+    @GeneratedValue
+    private Long id;
+    private String content;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member writer;
+    @Enumerated(EnumType.STRING)
+    private StaticDataType staticDataType;
+    private Long contentId;
+
+    @Builder
+    public AdminContentMemo(String content, Member writer,
+                            StaticDataType staticDataType, Long contentId) {
+        this.content = content;
+        this.writer = writer;
+        this.staticDataType = staticDataType;
+        this.contentId = contentId;
+    }
+}

--- a/src/main/java/org/myteam/server/admin/entity/AdminContentMemo.java
+++ b/src/main/java/org/myteam/server/admin/entity/AdminContentMemo.java
@@ -13,7 +13,7 @@ import org.myteam.server.member.entity.Member;
 @NoArgsConstructor
 public class AdminContentMemo extends BaseTime {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String content;
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/myteam/server/admin/entity/AdminImproveChangeLog.java
+++ b/src/main/java/org/myteam/server/admin/entity/AdminImproveChangeLog.java
@@ -1,0 +1,36 @@
+package org.myteam.server.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.global.domain.BaseTime;
+import org.myteam.server.improvement.domain.ImportantStatus;
+import org.myteam.server.improvement.domain.ImprovementStatus;
+import org.myteam.server.member.entity.Member;
+@Entity
+@Getter
+@NoArgsConstructor
+public class AdminImproveChangeLog extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member admin;
+    private Long contentId;
+    @Enumerated(EnumType.STRING)
+    private ImprovementStatus improvementStatus;
+    @Enumerated(EnumType.STRING)
+    private ImportantStatus importantStatus;
+
+    @Builder
+    public AdminImproveChangeLog(
+            ImportantStatus importantStatus,ImprovementStatus improvementStatus
+            , Member admin,Long contentId) {
+        this.importantStatus=importantStatus;
+        this.improvementStatus=improvementStatus;
+        this.admin = admin;
+        this.contentId = contentId;
+    }
+}

--- a/src/main/java/org/myteam/server/admin/entity/AdminInquiryChangeLog.java
+++ b/src/main/java/org/myteam/server/admin/entity/AdminInquiryChangeLog.java
@@ -1,0 +1,31 @@
+package org.myteam.server.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.global.domain.BaseTime;
+import org.myteam.server.member.entity.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class AdminInquiryChangeLog extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member admin;
+    private Long contentId;
+    private boolean isAnswered;
+    private boolean isMember;
+    @Builder
+    public AdminInquiryChangeLog(boolean isAnswered,boolean isMember
+            , Member admin, Long contentId) {
+        this.isMember=isMember;
+        this.isAnswered=isAnswered;
+        this.admin = admin;
+        this.contentId = contentId;
+    }
+}

--- a/src/main/java/org/myteam/server/admin/entity/AdminMemberChangeLog.java
+++ b/src/main/java/org/myteam/server/admin/entity/AdminMemberChangeLog.java
@@ -1,0 +1,31 @@
+package org.myteam.server.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.global.domain.BaseTime;
+import org.myteam.server.member.domain.MemberStatus;
+import org.myteam.server.member.entity.Member;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class AdminMemberChangeLog extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member admin;
+    private UUID memberId;
+    @Enumerated(EnumType.STRING)
+    private MemberStatus memberStatus;
+
+    @Builder
+    public AdminMemberChangeLog(MemberStatus memberStatus,Member admin, UUID memberId) {
+        this.memberStatus = memberStatus;
+        this.admin = admin;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/org/myteam/server/admin/entity/AdminMemberMemo.java
+++ b/src/main/java/org/myteam/server/admin/entity/AdminMemberMemo.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 public class AdminMemberMemo extends BaseTime {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String content;
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/org/myteam/server/admin/entity/AdminMemberMemo.java
+++ b/src/main/java/org/myteam/server/admin/entity/AdminMemberMemo.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.myteam.server.admin.utill.StaticDataType;
 import org.myteam.server.global.domain.BaseTime;
 import org.myteam.server.member.entity.Member;
 
@@ -13,9 +12,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor
-public class AdminMemo extends BaseTime {
-
-
+public class AdminMemberMemo extends BaseTime {
 
     @Id
     @GeneratedValue
@@ -24,18 +21,10 @@ public class AdminMemo extends BaseTime {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member writer;
     private UUID memberId;
-    @Enumerated(EnumType.STRING)
-    private StaticDataType staticDataType;
-    private Long contentId;
-
-
-
     @Builder
-    public AdminMemo(String content, Member writer, UUID memberId, StaticDataType staticDataType, Long contentId) {
+    public AdminMemberMemo(String content, Member writer, UUID memberId) {
         this.content = content;
         this.writer = writer;
         this.memberId = memberId;
-        this.staticDataType = staticDataType;
-        this.contentId = contentId;
     }
 }

--- a/src/main/java/org/myteam/server/admin/repository/AdminDashBoardRepository.java
+++ b/src/main/java/org/myteam/server/admin/repository/AdminDashBoardRepository.java
@@ -31,7 +31,6 @@ import static org.myteam.server.admin.dto.request.AdminDashBoardRequestDto.Reque
 import static org.myteam.server.admin.dto.request.AdminDashBoardRequestDto.RequestStatic;
 import static org.myteam.server.admin.dto.response.AdminDashBoardResponseDto.ResponseLatestData;
 import static org.myteam.server.admin.dto.response.AdminDashBoardResponseDto.ResponseStatic;
-import static org.myteam.server.admin.entity.QAdminChangeLog.adminChangeLog;
 import static org.myteam.server.board.domain.QBoard.board;
 import static org.myteam.server.comment.domain.QComment.comment1;
 import static org.myteam.server.improvement.domain.QImprovement.improvement;
@@ -169,132 +168,22 @@ public class AdminDashBoardRepository {
                     .build();
         }
 
-        if (staticDataType.name().equals(StaticDataType.UserWarned.name())) {
-            Long current_count = queryFactory
-                    .select(adminChangeLog.memberId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(StaticUtil.betweenStaticTime(static_end_time, static_start_time, adminChangeLog),
-                            (adminChangeLog.memberStatus.eq(MemberStatus.WARNED)))
-                    .fetch().get(0);
-
-            Long past_count = queryFactory
-                    .select(adminChangeLog.memberId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(StaticUtil.betweenStaticTime(static_end_time2, static_start_time2, adminChangeLog),
-                            (adminChangeLog.memberStatus.eq(MemberStatus.WARNED)))
-                    .fetch().get(0);
-
-            Long tot_count = queryFactory.select(adminChangeLog.memberId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(adminChangeLog.memberStatus.eq(MemberStatus.WARNED))
-                    .fetch().get(0);
-            int percent = StaticUtil.makeStaticPercent(current_count, past_count);
-            return ResponseStatic
-                    .builder()
-                    .currentCount(current_count)
-                    .pastCount(past_count)
-                    .totCount(tot_count)
-                    .percent(percent)
-                    .build();
+        if (staticDataType.name().equals(StaticDataType.UserWarned.name())){
+           return CreateStaticQueryFactory.createStaticMemberStatusQuery(
+                   MemberStatus.WARNED,dateList,queryFactory);
         }
         if (staticDataType.name().equals(StaticDataType.UserBanned.name())) {
-            Long current_count = queryFactory
-                    .select(adminChangeLog.memberId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(StaticUtil.betweenStaticTime(static_end_time, static_start_time, adminChangeLog),
-                            (adminChangeLog.memberStatus.eq(MemberStatus.INACTIVE)))
-                    .fetch().get(0);
-
-            Long past_count = queryFactory
-                    .select(adminChangeLog.memberId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(StaticUtil.betweenStaticTime(static_end_time2, static_start_time2, adminChangeLog),
-                            (adminChangeLog.memberStatus.eq(MemberStatus.INACTIVE)))
-                    .fetch().get(0);
-
-            Long tot_count = queryFactory.select(adminChangeLog.memberId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(adminChangeLog.memberStatus.eq(MemberStatus.INACTIVE))
-                    .fetch().get(0);
-
-            int percent = StaticUtil.makeStaticPercent(current_count, past_count);
-
-            return ResponseStatic
-                    .builder()
-                    .currentCount(current_count)
-                    .pastCount(past_count)
-                    .totCount(tot_count)
-                    .percent(percent)
-                    .build();
+            return CreateStaticQueryFactory.createStaticMemberStatusQuery(
+                    MemberStatus.INACTIVE,dateList,queryFactory);
         }
+        if (staticDataType.name().equals(StaticDataType.HideComment.name())
+        ||staticDataType.name().equals(StaticDataType.HideBoard.name())) {
 
-        if (staticDataType.name().equals(StaticDataType.HideComment.name())) {
-            Long current_count = queryFactory
-                    .select(adminChangeLog.contentId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(StaticUtil.betweenStaticTime(static_end_time, static_start_time, adminChangeLog),
-                            (adminChangeLog.adminControlType.eq(AdminControlType.HIDDEN)),
-                            (adminChangeLog.staticDataType.eq(StaticDataType.COMMENT)))
-                    .fetch().get(0);
+            StaticDataType staticDataType1=StaticDataType.HideComment.equals(StaticDataType.HideComment)
+                    ? StaticDataType.COMMENT:StaticDataType.BOARD;
 
-            Long past_count = queryFactory
-                    .select(adminChangeLog.contentId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(StaticUtil.betweenStaticTime(static_end_time2, static_start_time2, adminChangeLog),
-                            (adminChangeLog.adminControlType.eq(AdminControlType.HIDDEN))
-                            , (adminChangeLog.staticDataType.eq(StaticDataType.COMMENT)))
-                    .fetch().get(0);
-
-            Long tot_count = queryFactory.select(adminChangeLog
-                            .contentId.countDistinct())
-                    .from(adminChangeLog)
-                    .where((adminChangeLog.adminControlType.eq(AdminControlType.HIDDEN))
-                            .and(adminChangeLog.staticDataType.eq(StaticDataType.COMMENT)))
-                    .fetch().get(0);
-
-            int percent = StaticUtil.makeStaticPercent(current_count, past_count);
-
-            return ResponseStatic
-                    .builder()
-                    .currentCount(current_count)
-                    .pastCount(past_count)
-                    .totCount(tot_count)
-                    .percent(percent)
-                    .build();
-        }
-
-        if (staticDataType.name().equals(StaticDataType.HideBoard.name())) {
-            Long current_count = queryFactory
-                    .select(adminChangeLog.contentId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(StaticUtil.betweenStaticTime(static_end_time, static_start_time, adminChangeLog),
-                            (adminChangeLog.adminControlType.eq(AdminControlType.HIDDEN))
-                            , (adminChangeLog.staticDataType.eq(StaticDataType.BOARD)))
-                    .fetch().get(0);
-
-            Long past_count = queryFactory
-                    .select(adminChangeLog.contentId.countDistinct())
-                    .from(adminChangeLog)
-                    .where(StaticUtil.betweenStaticTime(static_end_time2, static_start_time2, adminChangeLog),
-                            (adminChangeLog.adminControlType.eq(AdminControlType.HIDDEN))
-                            , (adminChangeLog.staticDataType.eq(StaticDataType.BOARD)))
-                    .fetch().get(0);
-
-            Long tot_count = queryFactory.select(adminChangeLog.contentId.countDistinct())
-                    .from(adminChangeLog)
-                    .where((adminChangeLog.adminControlType.eq(AdminControlType.HIDDEN))
-                            , (adminChangeLog.staticDataType.eq(StaticDataType.BOARD)))
-                    .fetch().get(0);
-
-            int percent = StaticUtil.makeStaticPercent(current_count, past_count);
-
-            return ResponseStatic
-                    .builder()
-                    .currentCount(current_count)
-                    .pastCount(past_count)
-                    .totCount(tot_count)
-                    .percent(percent)
-                    .build();
+            return CreateStaticQueryFactory.createStaticContentQuery(staticDataType1,AdminControlType.HIDDEN
+                    ,dateList,queryFactory);
         }
         if(staticDataType.equals(StaticDataType.InquiryComplete)||staticDataType
                 .equals(StaticDataType.InquiryPending)){

--- a/src/main/java/org/myteam/server/admin/repository/AdminImprovementSearchRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/AdminImprovementSearchRepo.java
@@ -140,7 +140,7 @@ public class AdminImprovementSearchRepo {
                         , DateFormatUtil.FLEXIBLE_NANO_FORMATTER)));
 
         responseImprovementDetail.updateAdminMemoList(
-                createAdminMemo.getAdminMemo(StaticDataType.Improvement,
+                createAdminMemo.getAdminContentMemo(StaticDataType.Improvement,
                         requestImprovementDetail.getContentId(), queryFactory));
 
         return responseImprovementDetail;

--- a/src/main/java/org/myteam/server/admin/repository/AdminMemberRepository.java
+++ b/src/main/java/org/myteam/server/admin/repository/AdminMemberRepository.java
@@ -13,10 +13,6 @@ import org.myteam.server.admin.dto.ctes.QBoardCountCte;
 import org.myteam.server.admin.dto.ctes.QCommentCountCte;
 import org.myteam.server.admin.dto.ctes.QMemberReportCte;
 import org.myteam.server.admin.dto.ctes.QReportCountCte;
-import org.myteam.server.admin.entity.AdminChangeLog;
-import org.myteam.server.admin.entity.AdminMemo;
-import org.myteam.server.admin.repository.simpleRepo.AdminChangeLogRepo;
-import org.myteam.server.admin.repository.simpleRepo.AdminMemoRepository;
 import org.myteam.server.admin.utill.CreateAdminMemo;
 import org.myteam.server.global.util.date.DateFormatUtil;
 import org.myteam.server.member.domain.GenderType;
@@ -53,7 +49,6 @@ import static org.myteam.server.report.domain.QReport.report;
 @RequiredArgsConstructor
 @Transactional
 public class AdminMemberRepository {
-    private final AdminChangeLogRepo adminChangeLogRepo;
     private final JPAQueryFactory queryFactory;
     private final BlazeJPAQueryFactory blazeJPAQueryFactory;
     private final CreateAdminMemo createAdminMemo;
@@ -435,7 +430,7 @@ public class AdminMemberRepository {
     private void editTime(UUID publicId
             , ResponseMemberDetail responseMemberDetail) {
         List<AdminMemoResponse> adminMemoResponses=
-                createAdminMemo.getMemberAdminMemo(publicId,queryFactory);
+                createAdminMemo.getAdminMemberMemo(publicId,queryFactory);
         responseMemberDetail.updateAdminMemoResponse(adminMemoResponses);
     }
 }

--- a/src/main/java/org/myteam/server/admin/repository/ContentSearchRepository.java
+++ b/src/main/java/org/myteam/server/admin/repository/ContentSearchRepository.java
@@ -731,7 +731,7 @@ public class ContentSearchRepository {
             responseDetail.updateReported("신고");
         }
         List<CommonResponseDto.AdminMemoResponse> adminMemoResponses =
-                createAdminMemo.getAdminMemo(staticDataType,
+                createAdminMemo.getAdminContentMemo(staticDataType,
                         requestDetail.getContentId(),queryFactory);
 
         responseDetail.updateAdminMemoResponses(adminMemoResponses);

--- a/src/main/java/org/myteam/server/admin/repository/InquirySearchRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/InquirySearchRepo.java
@@ -137,8 +137,8 @@ public class InquirySearchRepo {
                                 inquiry.id
                                 , new CaseBuilder()
                                         .when(inquiry.isAdminAnswered.isTrue())
-                                        .then("답변대기")
-                                        .otherwise("답변완료"),
+                                        .then("답변완료")
+                                        .otherwise("답변대기"),
                                 new CaseBuilder()
                                         .when(member.isNull())
                                         .then("비회원")

--- a/src/main/java/org/myteam/server/admin/repository/InquirySearchRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/InquirySearchRepo.java
@@ -6,7 +6,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.myteam.server.admin.entity.AdminMemo;
+import org.myteam.server.admin.entity.AdminContentMemo;
 import org.myteam.server.admin.utill.CreateAdminMemo;
 import org.myteam.server.admin.utill.StaticDataType;
 import org.myteam.server.global.util.date.DateFormatUtil;
@@ -35,7 +35,7 @@ public class InquirySearchRepo {
     private final JPAQueryFactory queryFactory;
     private final CreateAdminMemo createAdminMemo;
 
-    public AdminMemo createAdminMemo(AdminMemoInquiryRequest adminMemoRequest) {
+    public AdminContentMemo createAdminMemo(AdminMemoInquiryRequest adminMemoRequest) {
 
         return createAdminMemo.createInquiryAdminMemo(adminMemoRequest, queryFactory);
     }
@@ -52,18 +52,18 @@ public class InquirySearchRepo {
                                 inquiry.createdAt.stringValue(),
                                 inquiry.clientIp,
                                 new CaseBuilder()
-                                        .when(member.nickname.isNull())
+                                        .when(member.isNull())
                                         .then("비회원")
                                         .otherwise("회원"),
                                 new CaseBuilder()
-                                        .when(member.nickname.isNull())
+                                        .when(member.isNull())
                                         .then("-")
                                         .otherwise(member.nickname),
-                                member.email,
+                                inquiry.email,
                                 inquiry.content
                         ))
                 .from(inquiry)
-                .join(member)
+                .leftJoin(member)
                 .on(member.eq(inquiry.member))
                 .where(inquiry.id.eq(requestInquiryDetail.getContentId()))
                 .fetchOne();
@@ -72,7 +72,7 @@ public class InquirySearchRepo {
                 .format(LocalDateTime.parse(responseInquiryDetail.getCreateDate()
                         , DateFormatUtil.FLEXIBLE_NANO_FORMATTER)));
         responseInquiryDetail.updateAdminMemoList(
-                createAdminMemo.getAdminMemo(StaticDataType.Improvement,
+                createAdminMemo.getAdminContentMemo(StaticDataType.Inquiry,
                         requestInquiryDetail.getContentId(), queryFactory));
 
         return responseInquiryDetail;
@@ -90,24 +90,21 @@ public class InquirySearchRepo {
                                         .then("답변대기")
                                         .otherwise("답변완료"),
                                 new CaseBuilder()
-                                        .when(member.nickname.isNull())
+                                        .when(member.isNull())
                                         .then("비회원")
                                         .otherwise("회원"),
                                 new CaseBuilder()
-                                        .when(member.nickname.isNull())
+                                        .when(member.isNull())
                                         .then("-")
                                         .otherwise(member.nickname),
-                                new CaseBuilder()
-                                        .when(member.email.isNotNull())
-                                        .then(member.email)
-                                        .otherwise("-"),
+                                inquiry.email,
                                 inquiry.content,
                                 inquiry.createdAt.stringValue()
                         ))
                 .from(inquiry)
-                .join(member)
+                .leftJoin(member)
                 .on(member.eq(inquiry.member))
-                .where(member.publicId.eq(requestInquiryList.getPublicId()))
+                .where(inquiry.email.eq(requestInquiryList.getEmail()))
                 .orderBy(inquiry.createdAt.desc())
                 .limit(10)
                 .offset(pageable.getOffset())
@@ -123,9 +120,9 @@ public class InquirySearchRepo {
         Long totCount = Optional.ofNullable(queryFactory
                 .select(inquiry.count())
                 .from(inquiry)
-                .join(member)
+                .leftJoin(member)
                 .on(member.eq(inquiry.member))
-                .where(member.publicId.eq(requestInquiryList.getPublicId()))
+                .where(inquiry.email.eq(requestInquiryList.getEmail()))
                 .fetchOne()).orElse(0L);
 
         return new PageImpl<>(inquiryList, pageable, totCount);
@@ -143,23 +140,23 @@ public class InquirySearchRepo {
                                         .then("답변대기")
                                         .otherwise("답변완료"),
                                 new CaseBuilder()
-                                        .when(member.nickname.isNull())
+                                        .when(member.isNull())
                                         .then("비회원")
                                         .otherwise("회원"),
                                 new CaseBuilder()
-                                        .when(member.nickname.isNull())
-                                        .then(member.email)
+                                        .when(member.isNull())
+                                        .then(inquiry.email)
                                         .otherwise(member.nickname),
                                 inquiry.content,
                                 new CaseBuilder()
-                                        .when(member.publicId.isNotNull())
+                                        .when(member.isNotNull())
                                         .then(member.publicId.toString())
                                         .otherwise(""),
                                 inquiry.createdAt.stringValue()
                         )
                 )
                 .from(inquiry)
-                .join(member)
+                .leftJoin(member)
                 .on(inquiry.member.eq(member))
                 .where(contentSearchCond(requestInquiryListCond.getContent()),
                         searchByWriter(requestInquiryListCond.getNickName()),
@@ -182,7 +179,7 @@ public class InquirySearchRepo {
 
         Long count = Optional.ofNullable(queryFactory.select(inquiry.count())
                 .from(inquiry)
-                .join(member)
+                .leftJoin(member)
                 .on(inquiry.member.eq(member))
                 .where(contentSearchCond(requestInquiryListCond.getContent()),
                         searchByWriter(requestInquiryListCond.getNickName()),
@@ -201,9 +198,9 @@ public class InquirySearchRepo {
             return null;
         }
         if (isMember) {
-            return member.nickname.isNotNull();
+            return inquiry.member.isNotNull();
         }
-        return member.nickname.isNull();
+        return inquiry.member.isNull();
     }
 
     private Predicate contentSearchCond(String searchKeyWord) {

--- a/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminChangeLogRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminChangeLogRepo.java
@@ -1,9 +1,0 @@
-package org.myteam.server.admin.repository.simpleRepo;
-
-import org.myteam.server.admin.entity.AdminChangeLog;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-
-
-public interface AdminChangeLogRepo extends JpaRepository<AdminChangeLog, Long> {
-}

--- a/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminContentChangeLogRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminContentChangeLogRepo.java
@@ -1,0 +1,10 @@
+package org.myteam.server.admin.repository.simpleRepo;
+
+import org.myteam.server.admin.entity.AdminContentChangeLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AdminContentChangeLogRepo extends JpaRepository<AdminContentChangeLog,Long> {
+
+}

--- a/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminContentMemoRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminContentMemoRepo.java
@@ -1,0 +1,7 @@
+package org.myteam.server.admin.repository.simpleRepo;
+
+import org.myteam.server.admin.entity.AdminContentMemo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminContentMemoRepo extends JpaRepository<AdminContentMemo,Long> {
+}

--- a/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminImproveChangeLogRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminImproveChangeLogRepo.java
@@ -1,0 +1,7 @@
+package org.myteam.server.admin.repository.simpleRepo;
+
+import org.myteam.server.admin.entity.AdminImproveChangeLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminImproveChangeLogRepo extends JpaRepository<AdminImproveChangeLog,Long> {
+}

--- a/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminInquiryChangeLogRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminInquiryChangeLogRepo.java
@@ -1,0 +1,7 @@
+package org.myteam.server.admin.repository.simpleRepo;
+
+import org.myteam.server.admin.entity.AdminInquiryChangeLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminInquiryChangeLogRepo extends JpaRepository<AdminInquiryChangeLog,Long> {
+}

--- a/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminMemberChangeLogRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminMemberChangeLogRepo.java
@@ -1,0 +1,7 @@
+package org.myteam.server.admin.repository.simpleRepo;
+
+import org.myteam.server.admin.entity.AdminMemberChangeLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminMemberChangeLogRepo extends JpaRepository<AdminMemberChangeLog,Long> {
+}

--- a/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminMemberMemoRepo.java
+++ b/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminMemberMemoRepo.java
@@ -1,0 +1,7 @@
+package org.myteam.server.admin.repository.simpleRepo;
+
+import org.myteam.server.admin.entity.AdminMemberMemo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminMemberMemoRepo extends JpaRepository<AdminMemberMemo,Long> {
+}

--- a/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminMemoRepository.java
+++ b/src/main/java/org/myteam/server/admin/repository/simpleRepo/AdminMemoRepository.java
@@ -1,7 +1,0 @@
-package org.myteam.server.admin.repository.simpleRepo;
-
-import org.myteam.server.admin.entity.AdminMemo;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AdminMemoRepository extends JpaRepository<AdminMemo,Long> {
-}

--- a/src/main/java/org/myteam/server/admin/service/AdminBotListener.java
+++ b/src/main/java/org/myteam/server/admin/service/AdminBotListener.java
@@ -1,0 +1,98 @@
+package org.myteam.server.admin.service;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.myteam.server.admin.entity.AdminInquiryChangeLog;
+import org.myteam.server.admin.utill.*;
+import org.myteam.server.comment.domain.Comment;
+import org.myteam.server.improvement.domain.ImportantStatus;
+import org.myteam.server.improvement.domain.ImprovementStatus;
+import org.myteam.server.report.domain.ReportType;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+
+import java.util.Optional;
+
+import static org.myteam.server.admin.dto.request.AdminMemoRequestDto.*;
+import static org.myteam.server.board.domain.QBoard.board;
+import static org.myteam.server.board.domain.QBoardCount.boardCount;
+import static org.myteam.server.comment.domain.QComment.comment1;
+import static org.myteam.server.report.domain.QReport.report;
+
+@RequiredArgsConstructor
+@Component
+public class AdminBotListener {
+    private final JPAQueryFactory queryFactory;
+    private final CreateAdminMemo createAdminMemo;
+    @EventListener
+    public void reportAutoHide(AdminBotAutoHideEvent autoHideEvent){
+        Long reportCount= Optional.ofNullable(queryFactory.select(report.count())
+                        .from(report)
+                        .where(report.reportedContentId.eq(autoHideEvent.getContentId())
+                                ,report.reportType.eq(autoHideEvent.getReportType()))
+                        .fetchOne())
+                .orElse(0L);
+        if(autoHideEvent.getReportType().equals(ReportType.BOARD)){
+            int viewCount=queryFactory.select(board.boardCount.viewCount)
+                    .from(board)
+                    .join(boardCount)
+                    .on(boardCount.board.eq(board))
+                    .where(board.id.eq(autoHideEvent.getContentId()))
+                    .fetchOne();
+            if(reportCount>=viewCount*0.8){
+                AdminMemoContentRequest adminMemoContentRequest=
+                        AdminMemoContentRequest
+                                .builder()
+                                .contentId(autoHideEvent.getContentId())
+                                .adminControlType(AdminControlType.HIDDEN)
+                                .content("신고 비율이 초과되어서 자동 숨김처리 되었습니다.")
+                                .staticDataType(StaticDataType.BOARD)
+                                .auto("auto")
+                                .build();
+                createAdminMemo.createContentAdminMemo(adminMemoContentRequest,queryFactory);
+            }
+            return;
+        }
+        if(autoHideEvent.getReportType().equals(ReportType.COMMENT)){
+            Comment comment=queryFactory.selectFrom(comment1)
+                    .where(comment1.id.eq(autoHideEvent.getContentId()))
+                    .fetchOne();
+            int recommendCount=comment.getRecommendCount();
+            if(reportCount>=recommendCount*0.8){
+                AdminMemoContentRequest adminMemoContentRequest=
+                        AdminMemoContentRequest
+                                .builder()
+                                .contentId(autoHideEvent.getContentId())
+                                .adminControlType(AdminControlType.HIDDEN)
+                                .content("신고 비율이 초과되어서 자동 숨김처리 되었습니다.")
+                                .staticDataType(StaticDataType.COMMENT)
+                                .auto("auto")
+                                .build();
+                createAdminMemo.createContentAdminMemo(adminMemoContentRequest,queryFactory);
+            }
+            return;
+        }
+    }
+    @EventListener
+    public void adminBotAutoLogEvent(AdminBotCreateLogEvent adminBotEvent){
+        if(adminBotEvent.getStaticDataType().equals(StaticDataType.Improvement)){
+            AdminMemoImprovementRequest adminMemoImprovementRequest=AdminMemoImprovementRequest
+                    .builder()
+                    .importantStatus(ImportantStatus.NORMAL)
+                    .improvementStatus(ImprovementStatus.PENDING)
+                    .contentId(adminBotEvent.getContentId())
+                    .auto("auto")
+                    .build();
+            createAdminMemo.createImprovementMemo(adminMemoImprovementRequest,queryFactory);
+            return;
+        }
+        AdminMemoInquiryRequest adminMemoInquiryRequest=AdminMemoInquiryRequest
+                .builder()
+                .contentId(adminBotEvent.getContentId())
+                .isMember(adminBotEvent.getIsMember())
+                .build();
+        createAdminMemo.adminBotCreateInquiryLog(adminMemoInquiryRequest);
+    }
+}

--- a/src/main/java/org/myteam/server/admin/service/AdminBotListener.java
+++ b/src/main/java/org/myteam/server/admin/service/AdminBotListener.java
@@ -41,7 +41,7 @@ public class AdminBotListener {
                     .on(boardCount.board.eq(board))
                     .where(board.id.eq(autoHideEvent.getContentId()))
                     .fetchOne();
-            if(reportCount>=viewCount*0.8){
+            if(reportCount>=viewCount*0.8&&viewCount>=10){
                 AdminMemoContentRequest adminMemoContentRequest=
                         AdminMemoContentRequest
                                 .builder()
@@ -60,7 +60,7 @@ public class AdminBotListener {
                     .where(comment1.id.eq(autoHideEvent.getContentId()))
                     .fetchOne();
             int recommendCount=comment.getRecommendCount();
-            if(reportCount>=recommendCount*0.8){
+            if(reportCount>=recommendCount*0.8&&recommendCount>=3){
                 AdminMemoContentRequest adminMemoContentRequest=
                         AdminMemoContentRequest
                                 .builder()

--- a/src/main/java/org/myteam/server/admin/service/AdminInquiryService.java
+++ b/src/main/java/org/myteam/server/admin/service/AdminInquiryService.java
@@ -1,7 +1,7 @@
 package org.myteam.server.admin.service;
 
 import lombok.RequiredArgsConstructor;
-import org.myteam.server.admin.entity.AdminMemo;
+import org.myteam.server.admin.entity.AdminContentMemo;
 import org.myteam.server.admin.repository.InquirySearchRepo;
 import org.myteam.server.common.certification.service.InquiryAnsSendService;
 import org.myteam.server.member.service.MemberReadService;
@@ -38,9 +38,10 @@ public class AdminInquiryService {
     }
 
     public void sendInquiryAnswer(AdminMemoInquiryRequest adminMemoRequest) {
-        AdminMemo adminMemo = inquirySearchRepo.createAdminMemo(adminMemoRequest);
+        AdminContentMemo adminMemo = inquirySearchRepo.createAdminMemo(adminMemoRequest);
         if (adminMemo != null) {
-            inquiryAnsSendStrategy.send(adminMemo, memberReadService.getByEmail(adminMemoRequest.getEmail()));
+            inquiryAnsSendStrategy.send(adminMemo,
+                    memberReadService.getByEmail(adminMemoRequest.getEmail()));
         }
     }
 }

--- a/src/main/java/org/myteam/server/admin/utill/AdminBotAutoHideEvent.java
+++ b/src/main/java/org/myteam/server/admin/utill/AdminBotAutoHideEvent.java
@@ -1,0 +1,17 @@
+package org.myteam.server.admin.utill;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.myteam.server.report.domain.ReportType;
+
+@Getter
+public class AdminBotAutoHideEvent {
+    private Long contentId;
+    private ReportType reportType;
+
+    @Builder
+    public AdminBotAutoHideEvent(Long contentId, ReportType reportType){
+        this.contentId=contentId;
+        this.reportType=reportType;
+    }
+}

--- a/src/main/java/org/myteam/server/admin/utill/AdminBotCreateLogEvent.java
+++ b/src/main/java/org/myteam/server/admin/utill/AdminBotCreateLogEvent.java
@@ -1,0 +1,23 @@
+package org.myteam.server.admin.utill;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.myteam.server.report.domain.ReportType;
+
+@NoArgsConstructor
+@Getter
+public class AdminBotCreateLogEvent {
+
+    private Long contentId;
+    private StaticDataType staticDataType;
+    private Boolean isMember;
+
+    @Builder
+    public AdminBotCreateLogEvent(Long contentId,StaticDataType staticDataType,Boolean isMember){
+        this.contentId=contentId;
+        this.staticDataType=staticDataType;
+        this.isMember=isMember;
+    }
+}

--- a/src/main/java/org/myteam/server/admin/utill/CreateStaticQueryFactory.java
+++ b/src/main/java/org/myteam/server/admin/utill/CreateStaticQueryFactory.java
@@ -6,16 +6,19 @@ import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.EntityPathBase;
 import com.querydsl.core.types.dsl.StringTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.myteam.server.admin.entity.AdminInquiryChangeLog;
 import org.myteam.server.improvement.domain.ImprovementStatus;
-import org.myteam.server.improvement.domain.QImprovement;
+import org.myteam.server.member.domain.MemberStatus;
 import org.myteam.server.report.domain.ReportType;
-
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import static org.myteam.server.admin.dto.response.AdminDashBoardResponseDto.ResponseStatic;
-import static org.myteam.server.improvement.domain.QImprovement.*;
+import static org.myteam.server.admin.entity.QAdminContentChangeLog.adminContentChangeLog;
+import static org.myteam.server.admin.entity.QAdminImproveChangeLog.adminImproveChangeLog;
+import static org.myteam.server.admin.entity.QAdminInquiryChangeLog.adminInquiryChangeLog;
+import static org.myteam.server.admin.entity.QAdminMemberChangeLog.*;
 import static org.myteam.server.inquiry.domain.QInquiry.inquiry;
 import static org.myteam.server.member.entity.QMember.member;
 import static org.myteam.server.report.domain.QReport.report;
@@ -79,21 +82,21 @@ public class CreateStaticQueryFactory {
         LocalDateTime staticStartTimePast = dateList.get(2);
         LocalDateTime staticEndTimePast = dateList.get(3);
 
-        Long currentCount = queryFactory.select(improvement.count())
-                .from(improvement)
-                .where(StaticUtil.betweenStaticTime(staticEndTime, staticStartTime, improvement),
+        Long currentCount = queryFactory.select(adminImproveChangeLog.id.countDistinct())
+                .from(adminImproveChangeLog)
+                .where(StaticUtil.betweenStaticTime(staticEndTime, staticStartTime,adminImproveChangeLog),
                         improvementProcessCond(staticDataType))
                 .fetch()
                 .get(0);
-        Long pastCount = queryFactory.select(improvement.count())
-                .from(improvement)
-                .where(StaticUtil.betweenStaticTime(staticEndTimePast, staticStartTimePast, improvement),
+        Long pastCount = queryFactory.select(adminImproveChangeLog.id.countDistinct())
+                .from(adminImproveChangeLog)
+                .where(StaticUtil.betweenStaticTime(staticEndTimePast, staticStartTimePast,adminImproveChangeLog),
                         improvementProcessCond(staticDataType))
                 .fetch()
                 .get(0);
 
-        Long totCount = queryFactory.select(improvement.count())
-                .from(improvement)
+        Long totCount = queryFactory.select(adminImproveChangeLog.id.countDistinct())
+                .from(adminImproveChangeLog)
                 .where(improvementProcessCond(staticDataType))
                 .fetch()
                 .get(0);
@@ -114,22 +117,22 @@ public class CreateStaticQueryFactory {
         LocalDateTime staticStartTimePast = dateList.get(2);
         LocalDateTime staticEndTimePast = dateList.get(3);
 
-        Long currentCount = queryFactory.select(inquiry.count())
-                .from(inquiry)
-                .where(StaticUtil.betweenStaticTime(staticEndTime, staticStartTime,inquiry),
-                        inquiry.isAdminAnswered.eq(isAnswered))
+        Long currentCount = queryFactory.select(adminInquiryChangeLog.id.countDistinct())
+                .from(adminInquiryChangeLog)
+                .where(StaticUtil.betweenStaticTime(staticEndTime, staticStartTime,adminInquiryChangeLog),
+                        adminInquiryChangeLog.isAnswered.eq(isAnswered))
                 .fetch()
                 .get(0);
-        Long pastCount = queryFactory.select(inquiry.count())
-                .from(inquiry)
-                .where(StaticUtil.betweenStaticTime(staticEndTimePast, staticStartTimePast,inquiry),
-                        inquiry.isAdminAnswered.eq(isAnswered))
+        Long pastCount = queryFactory.select(adminInquiryChangeLog.id.countDistinct())
+                .from(adminInquiryChangeLog)
+                .where(StaticUtil.betweenStaticTime(staticEndTimePast, staticStartTimePast,adminInquiryChangeLog),
+                    adminInquiryChangeLog.isAnswered.eq(isAnswered))
                 .fetch()
                 .get(0);
 
-        Long totCount = queryFactory.select(inquiry.count())
-                .from(inquiry)
-                .where(inquiry.isAdminAnswered.eq(isAnswered))
+        Long totCount = queryFactory.select(adminInquiryChangeLog.id.countDistinct())
+                .from(adminInquiryChangeLog)
+                .where(adminInquiryChangeLog.isAnswered.eq(isAnswered))
                 .fetch()
                 .get(0);
         int percent = StaticUtil.makeStaticPercent(currentCount, pastCount);
@@ -149,26 +152,26 @@ public class CreateStaticQueryFactory {
         LocalDateTime staticStartTimePast = dateList.get(2);
         LocalDateTime staticEndTimePast = dateList.get(3);
 
-        Long currentCount = queryFactory.select(inquiry.count())
-                .from(inquiry)
+        Long currentCount = queryFactory.select(adminInquiryChangeLog.id.countDistinct())
+                .from(adminInquiryChangeLog)
                 .join(member)
-                .on(member.eq(inquiry.member))
-                .where(StaticUtil.betweenStaticTime(staticEndTime, staticStartTime,inquiry),
+                .on(member.eq(adminInquiryChangeLog.admin))
+                .where(StaticUtil.betweenStaticTime(staticEndTime, staticStartTime,adminInquiryChangeLog),
                         inquiryIsMember(isMember))
                 .fetch()
                 .get(0);
-        Long pastCount =queryFactory.select(inquiry.count())
-                .from(inquiry)
+        Long pastCount =queryFactory.select(adminInquiryChangeLog.id.countDistinct())
+                .from(adminInquiryChangeLog)
                 .join(member)
-                .on(member.eq(inquiry.member))
-                .where(StaticUtil.betweenStaticTime(staticEndTimePast, staticStartTimePast,inquiry),
+                .on(member.eq(adminInquiryChangeLog.admin))
+                .where(StaticUtil.betweenStaticTime(staticEndTimePast, staticStartTimePast,adminInquiryChangeLog),
                         inquiryIsMember(isMember))
                 .fetch()
                 .get(0);
-        Long totCount = queryFactory.select(inquiry.count())
-                .from(inquiry)
+        Long totCount = queryFactory.select(adminInquiryChangeLog.id.countDistinct())
+                .from(adminInquiryChangeLog)
                 .join(member)
-                .on(member.eq(inquiry.member))
+                .on(member.eq(adminInquiryChangeLog.admin))
                 .where(inquiryIsMember(isMember))
                 .fetch()
                 .get(0);
@@ -177,6 +180,85 @@ public class CreateStaticQueryFactory {
                 .currentCount(currentCount)
                 .pastCount(pastCount)
                 .totCount(totCount)
+                .percent(percent)
+                .build();
+    }
+
+    public static ResponseStatic createStaticContentQuery(StaticDataType staticDataType,
+                                                          AdminControlType adminControlType,List<LocalDateTime> dateList,JPAQueryFactory queryFactory)
+    {
+        LocalDateTime staticStartTime = dateList.get(0);
+        LocalDateTime staticEndTime = dateList.get(1);
+        LocalDateTime staticStartTimePast = dateList.get(2);
+        LocalDateTime staticEndTimePast = dateList.get(3);
+
+        Long current_count = queryFactory
+                .select(adminContentChangeLog.contentId.countDistinct())
+                .from(adminContentChangeLog)
+                .where(StaticUtil.betweenStaticTime(staticEndTime,staticStartTime,adminContentChangeLog),
+                        (adminContentChangeLog.adminControlType.eq(adminControlType)),
+                        (adminContentChangeLog.staticDataType.eq(staticDataType)))
+                .fetch().get(0);
+
+        Long past_count = queryFactory
+                .select(adminContentChangeLog.contentId.countDistinct())
+                .from(adminContentChangeLog)
+                .where(StaticUtil.betweenStaticTime(staticEndTimePast,staticStartTimePast,adminContentChangeLog),
+                        (adminContentChangeLog.adminControlType.eq(adminControlType))
+                        , (adminContentChangeLog.staticDataType.eq(staticDataType)))
+                .fetch().get(0);
+
+        Long tot_count = queryFactory.select(adminContentChangeLog
+                        .contentId.countDistinct())
+                .from(adminContentChangeLog)
+                .where((adminContentChangeLog.adminControlType.eq(adminControlType))
+                        .and(adminContentChangeLog.staticDataType.eq(staticDataType)))
+                .fetch().get(0);
+
+        int percent = StaticUtil.makeStaticPercent(current_count, past_count);
+
+        return ResponseStatic
+                .builder()
+                .currentCount(current_count)
+                .pastCount(past_count)
+                .totCount(tot_count)
+                .percent(percent)
+                .build();
+    }
+
+    public static ResponseStatic createStaticMemberStatusQuery(MemberStatus memberStatus,List<LocalDateTime> dateList,JPAQueryFactory queryFactory)
+    {
+        LocalDateTime staticStartTime = dateList.get(0);
+        LocalDateTime staticEndTime = dateList.get(1);
+        LocalDateTime staticStartTimePast = dateList.get(2);
+        LocalDateTime staticEndTimePast = dateList.get(3);
+
+        Long current_count = queryFactory
+                .select(adminMemberChangeLog.memberId.countDistinct())
+                .from(adminMemberChangeLog)
+                .where(StaticUtil.betweenStaticTime(staticEndTime,staticStartTime,
+                                adminMemberChangeLog),
+                        (adminMemberChangeLog.memberStatus.eq(memberStatus)))
+                .fetch().get(0);
+
+        Long past_count = queryFactory
+                .select(adminMemberChangeLog.memberId.countDistinct())
+                .from(adminMemberChangeLog)
+                .where(StaticUtil.betweenStaticTime(staticEndTimePast,staticStartTimePast,
+                               adminMemberChangeLog),
+                        (adminMemberChangeLog.memberStatus.eq(memberStatus)))
+                .fetch().get(0);
+
+        Long tot_count = queryFactory.select(adminMemberChangeLog.memberId.countDistinct())
+                .from(adminMemberChangeLog)
+                .where(adminMemberChangeLog.memberStatus.eq(memberStatus))
+                .fetch().get(0);
+        int percent = StaticUtil.makeStaticPercent(current_count, past_count);
+        return ResponseStatic
+                .builder()
+                .currentCount(current_count)
+                .pastCount(past_count)
+                .totCount(tot_count)
                 .percent(percent)
                 .build();
     }
@@ -231,20 +313,20 @@ public class CreateStaticQueryFactory {
     }
 
     private static Predicate inquiryIsMember(boolean isMember){
-        if(isMember){
-            return member.nickname.isNotNull();
+       if(isMember){
+            return adminInquiryChangeLog.isMember.isTrue();
         }
-        return member.nickname.isNull();
+        return adminInquiryChangeLog.isMember.isFalse();
     }
 
     private static Predicate improvementProcessCond(StaticDataType staticDataType){
         if(staticDataType.equals(StaticDataType.ImprovementPending)){
-            return improvement.improvementStatus.eq(ImprovementStatus.PENDING);
+            return adminImproveChangeLog.improvementStatus.eq(ImprovementStatus.PENDING);
         }
         if(staticDataType.equals(StaticDataType.ImprovementReceived)){
-            return improvement.improvementStatus.eq(ImprovementStatus.RECEIVED);
+            return adminImproveChangeLog.improvementStatus.eq(ImprovementStatus.RECEIVED);
         }
-        return improvement.improvementStatus.eq(ImprovementStatus.COMPLETED);
+        return adminImproveChangeLog.improvementStatus.eq(ImprovementStatus.COMPLETED);
     }
 
 

--- a/src/main/java/org/myteam/server/admin/utill/StaticUtil.java
+++ b/src/main/java/org/myteam/server/admin/utill/StaticUtil.java
@@ -3,13 +3,14 @@ package org.myteam.server.admin.utill;
 import com.querydsl.core.types.EntityPath;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.StringTemplate;
-
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.util.Date;
-
 import static com.querydsl.core.types.dsl.Expressions.stringTemplate;
-import static org.myteam.server.admin.entity.QAdminChangeLog.adminChangeLog;
+import static org.myteam.server.admin.entity.QAdminContentChangeLog.adminContentChangeLog;
+import static org.myteam.server.admin.entity.QAdminImproveChangeLog.adminImproveChangeLog;
+import static org.myteam.server.admin.entity.QAdminInquiryChangeLog.*;
+import static org.myteam.server.admin.entity.QAdminMemberChangeLog.adminMemberChangeLog;
 import static org.myteam.server.board.domain.QBoard.board;
 import static org.myteam.server.comment.domain.QComment.comment1;
 import static org.myteam.server.improvement.domain.QImprovement.improvement;
@@ -45,8 +46,17 @@ public class StaticUtil {
             case "MemberAccess" -> {
                 return memberAccess.accessTime.goe(static_end_time).and(memberAccess.accessTime.lt(static_start_time));
             }
-            case "AdminChangeLog" -> {
-                return adminChangeLog.createDate.goe(static_end_time).and(adminChangeLog.createDate.lt(static_start_time));
+            case "AdminMemberChangeLog" -> {
+                return adminMemberChangeLog.createDate.goe(static_end_time).and(adminMemberChangeLog.createDate.lt(static_start_time));
+            }
+            case "AdminContentChangeLog" -> {
+                return adminContentChangeLog.createDate.goe(static_end_time).and( adminContentChangeLog.createDate.lt(static_start_time));
+            }
+            case "AdminImproveChangeLog" -> {
+                return adminImproveChangeLog.createDate.goe(static_end_time).and(adminImproveChangeLog.createDate.lt(static_start_time));
+            }
+            case "AdminInquiryChangeLog" -> {
+                return adminInquiryChangeLog.createDate.goe(static_end_time).and(adminInquiryChangeLog.createDate.lt(static_start_time));
             }
             default -> {
                 return null;

--- a/src/main/java/org/myteam/server/common/certification/service/InquiryAnsSendService.java
+++ b/src/main/java/org/myteam/server/common/certification/service/InquiryAnsSendService.java
@@ -4,7 +4,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.myteam.server.admin.entity.AdminMemo;
+import org.myteam.server.admin.entity.AdminContentMemo;
 import org.myteam.server.global.exception.ErrorCode;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.util.date.DateFormatUtil;
@@ -43,7 +43,7 @@ public class InquiryAnsSendService {
         return templateEngine.process("mail/signup-complete-template", context);
     }
     @Async
-    public CompletableFuture<Void> send(AdminMemo adminMemo,MemberResponse memberResponse) {
+    public CompletableFuture<Void> send(AdminContentMemo adminMemo, MemberResponse memberResponse) {
 
         log.info("📨 Sending email to {}",memberResponse.getEmail());
 

--- a/src/main/java/org/myteam/server/improvement/service/ImprovementService.java
+++ b/src/main/java/org/myteam/server/improvement/service/ImprovementService.java
@@ -2,6 +2,10 @@ package org.myteam.server.improvement.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.myteam.server.admin.entity.AdminImproveChangeLog;
+import org.myteam.server.admin.repository.simpleRepo.AdminImproveChangeLogRepo;
+import org.myteam.server.admin.utill.AdminBotCreateLogEvent;
+import org.myteam.server.admin.utill.StaticDataType;
 import org.myteam.server.comment.domain.CommentType;
 import org.myteam.server.comment.service.CommentService;
 import org.myteam.server.global.exception.ErrorCode;
@@ -19,9 +23,12 @@ import org.myteam.server.improvement.repository.ImprovementCountRepository;
 import org.myteam.server.improvement.repository.ImprovementQueryRepository;
 import org.myteam.server.improvement.repository.ImprovementRepository;
 import org.myteam.server.member.entity.Member;
+import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.member.service.SecurityReadService;
 import org.myteam.server.report.domain.DomainType;
 import org.myteam.server.upload.service.StorageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,6 +46,7 @@ public class ImprovementService {
     private final CommentService commentService;
     private final StorageService s3Service;
     private final RedisCountService redisCountService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * 개선요청 작성
@@ -56,6 +64,14 @@ public class ImprovementService {
                 improvement.getId(), null);
 
         log.info("개선요청 생성: {}", improvement.getId());
+
+
+        AdminBotCreateLogEvent adminBotCreateLogEvent=AdminBotCreateLogEvent
+                .builder()
+                .contentId(improvement.getId())
+                .staticDataType(StaticDataType.Improvement)
+                .build();
+        applicationEventPublisher.publishEvent(adminBotCreateLogEvent);
 
         Long previousId = improvementQueryRepository.findPreviousImprovementId(improvement.getId());
         Long nextId = improvementQueryRepository.findNextImprovementId(improvement.getId());

--- a/src/main/java/org/myteam/server/match/matchPrediction/dto/service/response/MatchPredictionResponse.java
+++ b/src/main/java/org/myteam/server/match/matchPrediction/dto/service/response/MatchPredictionResponse.java
@@ -2,6 +2,7 @@ package org.myteam.server.match.matchPrediction.dto.service.response;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.myteam.server.match.match.dto.service.response.TeamResponse;
 import org.myteam.server.match.matchPrediction.domain.MatchPrediction;
 import org.myteam.server.match.matchPrediction.dto.service.request.Side;
@@ -20,8 +21,14 @@ public class MatchPredictionResponse {
 	private TeamResponse homeTeam;
 	private TeamResponse awayTeam;
 	private LocalDateTime startTime;
+	@Schema(description = "home의 절대값")
 	private int home;
+	@Schema(description = "away의 절대값")
 	private int away;
+	@Schema(description = "home의 퍼센트")
+	private int homePercent;
+	@Schema(description = "away의 퍼센트")
+	private int awayPercent;
 	private boolean isVote;
 	private Side side;
 
@@ -56,7 +63,7 @@ public class MatchPredictionResponse {
 
 	private void updateAsPercentage() {
 		int[] percentage = PercentageUtil.getCalculatedPercentages(this.home, this.away);
-		this.home = percentage[0];
-		this.away = percentage[1];
+		this.homePercent = percentage[0];
+		this.awayPercent = percentage[1];
 	}
 }

--- a/src/main/java/org/myteam/server/member/service/MemberReadService.java
+++ b/src/main/java/org/myteam/server/member/service/MemberReadService.java
@@ -31,7 +31,8 @@ public class MemberReadService {
     private final MemberJpaRepository memberJpaRepository;
     private final SecurityReadService securityReadService;
     private final JwtProvider jwtProvider;
-
+    @Value("${SENDER_EMAIL}")
+    protected String senderEmail;
     public Member findById(UUID publicId) {
         Member member = memberJpaRepository.findByPublicId(publicId)
                 .orElseThrow(() -> new PlayHiveException(ErrorCode.USER_NOT_FOUND));
@@ -42,7 +43,10 @@ public class MemberReadService {
 
         return member;
     }
-
+    public Member getAdminBot(){
+        return memberJpaRepository.findByEmail(senderEmail)
+                .orElseThrow(() -> new PlayHiveException(USER_NOT_FOUND));
+    }
     public Member findByEmail(String email) {
         return memberJpaRepository.findByEmail(email)
                 .orElseThrow(() -> new PlayHiveException(USER_NOT_FOUND));

--- a/src/main/java/org/myteam/server/report/dto/request/ReportRequest.java
+++ b/src/main/java/org/myteam/server/report/dto/request/ReportRequest.java
@@ -1,5 +1,6 @@
 package org.myteam.server.report.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,5 +29,9 @@ public record ReportRequest() {
 
         @NotNull(message = "신고 사유(BanReason)는 선택해야 합니다.")
         private BanReason reasons;
+
+        @Schema(description ="신고 사유가 기타일 경우 들어가는 값입니다. 만일 입력된 값이 없거나" +
+                "없을 경우에는 null을 주세요")
+        private String reportDescription;
     }
 }

--- a/src/main/java/org/myteam/server/report/repository/ReportQueryRepository.java
+++ b/src/main/java/org/myteam/server/report/repository/ReportQueryRepository.java
@@ -1,8 +1,8 @@
 package org.myteam.server.report.repository;
 
+
 import static org.myteam.server.report.domain.QReport.report;
 import static org.myteam.server.member.entity.QMember.member;
-
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.UUID;
 

--- a/src/test/java/org/myteam/server/admin/AdminMemberSearchTest.java
+++ b/src/test/java/org/myteam/server/admin/AdminMemberSearchTest.java
@@ -2,6 +2,7 @@ package org.myteam.server.admin;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.myteam.server.admin.entity.AdminMemberMemo;
 import org.myteam.server.admin.repository.AdminMemberRepository;
 import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.CategoryType;
@@ -23,6 +24,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.myteam.server.admin.dto.request.MemberSearchRequestDto.*;
 import static org.myteam.server.admin.dto.response.MemberSearchResponseDto.*;
@@ -41,9 +45,6 @@ public class AdminMemberSearchTest extends IntegrationTestSupport {
 
     @Autowired
     CommentRepository commentRepository;
-
-    @Autowired
-    BoardRepository boardRepository;
 
     @Autowired
     MockMvc mockMvc;
@@ -162,6 +163,8 @@ public class AdminMemberSearchTest extends IntegrationTestSupport {
         ,m.getStatus(),MemberStatus.INACTIVE);
         ResponseMemberDetail responseMemberDetail = adminMemberRepository.getMemberDetail(m.getPublicId());
         assertThat(responseMemberDetail.getAdminMemoResponses().size()).isEqualTo(1);
+        List<AdminMemberMemo> adminMemberMemo=adminMemberMemoRepo.findAll();
+        assertThat(adminMemberMemo.size()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/org/myteam/server/admin/filter/LimitLoginTest.java
+++ b/src/test/java/org/myteam/server/admin/filter/LimitLoginTest.java
@@ -2,17 +2,12 @@ package org.myteam.server.admin.filter;
 
 import static org.assertj.core.api.Assertions.*;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
-import org.mockito.Mock;
-import org.myteam.server.admin.entity.AdminMemo;
+import org.myteam.server.admin.entity.AdminMemberMemo;
 import org.myteam.server.chat.info.domain.UserInfo;
-import org.myteam.server.common.certification.mail.core.MailStrategy;
 import org.myteam.server.common.certification.mail.domain.EmailType;
-import org.myteam.server.common.certification.mail.factory.MailStrategyFactory;
 import org.myteam.server.common.certification.mail.strategy.NotifyAdminSuspendGlobalStrategy;
 import org.myteam.server.common.certification.mail.strategy.NotifyAdminSuspendStrategy;
 import org.myteam.server.common.certification.service.SuspendMailSendService;
@@ -20,28 +15,19 @@ import org.myteam.server.global.security.jwt.JwtProvider;
 import org.myteam.server.global.util.redis.service.RedisUserInfoService;
 import org.myteam.server.member.domain.MemberRole;
 import org.myteam.server.member.domain.MemberStatus;
-import org.myteam.server.member.domain.MemberType;
-import org.myteam.server.member.dto.MemberSaveRequest;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.repository.MemberJpaRepository;
-import org.myteam.server.member.service.MemberReadService;
-import org.myteam.server.member.service.MemberService;
 import org.myteam.server.support.IntegrationTestSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
-
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
-
 import static org.mockito.BDDMockito.*;
 import static org.myteam.server.global.security.jwt.JwtProvider.TOKEN_CATEGORY_ACCESS;
 import static org.myteam.server.global.security.jwt.JwtProvider.TOKEN_CATEGORY_REFRESH;
@@ -141,7 +127,7 @@ public class LimitLoginTest extends IntegrationTestSupport {
         Optional<Member> member=memberJpaRepository.findByEmail(admin.getEmail());
         assertThat(member.get().getStatus()).isEqualTo(MemberStatus.INACTIVE);
 
-        List<AdminMemo> adminMemo=adminMemoRepository.findAll();
+        List<AdminMemberMemo> adminMemo=adminMemberMemoRepo.findAll();
         assertThat(adminMemo.size()).isEqualTo(1);
         assertThat(adminMemo.get(0).getMemberId()).isEqualTo(admin.getPublicId());
 

--- a/src/test/java/org/myteam/server/admin/repository/DashBoardRepoTest.java
+++ b/src/test/java/org/myteam/server/admin/repository/DashBoardRepoTest.java
@@ -1,14 +1,15 @@
 package org.myteam.server.admin.repository;
 
-
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.myteam.server.admin.entity.AdminChangeLog;
-import org.myteam.server.admin.repository.simpleRepo.AdminChangeLogRepo;
+import org.myteam.server.admin.entity.AdminContentChangeLog;
+import org.myteam.server.admin.entity.AdminImproveChangeLog;
+import org.myteam.server.admin.entity.AdminInquiryChangeLog;
+import org.myteam.server.admin.entity.AdminMemberChangeLog;
 import org.myteam.server.admin.service.AdminDashBoardService;
 import org.myteam.server.admin.utill.AdminControlType;
 import org.myteam.server.admin.utill.DateType;
@@ -19,6 +20,7 @@ import org.myteam.server.chat.block.domain.BanReason;
 import org.myteam.server.comment.domain.Comment;
 import org.myteam.server.global.domain.Category;
 import org.myteam.server.global.security.jwt.JwtProvider;
+import org.myteam.server.improvement.domain.ImportantStatus;
 import org.myteam.server.improvement.domain.Improvement;
 import org.myteam.server.improvement.domain.ImprovementStatus;
 import org.myteam.server.inquiry.domain.Inquiry;
@@ -34,7 +36,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
-
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -45,7 +46,6 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.myteam.server.admin.dto.request.AdminDashBoardRequestDto.RequestLatestData;
 import static org.myteam.server.admin.dto.request.AdminDashBoardRequestDto.RequestStatic;
@@ -70,8 +70,6 @@ public class DashBoardRepoTest extends IntegrationTestSupport {
     AdminDashBoardService adminDashBoardService;
     @Autowired
     JwtProvider jwtProvider;
-    @Autowired
-    AdminChangeLogRepo adminChangeLogRepo;
     @Autowired
     MockMvc mockMvc;
     @Autowired
@@ -125,56 +123,91 @@ public class DashBoardRepoTest extends IntegrationTestSupport {
                         member.updateDeleteAt(dates.get(0));
                         memberJpaRepository.save(member);
                         createMemberAccess(member, dates.get(1));
-                        AdminChangeLog adminChangeLog = AdminChangeLog
+                        AdminMemberChangeLog adminChangeLog = AdminMemberChangeLog
                                 .builder()
                                 .admin(admin)
                                 .memberId(member.getPublicId())
                                 .memberStatus(MemberStatus.WARNED)
                                 .build();
 
-                        AdminChangeLog adminChangeLog2 = AdminChangeLog
+                        AdminContentChangeLog adminChangeLog2 =AdminContentChangeLog
                                 .builder()
                                 .admin(admin)
                                 .contentId(comment.getId())
                                 .staticDataType(StaticDataType.COMMENT)
                                 .adminControlType(AdminControlType.HIDDEN)
                                 .build();
+
+                        AdminImproveChangeLog adminImproveChangeLog=AdminImproveChangeLog
+                                .builder()
+                                .improvementStatus(ImprovementStatus.COMPLETED)
+                                .admin(admin)
+                                .contentId(improvement.getId())
+                                .importantStatus(ImportantStatus.NORMAL)
+                                .build();
+
+
+                        AdminInquiryChangeLog adminInquiryChangeLog=
+                                AdminInquiryChangeLog
+                                        .builder()
+                                        .isMember(true)
+                                        .isAnswered(true)
+                                        .contentId(inquiry.getId())
+                                        .admin(admin)
+                                        .build();
+
+                        adminInquiryChangeLogRepo.save(adminInquiryChangeLog);
                         inquiry.updateAdminAnswered();
                         improvement.updateState(ImprovementStatus.COMPLETED);
                         inquiryRepository.save(inquiry);
                         improvementRepository.save(improvement);
-                        adminChangeLogRepo.save(adminChangeLog);
-                        adminChangeLogRepo.save(adminChangeLog2);
+                        adminMemberChangeLogRepo.save(adminChangeLog);
+                        adminContentChangeLogRepo.save(adminChangeLog2);
+                        adminImproveChangeLogRepo.save(adminImproveChangeLog);
                     }
                     else {
                         report = createReport(member, member, BanReason.ETC, ReportType.COMMENT, comment.getId());
                         member.updateDeleteAt(dates.get(2));
                         memberJpaRepository.save(member);
                         createMemberAccess(member, dates.get(2));
-                        AdminChangeLog adminChangeLog = AdminChangeLog
+                        AdminMemberChangeLog adminChangeLog = AdminMemberChangeLog
                                 .builder()
                                 .admin(admin)
                                 .memberId(member.getPublicId())
                                 .memberStatus(MemberStatus.INACTIVE)
                                 .build();
 
-                        AdminChangeLog adminChangeLogA = AdminChangeLog
-                                .builder()
-                                .admin(admin)
-                                .memberId(member.getPublicId())
-                                .memberStatus(MemberStatus.INACTIVE)
-                                .build();
-
-                        AdminChangeLog adminChangeLog2 = AdminChangeLog
+                        AdminContentChangeLog adminChangeLog2 = AdminContentChangeLog
                                 .builder()
                                 .admin(admin)
                                 .contentId(board.getId())
                                 .staticDataType(StaticDataType.BOARD)
                                 .adminControlType(AdminControlType.HIDDEN)
                                 .build();
-                        adminChangeLogRepo.save(adminChangeLog);
-                        adminChangeLogRepo.save(adminChangeLogA);
-                        adminChangeLogRepo.save(adminChangeLog2);
+
+
+                        AdminImproveChangeLog adminImproveChangeLog=AdminImproveChangeLog
+                                .builder()
+                                .improvementStatus(ImprovementStatus.PENDING)
+                                .admin(admin)
+                                .contentId(improvement.getId())
+                                .importantStatus(ImportantStatus.NORMAL)
+                                .build();
+
+
+                        AdminInquiryChangeLog adminInquiryChangeLog=
+                                AdminInquiryChangeLog
+                                        .builder()
+                                        .isMember(false)
+                                        .isAnswered(false)
+                                        .contentId(inquiry.getId())
+                                        .admin(admin)
+                                        .build();
+
+                        adminInquiryChangeLogRepo.save(adminInquiryChangeLog);
+                        adminImproveChangeLogRepo.save(adminImproveChangeLog);
+                        adminMemberChangeLogRepo.save(adminChangeLog);
+                        adminContentChangeLogRepo.save(adminChangeLog2);
                     }
                 });
     }
@@ -204,6 +237,31 @@ public class DashBoardRepoTest extends IntegrationTestSupport {
             assertThat(responseStatic1.getCurrentCount()).isEqualTo(5);
             assertThat(responseStatic1.getPastCount()).isEqualTo(0);
             assertThat(responseStatic1.getPercent()).isEqualTo(100);
+
+            RequestStatic InquiryIsMember= RequestStatic
+                    .builder()
+                    .staticDataType(StaticDataType.InquiryMember)
+                    .dateType(DateType.Day)
+                    .build();
+
+            RequestStatic InquiryNotMember = RequestStatic
+                    .builder()
+                    .staticDataType(StaticDataType.InquiryNoMember)
+                    .dateType(DateType.Day)
+                    .build();
+
+            ResponseStatic responseStaticIsMember=adminDashBoardService.getStaticData(InquiryIsMember);
+            ResponseStatic responseStaticNotMember=adminDashBoardService.getStaticData(InquiryNotMember);
+
+            assertThat(responseStaticIsMember.getCurrentCount()).isEqualTo(5);
+            assertThat(responseStaticIsMember.getPastCount()).isEqualTo(0);
+            assertThat(responseStaticIsMember.getPercent()).isEqualTo(100);
+
+            assertThat(responseStaticNotMember.getCurrentCount()).isEqualTo(5);
+            assertThat(responseStaticNotMember.getPastCount()).isEqualTo(0);
+            assertThat(responseStaticNotMember.getPercent()).isEqualTo(100);
+
+
 
 
             RequestStatic ImprovementFin= RequestStatic

--- a/src/test/java/org/myteam/server/improvement/service/ImprovementSaveServiceTest.java
+++ b/src/test/java/org/myteam/server/improvement/service/ImprovementSaveServiceTest.java
@@ -32,13 +32,12 @@ class ImprovementSaveServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private ImprovementService improvementService;
-    @MockBean
-    MemberReadService mockMemberReadService;
     private Member member;
     private UUID publicId;
 
     @BeforeEach
     void setUp() {
+        createAdminBot();
         member = createMember(1);
         publicId = member.getPublicId();
     }
@@ -60,7 +59,6 @@ class ImprovementSaveServiceTest extends IntegrationTestSupport {
                 anyLong(),
                 isNull()
         )).thenReturn(new CommonCountDto(0, 0, 0));
-        when(mockMemberReadService.getAdminBot()).thenReturn(member);
         ImprovementSaveRequest request = new ImprovementSaveRequest(
                 "제목",
                 "내용",

--- a/src/test/java/org/myteam/server/improvement/service/ImprovementSaveServiceTest.java
+++ b/src/test/java/org/myteam/server/improvement/service/ImprovementSaveServiceTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.myteam.server.admin.entity.AdminContentMemo;
+import org.myteam.server.admin.entity.AdminImproveChangeLog;
+import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.support.IntegrationTestSupport;
 import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.global.util.redis.CommonCountDto;
@@ -14,6 +17,7 @@ import org.myteam.server.member.entity.Member;
 import org.myteam.server.report.domain.DomainType;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,7 +31,6 @@ class ImprovementSaveServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private ImprovementService improvementService;
-
     private Member member;
     private UUID publicId;
 
@@ -54,7 +57,7 @@ class ImprovementSaveServiceTest extends IntegrationTestSupport {
                 anyLong(),
                 isNull()
         )).thenReturn(new CommonCountDto(0, 0, 0));
-
+        when(mockMemberReadService.getAdminBot()).thenReturn(member);
         ImprovementSaveRequest request = new ImprovementSaveRequest(
                 "제목",
                 "내용",
@@ -64,13 +67,16 @@ class ImprovementSaveServiceTest extends IntegrationTestSupport {
 
         // when
         ImprovementSaveResponse response = improvementService.saveImprovement(request, "127.0.0.1");
-
+        List<AdminImproveChangeLog> adminImproveChangeLogList=adminImproveChangeLogRepo.findAll();
+        List<AdminContentMemo> adminContentMemos=adminContentMemoRepo.findAll();
         // then
         assertThat(response).isNotNull();
         assertThat(response.getTitle()).isEqualTo("제목");
         assertThat(response.isRecommended()).isFalse();
         assertThat(response.getPreviousId()).isNull();
         assertThat(response.getNextId()).isNull();
+        assertThat(adminImproveChangeLogList.size()).isEqualTo(1);
+        assertThat(adminContentMemos.size()).isEqualTo(0);
     }
 
     @Test

--- a/src/test/java/org/myteam/server/improvement/service/ImprovementSaveServiceTest.java
+++ b/src/test/java/org/myteam/server/improvement/service/ImprovementSaveServiceTest.java
@@ -16,6 +16,7 @@ import org.myteam.server.improvement.dto.response.ImprovementResponse.*;
 import org.myteam.server.member.entity.Member;
 import org.myteam.server.report.domain.DomainType;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.List;
 import java.util.UUID;
@@ -31,6 +32,8 @@ class ImprovementSaveServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private ImprovementService improvementService;
+    @MockBean
+    MemberReadService mockMemberReadService;
     private Member member;
     private UUID publicId;
 

--- a/src/test/java/org/myteam/server/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/org/myteam/server/inquiry/service/InquiryServiceTest.java
@@ -29,15 +29,13 @@ class InquiryServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private InquiryService inquiryService;
-
-    @MockBean
-    MemberReadService mockMemberReadService;
     private Member member;
     private Inquiry inquiry;
 
     @Transactional
     @BeforeEach
     void setUp() {
+        createAdminBot();
         member = createMember(1);
         inquiry = createInquiry(member);
     }
@@ -47,7 +45,6 @@ class InquiryServiceTest extends IntegrationTestSupport {
     void createInquiry_withLoginUser_success() {
         // given
         when(securityReadService.getAuthenticatedPublicId()).thenReturn(member.getPublicId());
-        when(mockMemberReadService.getAdminBot()).thenReturn(member);
         // when
         String content = inquiryService.createInquiry("문의 내용입니다.", null, "127.0.0.1");
         List<AdminInquiryChangeLog> adminImproveChangeLogList=adminInquiryChangeLogRepo.findAll();
@@ -65,7 +62,6 @@ class InquiryServiceTest extends IntegrationTestSupport {
     void createInquiry_withoutLoginUser_withEmail_success() {
         // given
         when(securityReadService.getAuthenticatedPublicId()).thenReturn(null);
-        when(mockMemberReadService.getAdminBot()).thenReturn(member);
 
         // when
         String content = inquiryService.createInquiry("비회원 문의입니다.", "nonmember@example.com", "127.0.0.1");

--- a/src/test/java/org/myteam/server/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/org/myteam/server/inquiry/service/InquiryServiceTest.java
@@ -14,6 +14,7 @@ import org.myteam.server.global.exception.PlayHiveException;
 import org.myteam.server.inquiry.domain.Inquiry;
 import org.myteam.server.member.entity.Member;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -28,6 +29,9 @@ class InquiryServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private InquiryService inquiryService;
+
+    @MockBean
+    MemberReadService mockMemberReadService;
     private Member member;
     private Inquiry inquiry;
 

--- a/src/test/java/org/myteam/server/match/matchPrediction/dto/MatchPredictionResponseTest.java
+++ b/src/test/java/org/myteam/server/match/matchPrediction/dto/MatchPredictionResponseTest.java
@@ -28,9 +28,9 @@ public class MatchPredictionResponseTest extends TestContainerSupport {
                 .build();
 
         assertAll(
-                () -> assertThat(matchPredictionResponse1).extracting("matchId", "id", "home", "away")
+                () -> assertThat(matchPredictionResponse1).extracting("matchId", "id", "homePercent", "awayPercent")
                         .contains(1L, 1L, 100, 0),
-                () -> assertThat(matchPredictionResponse2).extracting("matchId", "id", "home", "away")
+                () -> assertThat(matchPredictionResponse2).extracting("matchId", "id", "homePercent", "awayPercent")
                         .contains(1L, 1L, 50, 50)
         );
     }

--- a/src/test/java/org/myteam/server/match/matchPrediction/service/MatchPredictionReadServiceTest.java
+++ b/src/test/java/org/myteam/server/match/matchPrediction/service/MatchPredictionReadServiceTest.java
@@ -53,7 +53,7 @@ class MatchPredictionReadServiceTest extends IntegrationTestSupport {
         createMatchPrediction(match, 1, 2);
 
         assertThat(matchPredictionReadService.findOne(match.getId()))
-                .extracting("home", "away")
+                .extracting("homePercent", "awayPercent")
                 .contains(33, 67);
     }
 
@@ -69,7 +69,7 @@ class MatchPredictionReadServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(response)
-                .extracting("home", "away", "isVote", "side")
+                .extracting("homePercent", "awayPercent", "isVote", "side")
                 .contains(33, 67, true, Side.HOME);
     }
 
@@ -84,7 +84,7 @@ class MatchPredictionReadServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(response)
-                .extracting("home", "away", "isVote", "side")
+                .extracting("homePercent", "awayPercent", "isVote", "side")
                 .contains(33, 67, false, null);
     }
 
@@ -99,7 +99,7 @@ class MatchPredictionReadServiceTest extends IntegrationTestSupport {
 
         // then
         assertThat(response)
-                .extracting("home", "away", "isVote", "side")
+                .extracting("homePercent", "awayPercent", "isVote", "side")
                 .contains(33, 67, false, null);
     }
 

--- a/src/test/java/org/myteam/server/report/service/ReportCreateFailureTest.java
+++ b/src/test/java/org/myteam/server/report/service/ReportCreateFailureTest.java
@@ -3,6 +3,7 @@ package org.myteam.server.report.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.support.IntegrationTestSupport;
 import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.CategoryType;

--- a/src/test/java/org/myteam/server/report/service/ReportCreateFailureTest.java
+++ b/src/test/java/org/myteam/server/report/service/ReportCreateFailureTest.java
@@ -56,7 +56,7 @@ class ReportCreateFailureTest extends IntegrationTestSupport {
         when(redisService.getTimeToLive(any(), any())).thenReturn(100L);
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC
+                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC,null
         );
 
         assertThrows(PlayHiveException.class, () ->
@@ -69,7 +69,7 @@ class ReportCreateFailureTest extends IntegrationTestSupport {
     void reportContent_selfReport() {
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reporter.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC
+                reporter.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC,null
         );
 
         assertThrows(PlayHiveException.class, () ->
@@ -83,7 +83,7 @@ class ReportCreateFailureTest extends IntegrationTestSupport {
         when(reportedContentValidatorFactory.getValidator(any())).thenReturn(null);
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC
+                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC,null
         );
 
         assertThrows(PlayHiveException.class, () ->
@@ -96,7 +96,7 @@ class ReportCreateFailureTest extends IntegrationTestSupport {
     void reportContent_success() {
         // given
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.NONE, 100L, BanReason.HARASSMENT
+                reported.getPublicId(), ReportType.NONE, 100L, BanReason.HARASSMENT,null
         );
 
         // when && then
@@ -112,7 +112,7 @@ class ReportCreateFailureTest extends IntegrationTestSupport {
         when(validator.isValid(any())).thenReturn(false);
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC
+                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC,null
         );
 
         assertThrows(PlayHiveException.class, () ->
@@ -128,7 +128,7 @@ class ReportCreateFailureTest extends IntegrationTestSupport {
         when(validator.getOwnerPublicId(any())).thenReturn(UUID.randomUUID());
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC
+                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC,null
         );
 
         assertThrows(PlayHiveException.class, () ->

--- a/src/test/java/org/myteam/server/report/service/ReportCreateSuccessTest.java
+++ b/src/test/java/org/myteam/server/report/service/ReportCreateSuccessTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.myteam.server.admin.entity.AdminContentChangeLog;
 import org.myteam.server.admin.utill.AdminControlType;
 import org.myteam.server.admin.utill.StaticDataType;
+import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.support.IntegrationTestSupport;
 import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.CategoryType;
@@ -37,6 +38,8 @@ class ReportCreateSuccessTest extends IntegrationTestSupport {
     @Autowired
     private ReportService reportService;
     @MockBean
+    MemberReadService mockMemberReadService;
+    @MockBean
     private ReportedContentValidatorFactory reportedContentValidatorFactory;
     private Member reporter;
     private Member reported;
@@ -64,7 +67,7 @@ class ReportCreateSuccessTest extends IntegrationTestSupport {
         // given
         when(validator.isValid(any())).thenReturn(true);
         when(validator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
-
+        when(mockMemberReadService.getAdminBot()).thenReturn(reporter);
         ReportSaveRequest request = new ReportSaveRequest(
                 reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
         );
@@ -81,7 +84,7 @@ class ReportCreateSuccessTest extends IntegrationTestSupport {
         ReportSaveRequest request = new ReportSaveRequest(
                 reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
         );
-
+        when(mockMemberReadService.getAdminBot()).thenReturn(reporter);
         when(validator.isValid(any())).thenReturn(true);
         when(validator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
         ReportSaveResponse response = reportService.reportContent(request, "127.0.0.1");

--- a/src/test/java/org/myteam/server/report/service/ReportCreateSuccessTest.java
+++ b/src/test/java/org/myteam/server/report/service/ReportCreateSuccessTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.Test;
 import org.myteam.server.admin.entity.AdminContentChangeLog;
 import org.myteam.server.admin.utill.AdminControlType;
 import org.myteam.server.admin.utill.StaticDataType;
+import org.myteam.server.member.domain.MemberRole;
+import org.myteam.server.member.domain.MemberStatus;
+import org.myteam.server.member.domain.MemberType;
 import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.support.IntegrationTestSupport;
 import org.myteam.server.board.domain.Board;
@@ -38,8 +41,6 @@ class ReportCreateSuccessTest extends IntegrationTestSupport {
     @Autowired
     private ReportService reportService;
     @MockBean
-    MemberReadService mockMemberReadService;
-    @MockBean
     private ReportedContentValidatorFactory reportedContentValidatorFactory;
     private Member reporter;
     private Member reported;
@@ -55,7 +56,7 @@ class ReportCreateSuccessTest extends IntegrationTestSupport {
         reported = createMember(2);
         board = createBoard(reported, Category.BASEBALL, CategoryType.FREE, "title", "content");
         validator = mock(ReportedContentValidator.class);
-
+        createAdminBot();
         when(securityReadService.getMember()).thenReturn(reporter);
         when(redisService.isAllowed(any(), any())).thenReturn(true);
         when(reportedContentValidatorFactory.getValidator(any())).thenReturn(validator);
@@ -67,7 +68,6 @@ class ReportCreateSuccessTest extends IntegrationTestSupport {
         // given
         when(validator.isValid(any())).thenReturn(true);
         when(validator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
-        when(mockMemberReadService.getAdminBot()).thenReturn(reporter);
         ReportSaveRequest request = new ReportSaveRequest(
                 reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
         );
@@ -84,7 +84,6 @@ class ReportCreateSuccessTest extends IntegrationTestSupport {
         ReportSaveRequest request = new ReportSaveRequest(
                 reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
         );
-        when(mockMemberReadService.getAdminBot()).thenReturn(reporter);
         when(validator.isValid(any())).thenReturn(true);
         when(validator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
         ReportSaveResponse response = reportService.reportContent(request, "127.0.0.1");

--- a/src/test/java/org/myteam/server/report/service/ReportCreateSuccessTest.java
+++ b/src/test/java/org/myteam/server/report/service/ReportCreateSuccessTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.myteam.server.admin.entity.AdminContentChangeLog;
 import org.myteam.server.admin.utill.AdminControlType;
 import org.myteam.server.admin.utill.StaticDataType;
+import org.myteam.server.board.domain.BoardCount;
 import org.myteam.server.member.domain.MemberRole;
 import org.myteam.server.member.domain.MemberStatus;
 import org.myteam.server.member.domain.MemberType;
@@ -26,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,13 +91,36 @@ class ReportCreateSuccessTest extends IntegrationTestSupport {
         ReportSaveResponse response = reportService.reportContent(request, "127.0.0.1");
 
         Board board1=boardRepository.findById(board.getId()).get();
-        assertThat(board1.getAdminControlType()).isEqualTo(AdminControlType.HIDDEN);
+        assertThat(board1.getAdminControlType()).isNotEqualTo(AdminControlType.HIDDEN);
 
-        AdminContentChangeLog adminContentChangeLog1=queryFactory.selectFrom(adminContentChangeLog)
+        List<AdminContentChangeLog> adminContentChangeLog1=queryFactory.selectFrom(adminContentChangeLog)
                 .where(adminContentChangeLog.contentId.eq(board1.getId()),
                         adminContentChangeLog.staticDataType.eq(StaticDataType.BOARD))
-                .fetchOne();
-        assertThat(adminContentChangeLog1.getAdminControlType()).isEqualTo(board1.getAdminControlType());
-        assertThat(adminContentChangeLog1.getAdminControlType()).isEqualTo(AdminControlType.HIDDEN);
+                .fetch();
+        assertThat(adminContentChangeLog1.size()).isEqualTo(0);
+        BoardCount boardCount=boardCountRepository.findByBoardId(board.getId()).get();
+        for(int i=0;i<10;i++) {
+            boardCount.addViewCount();
+        }
+        boardCountRepository.save(boardCount);
+        for(int i=0;i<7;i++){
+            Member reporter = createMember(i);
+            Member reported = createMember(i*2);
+            ReportSaveRequest request2 = new ReportSaveRequest(
+                    reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
+            );
+            validator = mock(ReportedContentValidator.class);
+            when(securityReadService.getMember()).thenReturn(reporter);
+            reportService.reportContent(request2, "127.0.0.1");
+        }
+        board1=boardRepository.findById(board.getId()).get();
+        assertThat(board1.getAdminControlType()).isEqualTo(AdminControlType.HIDDEN);
+
+        adminContentChangeLog1=queryFactory.selectFrom(adminContentChangeLog)
+                .where(adminContentChangeLog.contentId.eq(board1.getId()),
+                        adminContentChangeLog.staticDataType.eq(StaticDataType.BOARD))
+                .fetch();
+        assertThat(adminContentChangeLog1.size()).isEqualTo(1);
+        assertThat(adminContentChangeLog1.get(0).getAdminControlType()).isEqualTo(AdminControlType.HIDDEN);
     }
 }

--- a/src/test/java/org/myteam/server/report/service/ReportReadServiceTest.java
+++ b/src/test/java/org/myteam/server/report/service/ReportReadServiceTest.java
@@ -30,7 +30,6 @@ class ReportReadServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private ReportReadService reportReadService;
-
     private Member reporter;
     private Member reported;
     private UUID reporterPublicId;

--- a/src/test/java/org/myteam/server/report/service/ReportServiceTest.java
+++ b/src/test/java/org/myteam/server/report/service/ReportServiceTest.java
@@ -42,8 +42,6 @@ class ReportServiceTest extends IntegrationTestSupport {
     private ReportService reportService;
     @MockBean
     private ReportedContentValidatorFactory reportedContentValidatorFactory;
-    @MockBean
-    MemberReadService mockMemberReadService;
     private Member reporter;
     private Member reported;
     private Member admin;
@@ -64,7 +62,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         admin = createAdmin(3);
         reporterPublicId = reporter.getPublicId();
         reportedPublicId = reported.getPublicId();
-
+        createAdminBot();
         board = createBoard(reported, Category.BASEBALL, CategoryType.FREE, "title", "content");
         news = createNews(0, Category.BASEBALL, 0);
         improvement = createImprovement(reported, false);
@@ -86,7 +84,6 @@ class ReportServiceTest extends IntegrationTestSupport {
         // given
         when(reportedContentValidator.isValid(any())).thenReturn(true);
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
-        when(mockMemberReadService.getAdminBot()).thenReturn(reporter);
         ReportSaveRequest request = new ReportSaveRequest(
                 reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
         );
@@ -175,7 +172,6 @@ class ReportServiceTest extends IntegrationTestSupport {
         // given
         when(reportedContentValidator.isValid(any())).thenReturn(true);
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
-        when(mockMemberReadService.getAdminBot()).thenReturn(reporter);
         ReportSaveRequest request = new ReportSaveRequest(
                 reported.getPublicId(), ReportType.COMMENT, comment.getId(), BanReason.HARASSMENT,null
         );

--- a/src/test/java/org/myteam/server/report/service/ReportServiceTest.java
+++ b/src/test/java/org/myteam/server/report/service/ReportServiceTest.java
@@ -86,7 +86,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT
+                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
         );
 
         // when
@@ -103,7 +103,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.NEWS, news.getId(), BanReason.HARASSMENT
+                reported.getPublicId(), ReportType.NEWS, news.getId(), BanReason.HARASSMENT,null
         );
 
         // when
@@ -121,7 +121,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.INQUIRY, inquiry.getId(), BanReason.HARASSMENT
+                reported.getPublicId(), ReportType.INQUIRY, inquiry.getId(), BanReason.HARASSMENT,null
         );
 
         // when
@@ -139,7 +139,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.IMPROVEMENT, improvement.getId(), BanReason.HARASSMENT
+                reported.getPublicId(), ReportType.IMPROVEMENT, improvement.getId(), BanReason.HARASSMENT,null
         );
 
         // when
@@ -157,7 +157,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.NOTICE, notice.getId(), BanReason.HARASSMENT
+                reported.getPublicId(), ReportType.NOTICE, notice.getId(), BanReason.HARASSMENT,null
         );
 
         // when
@@ -175,7 +175,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.COMMENT, comment.getId(), BanReason.HARASSMENT
+                reported.getPublicId(), ReportType.COMMENT, comment.getId(), BanReason.HARASSMENT,null
         );
 
         // when
@@ -193,7 +193,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         when(redisService.getTimeToLive(anyString(), anyString())).thenReturn(100L);
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT
+                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
         );
 
         // when & then
@@ -208,7 +208,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         // given
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reporter.getPublicId(), ReportType.BOARD, board.getId(), BanReason.PROMOTIONAL_OR_ILLEGAL_ADS
+                reporter.getPublicId(), ReportType.BOARD, board.getId(), BanReason.PROMOTIONAL_OR_ILLEGAL_ADS,null
         );
 
         // when & then
@@ -224,7 +224,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         when(reportedContentValidatorFactory.getValidator(any())).thenReturn(null);
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC
+                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.ETC,null
         );
 
         // when & then
@@ -240,7 +240,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         when(reportedContentValidator.isValid(any())).thenReturn(false);
 
         ReportSaveRequest request = new ReportSaveRequest(
-                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT
+                reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
         );
 
         // when & then

--- a/src/test/java/org/myteam/server/report/service/ReportServiceTest.java
+++ b/src/test/java/org/myteam/server/report/service/ReportServiceTest.java
@@ -3,6 +3,7 @@ package org.myteam.server.report.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.support.IntegrationTestSupport;
 import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.CategoryType;
@@ -41,7 +42,8 @@ class ReportServiceTest extends IntegrationTestSupport {
     private ReportService reportService;
     @MockBean
     private ReportedContentValidatorFactory reportedContentValidatorFactory;
-
+    @MockBean
+    MemberReadService mockMemberReadService;
     private Member reporter;
     private Member reported;
     private Member admin;
@@ -84,7 +86,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         // given
         when(reportedContentValidator.isValid(any())).thenReturn(true);
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
-
+        when(mockMemberReadService.getAdminBot()).thenReturn(reporter);
         ReportSaveRequest request = new ReportSaveRequest(
                 reported.getPublicId(), ReportType.BOARD, board.getId(), BanReason.HARASSMENT,null
         );
@@ -173,7 +175,7 @@ class ReportServiceTest extends IntegrationTestSupport {
         // given
         when(reportedContentValidator.isValid(any())).thenReturn(true);
         when(reportedContentValidator.getOwnerPublicId(any())).thenReturn(reported.getPublicId());
-
+        when(mockMemberReadService.getAdminBot()).thenReturn(reporter);
         ReportSaveRequest request = new ReportSaveRequest(
                 reported.getPublicId(), ReportType.COMMENT, comment.getId(), BanReason.HARASSMENT,null
         );

--- a/src/test/java/org/myteam/server/support/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/support/IntegrationTestSupport.java
@@ -159,6 +159,29 @@ public abstract class IntegrationTestSupport extends TestDriverSupport {
 
         return memberJpaRepository.findByEmail("test" + index + "@test.com").get();
     }
+    @Transactional
+    protected  Member createAdminBot(){
+        Member member = Member.builder()
+                .email("test@test.com")
+                .password("1234")
+                .tel("01012345678")
+                .nickname("test")
+                .role(MemberRole.ADMIN)
+                .type(MemberType.LOCAL)
+                .publicId(UUID.randomUUID())
+                .status(MemberStatus.ACTIVE)
+                .build();
+        MemberActivity memberActivity = new MemberActivity(member);
+        Member savedMember = memberJpaRepository.save(member);
+
+        given(securityReadService.getMember())
+                .willReturn(savedMember);
+
+        given(securityReadService.getAuthenticatedPublicId())
+                .willReturn(member.getPublicId());
+
+        return savedMember;
+    }
 
     @Transactional
     protected Member createMember(int index) {
@@ -184,23 +207,6 @@ public abstract class IntegrationTestSupport extends TestDriverSupport {
 
         return savedMember;
     }
-
-    @Transactional
-    protected Member createMemberWithOutSave(int index) {
-        Member member = Member.builder()
-                .email("test" + index + "@test.com")
-                .password("1234")
-                .tel("01012345678")
-                .nickname("test" + index)
-                .role(MemberRole.USER)
-                .type(MemberType.LOCAL)
-                .publicId(UUID.randomUUID())
-                .status(MemberStatus.ACTIVE)
-                .build();
-        memberJpaRepository.save(member);
-        return member;
-    }
-
 
     protected Member createOAuthMember(int index) {
         Member member = Member.builder()

--- a/src/test/java/org/myteam/server/support/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/support/IntegrationTestSupport.java
@@ -72,9 +72,6 @@ public abstract class IntegrationTestSupport extends TestDriverSupport {
     @MockBean
     protected RedisService redisService;
 
-    @MockBean
-    protected MemberReadService mockMemberReadService;
-
     /**
      * =================== Service ===================
      */

--- a/src/test/java/org/myteam/server/support/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/support/IntegrationTestSupport.java
@@ -8,7 +8,10 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
-import org.myteam.server.admin.repository.simpleRepo.AdminChangeLogRepo;
+import org.myteam.server.admin.entity.AdminContentChangeLog;
+import org.myteam.server.admin.entity.AdminImproveChangeLog;
+import org.myteam.server.admin.entity.AdminMemberMemo;
+import org.myteam.server.admin.repository.simpleRepo.*;
 import org.myteam.server.board.service.BoardCountService;
 import org.myteam.server.board.service.BoardReadService;
 import org.myteam.server.board.util.RedisBoardRankingReader;
@@ -31,6 +34,7 @@ import org.myteam.server.member.entity.Member;
 import org.myteam.server.member.entity.MemberAccess;
 import org.myteam.server.member.entity.MemberActivity;
 import org.myteam.server.member.repository.MemberAccessRepository;
+import org.myteam.server.member.service.MemberReadService;
 import org.myteam.server.member.service.MemberService;
 import org.myteam.server.member.service.SecurityReadService;
 import org.myteam.server.mypage.service.MyPageReadService;
@@ -68,6 +72,9 @@ public abstract class IntegrationTestSupport extends TestDriverSupport {
     @MockBean
     protected RedisService redisService;
 
+    @MockBean
+    protected MemberReadService mockMemberReadService;
+
     /**
      * =================== Service ===================
      */
@@ -93,11 +100,25 @@ public abstract class IntegrationTestSupport extends TestDriverSupport {
     protected MemberAccessRepository memberAccessRepository;
 
     @Autowired
-    protected AdminChangeLogRepo adminChangeLogRepo;
-
+    protected AdminContentMemoRepo adminContentMemoRepo;
+    @Autowired
+    protected AdminContentChangeLogRepo adminContentChangeLogRepo;
+    @Autowired
+    protected AdminMemberChangeLogRepo adminMemberChangeLogRepo;
+    @Autowired
+    protected AdminImproveChangeLogRepo adminImproveChangeLogRepo;
+    @Autowired
+    protected AdminInquiryChangeLogRepo adminInquiryChangeLogRepo;
+    @Autowired
+    protected AdminMemberMemoRepo adminMemberMemoRepo;
     @AfterEach
     void tearDown() {
-        adminChangeLogRepo.deleteAllInBatch();;
+        adminMemberMemoRepo.deleteAllInBatch();;
+        adminInquiryChangeLogRepo.deleteAllInBatch();
+        adminImproveChangeLogRepo.deleteAllInBatch();
+        adminMemberChangeLogRepo.deleteAllInBatch();;
+        adminContentChangeLogRepo.deleteAllInBatch();
+        adminContentMemoRepo.deleteAllInBatch();
         commentRecommendRepository.deleteAllInBatch();
         commentRepository.deleteAllInBatch();
         matchPredictionMemberRepository.deleteAllInBatch();
@@ -119,11 +140,8 @@ public abstract class IntegrationTestSupport extends TestDriverSupport {
         noticeRepository.deleteAllInBatch();
         reportRepository.deleteAllInBatch();
         memberActivityRepository.deleteAllInBatch();
-        adminChangeLogRepo.deleteAllInBatch();
-        adminMemoRepository.deleteAllInBatch();
-        ;
-        memberJpaRepository.deleteAllInBatch();
         memberAccessRepository.deleteAllInBatch();
+        memberJpaRepository.deleteAllInBatch();
     }
 
     @Transactional

--- a/src/test/java/org/myteam/server/support/TestDriverSupport.java
+++ b/src/test/java/org/myteam/server/support/TestDriverSupport.java
@@ -340,6 +340,7 @@ public abstract class TestDriverSupport {
                 .member(member)
                 .clientIp("0.0.0.1")
                 .createdAt(LocalDateTime.now())
+                .email(member.getEmail())
                 .isAdminAnswered(false)
                 .build();
 

--- a/src/test/java/org/myteam/server/support/TestDriverSupport.java
+++ b/src/test/java/org/myteam/server/support/TestDriverSupport.java
@@ -1,8 +1,6 @@
 package org.myteam.server.support;
 
 import org.junit.jupiter.api.AfterEach;
-import org.myteam.server.admin.repository.simpleRepo.AdminChangeLogRepo;
-import org.myteam.server.admin.repository.simpleRepo.AdminMemoRepository;
 import org.myteam.server.aop.count.CommonCountAspect;
 import org.myteam.server.board.domain.Board;
 import org.myteam.server.board.domain.BoardCount;
@@ -121,11 +119,6 @@ public abstract class TestDriverSupport {
     protected CommentRecommendRepository commentRecommendRepository;
     @Autowired
     protected ReportRepository reportRepository;
-    @Autowired
-    protected AdminMemoRepository adminMemoRepository;
-
-    @Autowired
-    protected AdminChangeLogRepo adminChangeLogRepo;
 
     /**
      * ================== Service ========================


### PR DESCRIPTION
## 기능 설명
- 댓글, 게시물에 대한 신고 비율이 특정 조건을 만족할경우 자동으로 숨김 처리하도록 수정.(단 신고 생성시에만 비교해서 처리하도록 하였음.)
- 관리자 대시보드 상에서 통계시 필요한 엔티티 추가.
-관리자 문의 사항 조회시 비회원도 확실하게 조회 하게 쿼리 수정.
### 작업 내용
- 관리자 대시보드 상에서 통계데이터를 불러올때 사용하는 기존의 adminchangelog,adminmemo를 회원,콘텐츠(게시글,댓글),문의,질의 4가지 종류로 분리하여 추후에 데이터 사이즈가 커져도 원하는것만 가져올수있게 만들었음.
- 관리자 문의사항 조회시 비회원 문의를 확실하게 조회할수있도로록 변경
- 통계상 필요로 인해서 문의,개선사항 생성시 최초의 adminchagelog생성하게 변경
## 수정 사항
- 
## 추가 작업 예정
- 채팅이 추가될경우 채팅을 위한 log,memo의 수정이 필요해보이고 또한 각종 통계 및 관리자의 게시물 관리 기능에서도 채팅을 다룰수있게 추가 해줘야 될것으로 보임.
- 문의 사항의 경우 답변에 대한 이메일 템플릿을 받지못함. 추후에 받으면 추가할 예정.
- pr후에 파일 구조를 약속한대로 수정할 예정.
- pr후에 db에다가까먹지 말고 엔티티 추가하기
- 자동 숨김처리에서 댓글,게시글에 최소 조건 추가.
- 승부 예측에서 response값에다가 절대값(수치)를 넘겨주도록 추가.
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인