### PR TITLE
fix: add column to responsemebersearch

### DIFF
--- a/src/main/java/org/myteam/server/admin/dto/response/MemberSearchResponseDto.java
+++ b/src/main/java/org/myteam/server/admin/dto/response/MemberSearchResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.UUID;
 
 import static org.myteam.server.admin.dto.response.CommonResponseDto.*;
 
@@ -25,6 +26,8 @@ public record MemberSearchResponseDto() {
         private String email;
         private String tel;
         private String createDate;
+        @Schema(description = "회원 식별값입니다. 상세검색시에 이용해주세요")
+        private UUID memberId;
 
         public void updateCreateDate(String date) {
             this.createDate = date;

--- a/src/main/java/org/myteam/server/admin/repository/AdminMemberRepository.java
+++ b/src/main/java/org/myteam/server/admin/repository/AdminMemberRepository.java
@@ -148,7 +148,8 @@ public class AdminMemberRepository {
                                         .otherwise("일반"),
                                 member.email,
                                 member.tel,
-                                member.createDate.stringValue()
+                                member.createDate.stringValue(),
+                                member.publicId
                         )
                 )
                 .from(member)


### PR DESCRIPTION
## 기능 설명
- 
### 작업 내용
- 
## 수정 사항
- 회원 정보 검색시 publicid컬럼 을 응답에추가.
## 추가 작업 예정
- 
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인