### PR TITLE
fix:memberblock logic

### DIFF
--- a/src/main/java/org/myteam/server/chat/block/controller/BlockController.java
+++ b/src/main/java/org/myteam/server/chat/block/controller/BlockController.java
@@ -1,12 +1,20 @@
 package org.myteam.server.chat.block.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.myteam.server.chat.block.dto.request.BlockRequest.*;
 import org.myteam.server.chat.block.dto.response.BlockResponse.*;
 import org.myteam.server.chat.block.dto.response.BlockedMembersResponse;
 import org.myteam.server.chat.block.service.BlockReadService;
 import org.myteam.server.chat.block.service.BlockService;
+import org.myteam.server.global.exception.ErrorResponse;
 import org.myteam.server.global.web.response.ResponseDto;
+import org.simpleframework.xml.Path;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +28,7 @@ import static org.myteam.server.global.web.response.ResponseStatus.SUCCESS;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/block")
+@Tag(name = "채팅 차단 관련 api", description = "채팅 차단 추가,삭제 및 차단 목록 조회")
 public class BlockController {
 
     private final BlockService blockService;
@@ -28,21 +37,30 @@ public class BlockController {
     /**
      * 유저 밴하기
      */
-    @PostMapping("/add")
-    public ResponseEntity<ResponseDto<SuccessBlockResponse>> banUser(@RequestBody BlockUserRequest request) {
-        SuccessBlockResponse response = blockService.banUser(request);
+    @Operation(summary = "차단 추가", description = "특정 이용자의 차단 리스트에 추가합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "게시글 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "회원, 게시글이 존재하지 않음", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping("/add/{blockedId}")
+    public ResponseEntity<ResponseDto<SuccessBlockResponse>> banUser(@PathVariable(value = "blockedId",required = true) UUID blockedId){
+        SuccessBlockResponse response = blockService.banUser(blockedId);
         return ResponseEntity.ok(new ResponseDto(
                 SUCCESS.name(),
                 "Ban Success",
                 response
         ));
     }
-
     /**
      * 유저 밴 해제
      */
+    @Operation(summary = "차단 해제", description = "특정 이용자의 차단 리스트에 삭제합니다")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @DeleteMapping("/del/{blockedId}")
-    public ResponseEntity<ResponseDto<String>> unbanUser(@PathVariable UUID blockedId) {
+    public ResponseEntity<ResponseDto<String>> unbanUser(@PathVariable(required = true) UUID blockedId) {
         blockService.unblockUser(blockedId);
         return ResponseEntity.ok(new ResponseDto(
                 SUCCESS.name(),
@@ -54,6 +72,10 @@ public class BlockController {
     /**
      * 특정 유저 밴 정보 조회
      */
+    @Operation(summary = "차단 목록조회", description = "특정 이용자의 차단 리스트를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 형식", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @GetMapping("/{blockerId}/blocked")
     public ResponseEntity<ResponseDto<BlockedMembersResponse>> getBanByPublicId(@PathVariable UUID blockerId) {
         BlockedMembersResponse response = blockReadService.getBlockedUsers(blockerId);

--- a/src/main/java/org/myteam/server/chat/block/controller/BlockController.java
+++ b/src/main/java/org/myteam/server/chat/block/controller/BlockController.java
@@ -19,7 +19,7 @@ import static org.myteam.server.global.web.response.ResponseStatus.SUCCESS;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/bans")
+@RequestMapping("/api/block")
 public class BlockController {
 
     private final BlockService blockService;
@@ -28,7 +28,7 @@ public class BlockController {
     /**
      * 유저 밴하기
      */
-    @PostMapping
+    @PostMapping("/add")
     public ResponseEntity<ResponseDto<SuccessBlockResponse>> banUser(@RequestBody BlockUserRequest request) {
         SuccessBlockResponse response = blockService.banUser(request);
         return ResponseEntity.ok(new ResponseDto(
@@ -41,7 +41,7 @@ public class BlockController {
     /**
      * 유저 밴 해제
      */
-    @DeleteMapping("/{blockedId}")
+    @DeleteMapping("/del/{blockedId}")
     public ResponseEntity<ResponseDto<String>> unbanUser(@PathVariable UUID blockedId) {
         blockService.unblockUser(blockedId);
         return ResponseEntity.ok(new ResponseDto(

--- a/src/main/java/org/myteam/server/chat/block/domain/MemberBlock.java
+++ b/src/main/java/org/myteam/server/chat/block/domain/MemberBlock.java
@@ -11,6 +11,7 @@ import org.myteam.server.member.entity.Member;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Entity
@@ -23,40 +24,27 @@ public class MemberBlock extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "blocker_id", nullable = false)
-    private Member blocker;
+    @Column(name = "blocker_id", nullable = false)
+    private UUID blocker;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "blocked_id", nullable = false)
-    private Member blocked;
+    @Column(name = "blocked_id", nullable = false)
+    private UUID blocked;
 
-    @ElementCollection(fetch = FetchType.LAZY)
-    @Enumerated(EnumType.STRING)
-    private List<BanReason> reasons = new ArrayList<>(); // 밴 사유
-
-    private String message;
 
     @Builder
-    private MemberBlock(Member blocker, Member blocked, List<BanReason> reasons, LocalDateTime bannedAt, String message) {
+    private MemberBlock(UUID blocker, UUID blocked, LocalDateTime bannedAt) {
         this.blocker = blocker;
         this.blocked = blocked;
-        if (reasons != null) {
-            this.reasons.addAll(reasons);
-        }
-        this.message = message;
     }
 
     /**
      * 차단 엔티티 생성
      */
-    public static MemberBlock createMemberBlock(Member blocker, Member blocked, List<BanReason> reasons, String message) {
+    public static MemberBlock createMemberBlock(UUID blocker,UUID blocked) {
         return MemberBlock.builder()
                 .blocker(blocker)
                 .blocked(blocked)
-                .reasons(reasons)
                 .bannedAt(LocalDateTime.now())
-                .message(message)
                 .build();
     }
 

--- a/src/main/java/org/myteam/server/chat/block/dto/request/BlockRequest.java
+++ b/src/main/java/org/myteam/server/chat/block/dto/request/BlockRequest.java
@@ -3,9 +3,6 @@ package org.myteam.server.chat.block.dto.request;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.myteam.server.chat.block.domain.BanReason;
-
-import java.util.List;
 import java.util.UUID;
 
 public record BlockRequest() {
@@ -13,10 +10,8 @@ public record BlockRequest() {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public class BlockUserRequest {
+    public static class BlockUserRequest {
         private UUID blockedId;
-        private List<BanReason> reasons;
-        private String message;
     }
 
     @Getter

--- a/src/main/java/org/myteam/server/chat/block/dto/response/BlockResponse.java
+++ b/src/main/java/org/myteam/server/chat/block/dto/response/BlockResponse.java
@@ -20,8 +20,8 @@ public record BlockResponse() {
 
         public static SuccessBlockResponse createBlockResponse(MemberBlock block) {
             return SuccessBlockResponse.builder()
-                    .blocker(block.getBlocker().getPublicId())
-                    .blocked(block.getBlocked().getPublicId())
+                    .blocker(block.getBlocker())
+                    .blocked(block.getBlocked())
                     .build();
         }
     }

--- a/src/main/java/org/myteam/server/chat/block/repository/MemberBlockRepository.java
+++ b/src/main/java/org/myteam/server/chat/block/repository/MemberBlockRepository.java
@@ -9,6 +9,6 @@ import java.util.UUID;
 
 @Repository
 public interface MemberBlockRepository extends JpaRepository<MemberBlock, Long>, MemberBlockQueryRepository {
-    boolean existsByBlockerPublicIdAndBlockedPublicId(UUID blocker, UUID blocked);
-    Optional<MemberBlock> findByBlockerPublicIdAndBlockedPublicId(UUID blocker, UUID blocked);
+    boolean existsByBlockerAndBlocked(UUID blocker, UUID blocked);
+    Optional<MemberBlock> findByBlockerAndBlocked(UUID blocker, UUID blocked);
 }

--- a/src/main/java/org/myteam/server/chat/block/repository/impl/MemberBlockQueryRepositoryImpl.java
+++ b/src/main/java/org/myteam/server/chat/block/repository/impl/MemberBlockQueryRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.myteam.server.chat.block.domain.QMemberBlock;
 import org.myteam.server.chat.block.repository.MemberBlockQueryRepository;
-import org.myteam.server.member.entity.QMember;
 
 import java.util.List;
 import java.util.UUID;
@@ -15,14 +14,13 @@ public class MemberBlockQueryRepositoryImpl implements MemberBlockQueryRepositor
     private final JPAQueryFactory queryFactory;
 
     QMemberBlock memberBlock = QMemberBlock.memberBlock;
-    QMember member = QMember.member;
 
     @Override
     public List<UUID> existsByBlockerPublicId(UUID blockerPublicId) {
         return queryFactory
-                .select(memberBlock.blocked.publicId)
+                .select(memberBlock.blocked)
                 .from(memberBlock)
-                .where(memberBlock.blocker.publicId.eq(blockerPublicId))
+                .where(memberBlock.blocker.eq(blockerPublicId))
                 .fetch();
     }
 }

--- a/src/main/java/org/myteam/server/chat/block/service/BlockService.java
+++ b/src/main/java/org/myteam/server/chat/block/service/BlockService.java
@@ -31,16 +31,15 @@ public class BlockService {
      */
     public SuccessBlockResponse banUser(BlockUserRequest request) {
         Member blocker = securityReadService.getMember();
-        Member blocked = memberReadService.findById(request.getBlockedId());
-        log.info("This user: {} has received a blocking request.", blocker.getPublicId());
+        log.info("This user: {} has received a blocking request.", request.getBlockedId());
 
         // 이미 밴된 유저인지 확인
-        if (memberBlockRepository.existsByBlockerPublicIdAndBlockedPublicId(blocker.getPublicId(), request.getBlockedId())) {
-            log.error("This user: {} is already ban this user: {}", blocker.getPublicId(), blocked.getPublicId());
+        if (memberBlockRepository.existsByBlockerAndBlocked(blocker.getPublicId(), request.getBlockedId())) {
+            log.error("This user: {} is already ban this user: {}", blocker.getPublicId(), request.getBlockedId());
             throw new PlayHiveException(ErrorCode.BAN_ALREADY_EXISTS);
         }
 
-        MemberBlock block = MemberBlock.createMemberBlock(blocker, blocked, request.getReasons(), request.getMessage());
+        MemberBlock block = MemberBlock.createMemberBlock(blocker.getPublicId(),request.getBlockedId());
         memberBlockRepository.save(block);
 
         return SuccessBlockResponse.createBlockResponse(block);
@@ -51,13 +50,12 @@ public class BlockService {
      */
     public void unblockUser(UUID blockedId) {
         Member blocker = securityReadService.getMember();
-        Member blocked = memberReadService.findById(blockedId);
-        log.info("This user: {} has received a unblocking request.", blocker.getPublicId());
+        log.info("This user: {} has received a unblocking request.",blockedId);
 
-        MemberBlock block = memberBlockRepository.findByBlockerPublicIdAndBlockedPublicId(
-                        blocker.getPublicId(), blocked.getPublicId())
+        MemberBlock block = memberBlockRepository.findByBlockerAndBlocked(
+                        blocker.getPublicId(), blockedId)
                 .orElseThrow(() -> {
-                    log.error("This user: {} is not banned this user: {}", blocker.getPublicId(), blocked.getPublicId());
+                    log.error("This user: {} is not banned this user: {}", blocker.getPublicId(),blockedId);
                     throw new PlayHiveException(ErrorCode.BAN_NOT_FOUND);
                 });
 

--- a/src/main/java/org/myteam/server/chat/block/service/BlockService.java
+++ b/src/main/java/org/myteam/server/chat/block/service/BlockService.java
@@ -29,17 +29,18 @@ public class BlockService {
     /**
      * 유저 밴 적용
      */
-    public SuccessBlockResponse banUser(BlockUserRequest request) {
+    public SuccessBlockResponse banUser(UUID blockedId) {
         Member blocker = securityReadService.getMember();
-        log.info("This user: {} has received a blocking request.", request.getBlockedId());
+        Member blocked=memberReadService.findById(blockedId);
+        log.info("This user: {} has received a blocking request.", blockedId);
 
         // 이미 밴된 유저인지 확인
-        if (memberBlockRepository.existsByBlockerAndBlocked(blocker.getPublicId(), request.getBlockedId())) {
-            log.error("This user: {} is already ban this user: {}", blocker.getPublicId(), request.getBlockedId());
+        if (memberBlockRepository.existsByBlockerAndBlocked(blocker.getPublicId(), blockedId)) {
+            log.error("This user: {} is already ban this user: {}", blocker.getPublicId(), blocked);
             throw new PlayHiveException(ErrorCode.BAN_ALREADY_EXISTS);
         }
 
-        MemberBlock block = MemberBlock.createMemberBlock(blocker.getPublicId(),request.getBlockedId());
+        MemberBlock block = MemberBlock.createMemberBlock(blocker.getPublicId(),blockedId);
         memberBlockRepository.save(block);
 
         return SuccessBlockResponse.createBlockResponse(block);

--- a/src/test/java/org/myteam/server/chatblock/chatblocktest.java
+++ b/src/test/java/org/myteam/server/chatblock/chatblocktest.java
@@ -1,0 +1,66 @@
+package org.myteam.server.chatblock;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.myteam.server.chat.block.domain.MemberBlock;
+import org.myteam.server.chat.block.dto.request.BlockRequest;
+import org.myteam.server.chat.block.service.BlockService;
+import org.myteam.server.member.entity.Member;
+import org.myteam.server.support.IntegrationTestSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.myteam.server.chat.block.dto.request.BlockRequest.*;
+import static reactor.core.publisher.Mono.when;
+
+public class chatblocktest extends IntegrationTestSupport {
+
+
+    @Autowired
+    BlockService blockService;
+    Member blocker;
+    List<Member> blockedList;
+    @BeforeEach
+    void setting(){
+        blockedList=new ArrayList<>();
+       Mockito.when(securityReadService.getMember())
+               .thenReturn(blocker);
+        blocker=createMember(0);
+        for(int i=0;10>i;i++){
+            Member m=createMember(i+1);
+           blockedList.add(m);
+        }
+    }
+
+    @Test
+    void blockAddSuccess(){
+
+       blockedList.stream()
+               .forEach(x->{
+                   BlockUserRequest blockUserRequest=
+                           new BlockUserRequest(x.getPublicId());
+                   blockService.banUser(blockUserRequest);
+               });
+        List<MemberBlock> memberBlocks=memberBlockRepository.findAll();
+        Assertions.assertThat(memberBlocks.size()).isEqualTo(10);
+    }
+    @Test
+    void blockDelSuccess(){
+        blockedList.stream()
+                .forEach(x->{
+                    BlockUserRequest blockUserRequest=
+                            new BlockUserRequest(x.getPublicId());
+                    blockService.banUser(blockUserRequest);
+                });
+        blockService.unblockUser(blockedList.get(0).getPublicId());
+        List<MemberBlock> memberBlocks=memberBlockRepository.findAll();
+        Assertions.assertThat(memberBlocks.size()).isEqualTo(9);
+    }
+
+
+}

--- a/src/test/java/org/myteam/server/chatblock/chatblocktest.java
+++ b/src/test/java/org/myteam/server/chatblock/chatblocktest.java
@@ -42,9 +42,7 @@ public class chatblocktest extends IntegrationTestSupport {
 
        blockedList.stream()
                .forEach(x->{
-                   BlockUserRequest blockUserRequest=
-                           new BlockUserRequest(x.getPublicId());
-                   blockService.banUser(blockUserRequest);
+                   blockService.banUser(x.getPublicId());
                });
         List<MemberBlock> memberBlocks=memberBlockRepository.findAll();
         Assertions.assertThat(memberBlocks.size()).isEqualTo(10);
@@ -55,7 +53,7 @@ public class chatblocktest extends IntegrationTestSupport {
                 .forEach(x->{
                     BlockUserRequest blockUserRequest=
                             new BlockUserRequest(x.getPublicId());
-                    blockService.banUser(blockUserRequest);
+                    blockService.banUser(x.getPublicId());
                 });
         blockService.unblockUser(blockedList.get(0).getPublicId());
         List<MemberBlock> memberBlocks=memberBlockRepository.findAll();

--- a/src/test/java/org/myteam/server/support/IntegrationTestSupport.java
+++ b/src/test/java/org/myteam/server/support/IntegrationTestSupport.java
@@ -16,6 +16,7 @@ import org.myteam.server.board.service.BoardCountService;
 import org.myteam.server.board.service.BoardReadService;
 import org.myteam.server.board.util.RedisBoardRankingReader;
 import org.myteam.server.chat.block.domain.BanReason;
+import org.myteam.server.chat.block.repository.MemberBlockRepository;
 import org.myteam.server.comment.service.CommentReadService;
 import org.myteam.server.common.certification.mail.core.MailStrategy;
 import org.myteam.server.common.certification.mail.domain.EmailType;
@@ -108,6 +109,9 @@ public abstract class IntegrationTestSupport extends TestDriverSupport {
     protected AdminInquiryChangeLogRepo adminInquiryChangeLogRepo;
     @Autowired
     protected AdminMemberMemoRepo adminMemberMemoRepo;
+
+    @Autowired
+    protected MemberBlockRepository memberBlockRepository;
     @AfterEach
     void tearDown() {
         adminMemberMemoRepo.deleteAllInBatch();;
@@ -139,6 +143,7 @@ public abstract class IntegrationTestSupport extends TestDriverSupport {
         memberActivityRepository.deleteAllInBatch();
         memberAccessRepository.deleteAllInBatch();
         memberJpaRepository.deleteAllInBatch();
+        memberBlockRepository.deleteAllInBatch();
     }
 
     @Transactional


### PR DESCRIPTION
## 기능 설명
- 채팅 차단 기능관련 리팩토링
### 작업 내용
- 채팅 차단 엔티티 의 간소화
- 채팅 차단 엔티티 기능 관련 간소화
## 수정 사항
- 채팅 차단의 경우에는 해당 차단을 건사람 이외에는 굳이 볼일이 없다고 판단되기도 하거니와 사용자 식별값을 바탕으로 구분만 하면된다고 판단해서 member 가아니라 간단하게 publicId값으로 컬럼을 바꾸었습니다.
- 또한 관련된 reposiotry,service의 코드도 맞추어서 바꾸었습니다. 로직 전반이 바뀐건 아니고 기존에 member였던 컬럼을 publicid로 바꾸었습니다.
- 또한 채팅 차단 엔티티의 banreason,msg는 딱히 필요하다고 생각 되지않아서 없앴습니다.
- 
##추가 작업 예정
- banreason,msg는 신고기능에 넣는게 좋을거같습니다.
### 테스트
- [ ] 단위 테스트 확인
- [ ] 빌드 테스트 확인
- [ ] 비정상 입력 시 오류 메시지 확인
- [ ] AWS에 서버 올라가는지 / Swagger 확인